### PR TITLE
Fixes to support runs on small test samples

### DIFF
--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -115,7 +115,7 @@ def bedcov(bed_fname, bam_fname):
     # Count bases in each region; exclude 0-MAPQ reads
     lines = pysam.bedcov(bed_fname, bam_fname, '-Q', '1')
     if not lines:
-        raise ValueError("BED file sequence IDs don't match any in the BAM")
+        raise ValueError("BED file sequence IDs don't match any in the BAM: %s %s" % (bed_fname, bam_fname))
     # Return an iterable...
     for line in lines:
         try:

--- a/cnvlib/smoothing.py
+++ b/cnvlib/smoothing.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division
 from bisect import insort, bisect_left
 from collections import deque
+import math
 
 import numpy
 
@@ -17,7 +18,7 @@ def check_inputs(x, width):
     """
     x = numpy.asfarray(x)
     if 0 < width < 1:
-        wing = int(round(len(x) * width * 0.5, 0))
+        wing = int(math.ceil(len(x) * width * 0.5))
     elif width >= 2 and int(width) == width:
         wing = width // 2
     else:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ DIR = (dirname(__file__) or '.') + '/'
 
 setup_args.update(
     name='CNVkit',
-    version='0.2.3',
+    version='0.2.4',
     description=__doc__,
     author='Eric Talevich',
     author_email='eric.talevich@ucsf.edu',


### PR DESCRIPTION
Eric;
This has a couple of small fixes to support running this on small test samples in bcbio. With these I have working unit tests for single sample and tumor/normal calling.
- Avoid rounding down to 0 for very small anti-target sizes of 1 or 2 during smoothing.
- Provide better error message with BED and BAM files for debugging.
