### PR TITLE
Anti-target and VCF export fixes during testing

### DIFF
--- a/cnvlib/antitarget.py
+++ b/cnvlib/antitarget.py
@@ -38,7 +38,8 @@ def get_background(target_bed, access_bed, avg_bin_size, min_bin_size):
     backgrounds = find_background_regions(access_chroms, target_chroms,
                                           2 * INSERT_SIZE)
     # Emit regions as antitarget bins according to avg_bin_size and min_bin_size
-    for chrom, start, end in sorted(backgrounds,
+    # Do a set operation on backgrounds to avoid any duplicate regions
+    for chrom, start, end in sorted(list(set(backgrounds)),
                                     key=core.sorter_chrom_at(0)):
         span = end - start
         if span >= min_bin_size:

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -1596,7 +1596,8 @@ def _cmd_export_vcf(args):
     Input is a segmentation file (.cns) where, preferably, log2 ratios have
     already been adjusted to integer absolute values using the 'call' command.
     """
-    header, body = export.export_vcf(args.segments, args.ploidy, args.male_reference)
+    header, body = export.export_vcf(args.segments, args.ploidy, args.male_reference,
+                                     args.sample_id)
     core.write_text(args.output, header, body)
 
 P_export_vcf = P_export_subparsers.add_parser('vcf',
@@ -1604,6 +1605,9 @@ P_export_vcf = P_export_subparsers.add_parser('vcf',
 P_export_vcf.add_argument('segments', #nargs='1',
         help="""Segmented copy ratio data file (*.cns), the output of the
                 'segment' or 'call' sub-commands.""")
+P_export_vcf.add_argument("-i", "--sample-id", metavar="LABEL",
+        help="""Sample name to write in the genotype field of the output VCF file.
+                [Default: use the sample ID, taken from the file name]""")
 P_export_vcf.add_argument("--ploidy", type=int, default=2,
         help="Ploidy of the sample cells. [Default: %(default)d]")
 P_export_vcf.add_argument("-y", "--male-reference", action="store_true",

--- a/cnvlib/export.py
+++ b/cnvlib/export.py
@@ -276,8 +276,6 @@ def calculate_theta_fields(seg, ref_rows, chrom_id):
 
 VCF_HEADER = """\
 ##fileformat=VCFv4.0
-##fileDate=20100501
-##reference=1000GenomesPilot-NCBI36
 ##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END for imprecise variants">
 ##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS for imprecise variants">
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
@@ -299,7 +297,7 @@ VCF_HEADER = """\
 # 4 18665128  . T <DUP:TANDEM>  11  PASS  IMPRECISE;SVTYPE=DUP;END=18665204;SVLEN=76;CIPOS=-10,10;CIEND=-10,10  GT:GQ:CN:CNQ  ./.:0:5:8.3
 
 
-def export_vcf(sample_fname, ploidy, is_reference_male):
+def export_vcf(sample_fname, ploidy, is_reference_male, sample_id=None):
     """Convert segments to Variant Call Format.
 
     For now, only 1 sample per VCF. (Overlapping CNVs seem tricky.)
@@ -308,7 +306,7 @@ def export_vcf(sample_fname, ploidy, is_reference_male):
     """
     segments = CNA.read(sample_fname)
     vcf_columns = ["#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER",
-                   "INFO", "FORMAT", segments.sample_id]
+                   "INFO", "FORMAT", sample_id or segments.sample_id]
     vcf_rows = [(chrom, posn, '.', 'N', alt, '.', '.', info, fmts, gtype)
                 for chrom, posn, alt, info, fmts, gtype in
                 segments2vcf(segments, ploidy, is_reference_male)]


### PR DESCRIPTION
Fixes a few issues found during initial VCF export integration:

- The new antitarget logic can create duplicate regions, resulting
  in a pandas downstream error when attempting to index on the data
  frame.
- Allow specification of the sample ID to write in VCF output.
- Remove a few confusing header fileds in the VCF
  (wrong reference/file dates).