### PR TITLE
Fix typo in SVLEN VCF header

### DIFF
--- a/cnvlib/export.py
+++ b/cnvlib/export.py
@@ -220,7 +220,7 @@ VCF_HEADER = """\
 ##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS for imprecise variants">
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
 ##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description="Imprecise structural variation">
-##INFO=<ID=SVLEN,Number=-1,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DUP,Description="Duplication">


### PR DESCRIPTION
Number in SVLEN was set to -1 instead of 1, causing GATK parsing to
fail on CNVkit VCF output.