### PR TITLE
Fixes for VCF export and segmetrics

### DIFF
--- a/cnvlib/export.py
+++ b/cnvlib/export.py
@@ -307,7 +307,7 @@ def export_vcf(sample_fname, ploidy, is_reference_male, sample_id=None):
     segments = CNA.read(sample_fname)
     vcf_columns = ["#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER",
                    "INFO", "FORMAT", sample_id or segments.sample_id]
-    vcf_rows = [(chrom, posn, '.', 'N', alt, '.', '.', info, fmts, gtype)
+    vcf_rows = [(chrom, posn, '.', 'N', "<%s>" % alt, '.', '.', info, fmts, gtype)
                 for chrom, posn, alt, info, fmts, gtype in
                 segments2vcf(segments, ploidy, is_reference_male)]
     table = pd.DataFrame.from_records(vcf_rows, columns=vcf_columns)

--- a/cnvlib/gary.py
+++ b/cnvlib/gary.py
@@ -36,6 +36,8 @@ class GenomicArray(object):
                    self._required_columns):
             raise ValueError("data table must have at least columns "
                              + repr(self._required_columns))
+        # ensure chromosomes are strings to avoid integer conversion of 1, 2...
+        data_table["chromosome"] = data_table["chromosome"].astype(str)
         self.data = data_table
         self.meta = (dict(meta_dict)
                      if meta_dict is not None and len(meta_dict)


### PR DESCRIPTION
- Wrap alternative allele type with '<>' to match VCF specification and
  output of other callers.
- Treat chromosome column in pandas dataframe as a string. Without this
  GRCh37 coordinates (1, 2, 3...) are integers, affecting comparison
  logic which assumes strings.