### PR TITLE
Handle cns files with missing probe counts

### DIFF
--- a/cnvlib/_version.py
+++ b/cnvlib/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.1.dev0"
+__version__ = "0.7.2.dev0"

--- a/cnvlib/export.py
+++ b/cnvlib/export.py
@@ -268,12 +268,12 @@ def segments2vcf(segments, ploidy, is_reference_male, is_sample_female):
     # TODO be more clever about this
     for (_idx, out_row), (_idx, abs_row) in zip(out_dframe.iterrows(),
                                                 abs_dframe.iterrows()):
-        if out_row["ncopies"] == abs_row["expect"]:
+        if out_row["ncopies"] == abs_row["expect"] or out_row["probes"] == "_":
             # Skip regions of neutral copy number
             continue  # or "CNV" for subclonal?
 
         if out_row["ncopies"] > abs_row["expect"]:
-            genotype = "0/1:0:%d:%g" % (out_row["ncopies"], out_row["probes"])
+            genotype = "0/1:0:%d:%g" % (out_row["ncopies"], int(out_row["probes"]))
         elif out_row["ncopies"] < abs_row["expect"]:
             # TODO XXX handle non-diploid ploidies, haploid chroms
             if out_row["ncopies"] == 0:
@@ -282,7 +282,7 @@ def segments2vcf(segments, ploidy, is_reference_male, is_sample_female):
             else:
                 # Single copy deletion
                 gt = "0/1"
-            genotype = "%s:%d" % (gt, out_row["probes"])
+            genotype = "%s:%d" % (gt, int(out_row["probes"]))
 
         info = ";".join(["IMPRECISE",
                          "SVTYPE=%s" % out_row["svtype"],

--- a/cnvlib/export.py
+++ b/cnvlib/export.py
@@ -2,11 +2,10 @@
 from __future__ import absolute_import, division, print_function
 
 import collections
-import math
 
 import numpy as np
 import pandas as pd
-from Bio._py3k import map, range, zip, StringIO
+from Bio._py3k import map, range, zip
 
 from . import call, core
 from .cnary import CopyNumArray as CNA
@@ -268,7 +267,7 @@ def segments2vcf(segments, ploidy, is_reference_male, is_sample_female):
     # TODO be more clever about this
     for (_idx, out_row), (_idx, abs_row) in zip(out_dframe.iterrows(),
                                                 abs_dframe.iterrows()):
-        if out_row["ncopies"] == abs_row["expect"] or out_row["probes"] == "_":
+        if out_row["ncopies"] == abs_row["expect"] or not str(out_row["probes"]).isdigit():
             # Skip regions of neutral copy number
             continue  # or "CNV" for subclonal?
 


### PR DESCRIPTION
Eric;
We ended up with a .cns file having a '_' for `probes` which
caused issues on export to VCF since pandas converted the `probes`
column to a string instead of the expected integer. This is a band-aid
that skips rows without probes and assures other rows are integers
before feeding into string formatting. I'm not sure if other upstream
changes are more appropriate but this works for us since we're
passing VCF call files along.

This also bumps the version to 0.7.2.dev0 since .dev0 versions sort
before full versions (0.7.1.dev0 < 0.7.1).

Thanks much.