### PR TITLE
Add .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+source = cnvkit
+
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    test/*


### PR DESCRIPTION
> from your Codecov support request

I believe this will collect all the coverage files missing in your reports

Run `coverage report` in your local setup to confirm the files. 

http://coverage.readthedocs.org/en/latest/config.html