### PR TITLE
Small edge case fixes for whole genome analyses

### DIFF
--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -589,7 +589,8 @@ def do_fix(target_raw, antitarget_raw, reference,
     anti_cnarr = fix.load_adjust_coverages(antitarget_raw, reference,
                                            do_gc, False, do_rmask)
     # Merge target and antitarget & sort probes by chromosomal location
-    cnarr.merge(anti_cnarr)
+    if len(anti_cnarr):
+        cnarr.merge(anti_cnarr)
     if len(cnarr):
         cnarr.center_all()
     # Determine weights for each bin (used in segmentation)

--- a/cnvlib/diagram.py
+++ b/cnvlib/diagram.py
@@ -69,10 +69,11 @@ def create_diagram(cnarr, segarr, threshold, min_probes, outfname, male_referenc
     if do_both:
         # Draw segments in the left half of each chromosome (strand -1)
         for chrom, segrows in segarr.by_chromosome():
-            features[chrom].extend(
-                (srow['start'] - 1, srow['end'], -1, None,
-                 colors.Color(*plots.cvg2rgb(srow['coverage'], False)))
-                for srow in segrows)
+            for srow in segrows:
+                if srow['start'] - 1 >= 0 and srow['end'] <= chrom_sizes[chrom]:  # Sanity check
+                    features[chrom].append(
+                        (srow['start'] - 1, srow['end'], -1, None,
+                         colors.Color(*plots.cvg2rgb(srow['coverage'], False))))
 
     # Generate the diagram PDF
     if not outfname:


### PR DESCRIPTION
Eric;
This fixes two edge cases we ran into when running CNVkit in production:

- Empty antitarget files cause numpy merge errors:
```
File "/group/ngs/src/bcbio-nextgen/0.9.0/rhel6-x64/anaconda/lib/python2.7/site-packages/cnvlib/commands.py", line 592, in do_fix
  cnarr.merge(anti_cnarr)
File "/group/ngs/src/bcbio-nextgen/0.9.0/rhel6-x64/anaconda/lib/python2.7/site-packages/cnvlib/cnarray.py", line 417
self.data = numpy.concatenate((self.data, other.data))
TypeError: invalid type promotion
```

- Add additional sanity checks in diagram plots to avoid segements over
  the start or end of chromosomes

Thanks much