### PR TITLE
Fix coverage docs in pipeline.rst

### DIFF
--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -230,7 +230,8 @@ coverage
 
 Calculate coverage in the given regions from BAM read depths.
 
-With the -p option, calculates mean read depth from a pileup; otherwise, counts
+By default, coverage is calculated via mean read depth from a pileup.
+Alternatively, using the `--count` option counts
 the number of read start positions in the interval and normalizes to the
 interval size.
 
@@ -580,4 +581,3 @@ Or, in R::
 
     > log2( (0:4 + .5) / 2)
     [1] -2.0000000 -0.4150375  0.3219281  0.8073549  1.1699250
-


### PR DESCRIPTION
AFAIK (https://github.com/etal/cnvkit/blob/db70037e427c51b00a79c7962e33b9efbe2241c1/cnvlib/commands.py#L453) there is no `-p` option for coverage.  Furthermore, I believe the default is to count via pileup and use midpoint counting only if `--count` is specified.  Correct me if I am wrong here.