### PR TITLE
Provide ability to pass an R libpath when supporting libraries are not located in standard R paths

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -9,7 +9,7 @@ from ..cnarray import CopyNumArray as CNA
 from Bio._py3k import StringIO
 
 
-def do_segmentation(probes_fname, save_dataframe, method):
+def do_segmentation(probes_fname, save_dataframe, method, rlibpath=None):
     """Infer copy number segments from the given coverage table."""
     if not os.path.isfile(probes_fname):
         raise ValueError("Not a file: %s" % probes_fname)
@@ -26,6 +26,8 @@ def do_segmentation(probes_fname, save_dataframe, method):
         rscript = FLASSO_RSCRIPT
     else:
         raise ValueError("Unknown method %r" % method)
+    if rlibpath:
+        rscript = rscript.replace("# libPaths", '.libPaths(c("%s"))' % rlibpath)
     sample_id = core.fbase(probes_fname)
     with ngfrills.temp_write_text(rscript % (probes_fname,
                                              params.MIN_BIN_COVERAGE,
@@ -99,6 +101,7 @@ CBS_RSCRIPT = """\
 # Input: log2 coverage data in Nexus 'basic' format
 # Output: the CBS data table
 
+# libPaths
 library('PSCBS') # Requires: R.utils, R.oo, R.methodsS3
 
 write("Loading probe coverages into a data frame", stderr())
@@ -150,6 +153,7 @@ FLASSO_RSCRIPT = """\
 # Input: log2 coverage data in Nexus 'basic' format
 # Output: the CBS data table
 
+# libPaths
 library('cghFLasso')
 
 tbl <- read.delim("%s")

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ DIR = (dirname(__file__) or '.') + '/'
 
 setup_args.update(
     name='CNVkit',
-    version='0.2.4',
+    version='0.2.5',
     description=__doc__,
     author='Eric Talevich',
     author_email='eric.talevich@ucsf.edu',


### PR DESCRIPTION
Eric;
This is another bcbio integration request. We put the R libraries in non-standard paths so folks can install without needing sudo permissions. This pull request adds a `--rlibpath` option which will set the given path as the libPath to load libraries. Without the option specified it has the same behavior as previously. Thanks much
