### PR TITLE
Ignore bedtools produced '.' specifiers for gene names

### DIFF
--- a/cnvlib/cnarray.py
+++ b/cnvlib/cnarray.py
@@ -220,7 +220,7 @@ class CopyNumArray(object):
                                    lambda row: str(row['chromosome'])):
             yield chrom, self.to_rows(list(rows))
 
-    def by_gene(self, ignore=('-', 'CGH')):
+    def by_gene(self, ignore=('-', 'CGH', '.')):
         """Iterate over probes grouped by gene name.
 
         Emits pairs of (gene name, CNA of rows with same name)
@@ -494,7 +494,7 @@ class CopyNumArray(object):
             order = numpy.argsort(keys, kind='mergesort')
         self.data = self.data.take(order)
 
-    def squash_genes(self, ignore=('-', 'CGH'), squash_background=False,
+    def squash_genes(self, ignore=('-', 'CGH', '.'), squash_background=False,
                      summary_stat=metrics.biweight_location):
         """Combine consecutive bins with the same targeted gene name.
 

--- a/cnvlib/diagram.py
+++ b/cnvlib/diagram.py
@@ -41,7 +41,7 @@ def create_diagram(probe_pset, seg_pset, threshold, outfname, male_reference):
 
     # Consolidate genes & coverage values as chromsomal features
     features = collections.defaultdict(list)
-    no_name = ('Background', 'CGH', '-')
+    no_name = ('Background', 'CGH', '-', '.')
     strand = 1 if do_both else None
     probe_rows = core.shift_xx(probe_pset, male_reference)
     if not is_seg:

--- a/cnvlib/plots.py
+++ b/cnvlib/plots.py
@@ -377,7 +377,7 @@ def gene_coords_by_name(probes, names):
 
 # XXX should this be a CopyNumArray method?
 def gene_coords_by_range(probes, chrom, start, end,
-                         skip=('Background', 'CGH', '-')):
+                         skip=('Background', 'CGH', '-', '.')):
     """Find the chromosomal position of all genes in a range.
 
     Returns a dict: {chromosome: [(start, end, gene), ...]}

--- a/cnvlib/reports.py
+++ b/cnvlib/reports.py
@@ -13,7 +13,7 @@ iteritems = (dict.iteritems if sys.version_info[0] < 3 else dict.items)
 # _____________________________________________________________________________
 # breaks
 
-def get_gene_intervals(all_probes, skip=('Background', 'CGH', '-')):
+def get_gene_intervals(all_probes, skip=('Background', 'CGH', '-', '.')):
     """Tally genomic locations of each targeted gene.
 
     Return a dict of chromosomes to a list of tuples: (gene name, start, end).


### PR DESCRIPTION
Eric;
This is a small fix for etal/cnvkit#12 to skip over empty gene annotations with '.' as produced by bedtools.