### PR TITLE
Fixes for edge cases encountered in testing: empty and one line CNA files and problem VCFs

### DIFF
--- a/cnvlib/cnarray.py
+++ b/cnvlib/cnarray.py
@@ -565,7 +565,7 @@ class CopyNumArray(object):
             # Build CNA...
             xtra = _sniff_xtra(header)
             cnarr = cls(sample_id, xtra)
-            arr = numpy.loadtxt(handle, delimiter="\t", dtype=cnarr.data.dtype)
+            arr = numpy.loadtxt(handle, delimiter="\t", dtype=cnarr.data.dtype, ndmin=1)
         cnarr.data = arr
         return cnarr
 

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -204,7 +204,8 @@ def batch_make_reference(normal_bams, target_bed, antitarget_bed, male_reference
 def batch_write_coverage(bed_fname, bam_fname, out_fname, by_count):
     """Run coverage on one sample, write to file."""
     cnarr = do_coverage(bed_fname, bam_fname, by_count)
-    cnarr.write(out_fname)
+    if len(cnarr):
+        cnarr.write(out_fname)
 
 
 def batch_run_sample(bam_fname, target_bed, antitarget_bed, ref_fname,
@@ -217,10 +218,12 @@ def batch_run_sample(bam_fname, target_bed, antitarget_bed, ref_fname,
     sample_pfx = os.path.join(output_dir, sample_id)
 
     raw_tgt = do_coverage(target_bed, bam_fname, by_count)
-    raw_tgt.write(sample_pfx + '.targetcoverage.cnn')
+    if len(raw_tgt):
+        raw_tgt.write(sample_pfx + '.targetcoverage.cnn')
 
     raw_anti = do_coverage(antitarget_bed, bam_fname, by_count)
-    raw_anti.write(sample_pfx + '.antitargetcoverage.cnn')
+    if len(raw_anti):
+        raw_anti.write(sample_pfx + '.antitargetcoverage.cnn')
 
     cnarr = do_fix(raw_tgt, raw_anti, CNA.read(ref_fname))
     cnarr.write(sample_pfx + '.cnr')
@@ -440,7 +443,8 @@ def _cmd_coverage(args):
         if os.path.exists(args.output):
             args.output = '%s.%s.cnn' % (bambase, bedbase)
     ngfrills.ensure_path(args.output)
-    pset.write(args.output)
+    if len(pset):
+        pset.write(args.output)
 
 
 def do_coverage(bed_fname, bam_fname, by_count=False):

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -602,7 +602,8 @@ def do_fix(target_raw, antitarget_raw, reference,
                                            do_gc, False, do_rmask)
     # Merge target and antitarget & sort probes by chromosomal location
     cnarr.merge(anti_cnarr)
-    cnarr.center_all()
+    if len(cnarr):
+        cnarr.center_all()
     # Determine weights for each bin (used in segmentation)
     return fix.apply_weights(cnarr, reference)
 

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -204,8 +204,7 @@ def batch_make_reference(normal_bams, target_bed, antitarget_bed, male_reference
 def batch_write_coverage(bed_fname, bam_fname, out_fname, by_count):
     """Run coverage on one sample, write to file."""
     cnarr = do_coverage(bed_fname, bam_fname, by_count)
-    if len(cnarr):
-        cnarr.write(out_fname)
+    cnarr.write(out_fname)
 
 
 def batch_run_sample(bam_fname, target_bed, antitarget_bed, ref_fname,
@@ -218,12 +217,10 @@ def batch_run_sample(bam_fname, target_bed, antitarget_bed, ref_fname,
     sample_pfx = os.path.join(output_dir, sample_id)
 
     raw_tgt = do_coverage(target_bed, bam_fname, by_count)
-    if len(raw_tgt):
-        raw_tgt.write(sample_pfx + '.targetcoverage.cnn')
+    raw_tgt.write(sample_pfx + '.targetcoverage.cnn')
 
     raw_anti = do_coverage(antitarget_bed, bam_fname, by_count)
-    if len(raw_anti):
-        raw_anti.write(sample_pfx + '.antitargetcoverage.cnn')
+    raw_anti.write(sample_pfx + '.antitargetcoverage.cnn')
 
     cnarr = do_fix(raw_tgt, raw_anti, CNA.read(ref_fname))
     cnarr.write(sample_pfx + '.cnr')
@@ -443,8 +440,7 @@ def _cmd_coverage(args):
         if os.path.exists(args.output):
             args.output = '%s.%s.cnn' % (bambase, bedbase)
     ngfrills.ensure_path(args.output)
-    if len(pset):
-        pset.write(args.output)
+    pset.write(args.output)
 
 
 def do_coverage(bed_fname, bam_fname, by_count=False):

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -26,8 +26,8 @@ def interval_coverages(bed_fname, bam_fname, by_count):
                 break
         else:
             echo("Skip processing", os.path.basename(bam_fname),
-                "with empty regions file", bed_fname)
-            return []
+                 "with empty regions file", bed_fname)
+            return CNA(fbase(bam_fname))
 
     # Calculate average read depth in each bin
     ic_func = (interval_coverages_count if by_count

--- a/cnvlib/ngfrills/vcf.py
+++ b/cnvlib/ngfrills/vcf.py
@@ -1,6 +1,7 @@
 """NGS utilities: VCF I/O."""
 from __future__ import absolute_import, division, print_function
 
+from ..ngfrills import echo
 import collections
 
 def _get_sample(record, sample_id=None):
@@ -42,9 +43,12 @@ def load_vcf(fname, min_depth=1, skip_hom=True, sample_id=None):
             else:
                 alt_count = 0
         else:
-            raise ValueError("Unsure how to get alternative allele count: %s" % samp.data)
-        alt_freq = alt_count / depth
-        chrom_snvs[record.CHROM].append((record.POS, zygosity, alt_freq))
+            echo("Skipping: unsure how to get alternative allele count: %s %s %s %s" %
+                 (record.CHROM, record.POS, record.REF, str(samp.data)))
+            alt_count = None
+        if alt_count is not None:
+            alt_freq = alt_count / depth
+            chrom_snvs[record.CHROM].append((record.POS, zygosity, alt_freq))
     return chrom_snvs
 
 


### PR DESCRIPTION
Eric;
This pull request has a few fixes encountered when running on especially stubborn real life cases:

- Empty CNA files would return an empty list, which resulted in errors downstream for objects expecting a CNA, not a list. It now returns an empty CNA instead.
- Loading CNAs with a single items resulted in a data attribute with different dimensions than a full multi-item file.
- I found some VCF cases which just don't have alternative allele attribute so we warn and skip those.

Thanks much.