### PR TITLE
Added R channel to conda command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ This approach is preferred on Mac OS X, and is a solid choice on Linux, too.
 
 To download and install CNVkit and its Python dependencies::
 
-    conda install -c bioconda cnvkit
+    conda install -c bioconda -c r cnvkit
 
 
 From a Python package repository
@@ -175,4 +175,3 @@ directory, too. To run the test suite::
 
 To run the pipeline on additional, larger example file sets, see the separate
 repository `cnvkit-examples <https://github.com/etal/cnvkit-examples>`_.
-


### PR DESCRIPTION
As of recently (https://github.com/bioconda/bioconda-recipes/pull/523), the cnvkit recipe in bioconda will install the R dependencies necessary for segmentation.  For this to work, however, we need to add the `r` channel to the conda install command.  