### PR TITLE
Python3 compatibility and option "ignore_gt_field"

### DIFF
--- a/cnvlib/_cnarray.py
+++ b/cnvlib/_cnarray.py
@@ -1,5 +1,11 @@
 """Definitions for the core data structure, a copy number array."""
 from __future__ import print_function
+from builtins import str
+from builtins import zip
+from builtins import map
+from builtins import next
+from past.builtins import basestring
+from builtins import object
 
 import sys
 
@@ -457,7 +463,7 @@ class CopyNumArray(object):
             assert callable(selector)
             condition = numpy.apply_along_axis(selector, 0, outrows)
             outrows = numpy.extract(condition, outrows)
-        for key, val in kwargs.items():
+        for key, val in list(kwargs.items()):
             assert key in self
             outrows = outrows[outrows[key] == val]
         return self.to_rows(outrows)
@@ -534,7 +540,7 @@ class CopyNumArray(object):
         outrows = []
         for name, subarr in self.by_gene(ignore):
             if name == 'Background' and not squash_background:
-                outrows.extend(map(tuple, subarr))
+                outrows.extend(list(map(tuple, subarr)))
             else:
                 outrows.append(squash_rows(name, subarr))
         return self.to_rows(outrows)

--- a/cnvlib/access.py
+++ b/cnvlib/access.py
@@ -6,6 +6,8 @@ Inaccessible regions, e.g. telomeres and centromeres, are masked out with N in
 the reference genome sequence; this script scans those to identify the
 coordinates of the accessible regions (those between the long spans of N's).
 """
+from builtins import next
+from builtins import zip
 
 import itertools
 import logging

--- a/cnvlib/antitarget.py
+++ b/cnvlib/antitarget.py
@@ -1,5 +1,8 @@
 """Supporting functions for the 'antitarget' command."""
 from __future__ import absolute_import, division, print_function
+from builtins import map
+from builtins import next
+from builtins import range
 import re
 import sys
 import logging
@@ -45,7 +48,7 @@ def get_background(target_bed, access_bed, avg_bin_size, min_bin_size):
                               if not is_canonical.match(c)]
         else:
             # Alternative contigs have long names -- skip them
-            max_tgt_chr_name_len = max(map(len, target_chroms))
+            max_tgt_chr_name_len = max(list(map(len, target_chroms)))
             chroms_to_skip = [c for c in untgt_chroms
                               if len(c) > max_tgt_chr_name_len]
         for untgt_chr in chroms_to_skip:
@@ -89,8 +92,8 @@ def get_background(target_bed, access_bed, avg_bin_size, min_bin_size):
 def guess_chromosome_regions(target_chroms, telomere_size):
     """Determine (minimum) chromosome lengths from target coordinates."""
     endpoints = [target_region[len(target_region) - 1, 'end']
-                 for _chrom, target_region in target_chroms.iteritems()]
-    whole_chroms = RA.from_columns({"chromosome": target_chroms.keys(),
+                 for _chrom, target_region in target_chroms.items()]
+    whole_chroms = RA.from_columns({"chromosome": list(target_chroms.keys()),
                                     "start": telomere_size,
                                     "end": endpoints})
     return dict(whole_chroms.by_chromosome())
@@ -98,7 +101,7 @@ def guess_chromosome_regions(target_chroms, telomere_size):
 
 def find_background_regions(access_chroms, target_chroms, pad_size):
     """Take coordinates of accessible regions and targets; emit antitargets."""
-    for chrom, access_arr in access_chroms.iteritems():
+    for chrom, access_arr in access_chroms.items():
         if chrom in target_chroms:
             target_regions = target_chroms[chrom].coords()
 

--- a/cnvlib/cnary.py
+++ b/cnvlib/cnary.py
@@ -19,7 +19,7 @@ class CopyNumArray(gary.GenomicArray):
     Optional columns: gc, rmask, spread, weight, probes
     """
     _required_columns = ("chromosome", "start", "end", "gene", "log2")
-    _required_dtypes = ("string", "int", "int", "string", "float")
+    _required_dtypes = (str, int, int, str, float)
     # ENH: make gene optional
     # Extra columns, in order:
     # "gc", "rmask", "spread", "weight", "probes"

--- a/cnvlib/cnary.py
+++ b/cnvlib/cnary.py
@@ -1,5 +1,7 @@
 """CNVkit's core data structure, a copy number array."""
 from __future__ import print_function, absolute_import, division
+from builtins import map
+from past.builtins import basestring
 
 import logging
 

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -3,6 +3,9 @@
 #   "_cmd_*" handles I/O and arguments processing for the command
 #   "do_*" runs the command's functionality as an API
 from __future__ import absolute_import, division, print_function
+from builtins import map
+from builtins import zip
+from builtins import range
 import argparse
 import collections
 import logging
@@ -1032,7 +1035,7 @@ def do_scatter(cnarr, segments=None, variants=None,
             gene_coords = plots.gene_coords_by_name(cnarr, gene_names)
             if not len(gene_coords) == 1:
                 raise ValueError("Genes %s are split across chromosomes %s"
-                                 % (show_gene, gene_coords.keys()))
+                                 % (show_gene, list(gene_coords.keys())))
             g_chrom, genes = gene_coords.popitem()
             if chrom:
                 # Confirm that the selected chromosomes match

--- a/cnvlib/core.py
+++ b/cnvlib/core.py
@@ -1,5 +1,6 @@
 """CNV utilities."""
 from __future__ import absolute_import, division, print_function
+from builtins import map
 import sys
 import os.path
 from itertools import takewhile
@@ -89,7 +90,7 @@ def assert_equal(msg, **values):
     ok = True
     key1, val1 = values.popitem()
     msg += ": %s = %r" % (key1, val1)
-    for okey, oval in values.iteritems():
+    for okey, oval in values.items():
         msg += ", %s = %r" % (okey, oval)
         if oval != val1:
             ok = False

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -1,5 +1,9 @@
 """Supporting functions for the 'antitarget' command."""
 from __future__ import absolute_import, division
+from builtins import zip
+from builtins import str
+from builtins import map
+from past.builtins import basestring
 
 import logging
 import math
@@ -34,7 +38,7 @@ def interval_coverages(bed_fname, bam_fname, by_count, min_mapq):
     ic_func = (interval_coverages_count if by_count
                else interval_coverages_pileup)
     results = ic_func(bed_fname, bam_fname, min_mapq)
-    read_counts, cna_rows = zip(*list(results))
+    read_counts, cna_rows = list(zip(*list(results)))
 
     # Log some stats
     tot_time = time.time() - start_time
@@ -143,7 +147,7 @@ def bedcov(bed_fname, bam_fname, min_mapq):
             name = "-"
         else:
             raise RuntimeError("Bad line from bedcov:\n" + line)
-        start, end, basecount = map(int, (start_s, end_s, basecount_s.strip()))
+        start, end, basecount = list(map(int, (start_s, end_s, basecount_s.strip())))
         span = end - start
         if span > 0:
             # Algebra from above

--- a/cnvlib/diagram.py
+++ b/cnvlib/diagram.py
@@ -107,7 +107,7 @@ def build_chrom_diagram(features, chr_sizes, sample_id):
     chr_diagram.page_size = PAGE_SIZE
     chr_diagram.title_size = 18
 
-    for chrom, length in chr_sizes.items():
+    for chrom, length in list(chr_sizes.items()):
         chrom_features = features.get(chrom)
         if not chrom_features:
             continue

--- a/cnvlib/export.py
+++ b/cnvlib/export.py
@@ -1,5 +1,8 @@
 """Export CNVkit objects and files to other formats."""
 from __future__ import absolute_import, division, print_function
+from builtins import zip
+from builtins import str
+from builtins import range
 
 import collections
 import logging
@@ -160,8 +163,8 @@ def export_seg(sample_fnames):
         else:
             # Verify
             core.assert_equal("Segment chromosome names differ",
-                              previous=chrom_ids.keys(),
-                              current=create_chrom_ids(segments).keys())
+                              previous=list(chrom_ids.keys()),
+                              current=list(create_chrom_ids(segments).keys()))
         table = segments.data.loc[:, ["start", "end"]]
         table["ID"] = segments.sample_id
         table["mean"] = segments.data["log2"]

--- a/cnvlib/fix.py
+++ b/cnvlib/fix.py
@@ -1,5 +1,6 @@
 """Supporting functions for the 'fix' command."""
 from __future__ import absolute_import, division, print_function
+from builtins import map
 
 import logging
 

--- a/cnvlib/gary.py
+++ b/cnvlib/gary.py
@@ -22,7 +22,7 @@ class GenomicArray(object):
     columns.
     """
     _required_columns = ("chromosome", "start", "end")
-    _required_dtypes = ("str", "int", "int")
+    _required_dtypes = (str, int, int)
 
     def __init__(self, data_table, meta_dict=None):
         # Validation
@@ -265,9 +265,9 @@ class GenomicArray(object):
         endpoints to match the range boundaries, and ``inner`` excludes those
         bins.
         """
-        if isinstance(start, (int, float, np.float64)):
+        if isinstance(start, (int, np.int64, float, np.float64)):
             start = [int(start)]
-        if isinstance(end, (int, float, np.float64)):
+        if isinstance(end, (int, np.int64, float, np.float64)):
             end = [int(end)]
         results = self._iter_ranges(chrom, start, end, mode)
         return next(results)

--- a/cnvlib/gary.py
+++ b/cnvlib/gary.py
@@ -1,5 +1,9 @@
 """A generic array of genomic positions."""
 from __future__ import print_function, absolute_import, division
+from builtins import next
+from builtins import zip
+from past.builtins import basestring
+from builtins import object
 
 import logging
 import sys
@@ -18,7 +22,7 @@ class GenomicArray(object):
     columns.
     """
     _required_columns = ("chromosome", "start", "end")
-    _required_dtypes = ("string", "int", "int")
+    _required_dtypes = ("str", "int", "int")
 
     def __init__(self, data_table, meta_dict=None):
         # Validation
@@ -29,7 +33,7 @@ class GenomicArray(object):
             # Ensure chromosomes are strings to avoid integer conversion of 1, 2...
             if not isinstance(data_table.chromosome.iat[0], basestring):
                 data_table["chromosome"] = (data_table["chromosome"]
-                                            .astype("string"))
+                                            .astype("str"))
         elif not isinstance(data_table, pd.DataFrame):
             # Empty but conformant table
             data_table = self._make_blank()
@@ -386,7 +390,7 @@ class GenomicArray(object):
         """Create a new CNA, adding the specified extra columns to this CNA."""
         # return self.as_dataframe(self.data.assign(**columns))
         result = self.copy()
-        for key, values in columns.iteritems():
+        for key, values in columns.items():
             result[key] = values
         return result
 
@@ -414,7 +418,7 @@ class GenomicArray(object):
         table = self.data
         if selector is not None:
             table = table[table.apply(selector, axis=1)]
-        for key, val in kwargs.items():
+        for key, val in list(kwargs.items()):
             assert key in self
             table = table[table[key] == val]
         return self.as_dataframe(table)
@@ -456,7 +460,7 @@ class GenomicArray(object):
                 sample_id = '<unknown>'
         try:
             table = pd.read_table(infile,
-                                  dtype={'chromosome': 'string'})
+                                  dtype={'chromosome': 'str'})
             if "log2" in table.columns:
                 # Every bin needs a log2 value; the others can be NaN
                 t2 = table.dropna(subset=["log2"])

--- a/cnvlib/importers.py
+++ b/cnvlib/importers.py
@@ -1,5 +1,8 @@
 """Import from other formats to the CNVkit format."""
 from __future__ import absolute_import, division, print_function
+from builtins import next
+from builtins import map
+from builtins import zip
 
 import logging
 import math
@@ -176,7 +179,7 @@ def parse_theta_results(fname):
         # mu
         mu = body[1].split(',')
         mu_normal = float(mu[0])
-        mu_tumors = map(float, mu[1:])
+        mu_tumors = list(map(float, mu[1:]))
 
         # C
         copies = body[2].split(':')

--- a/cnvlib/jenks.py
+++ b/cnvlib/jenks.py
@@ -9,6 +9,7 @@ See:
 - https://www.macwright.org/simple-statistics/docs/simple_statistics.html
 """
 from __future__ import division, print_function
+from builtins import range
 
 import numpy as np
 
@@ -62,7 +63,7 @@ def jenks_matrices(data, n_classes):
     # 0 i i i
     # 0 i i i
 
-    for l in xrange(2, n_rows):
+    for l in range(2, n_rows):
         # Estimate variance for each potential classing of the data, for
         # each potential number of classes.
         # ENH: lift these out of the loop & apply more array magic
@@ -74,13 +75,13 @@ def jenks_matrices(data, n_classes):
         # Record the last variance in column 1
         variance_combinations[l][1] = variances[l-1]
 
-        for m in xrange(1, l):
+        for m in range(1, l):
             # For each column from index 1 to just before the diagonal
             # Or, for each element up to the current l marker again
             lower_class_limit = l - m + 1  # >=2, <=l
             iv = lower_class_limit - 1  # >=1, <l
             variance = variances[m-1]
-            for j in xrange(2, n_cols):
+            for j in range(2, n_cols):
                 # If adding this element to an existing class will increase
                 # its variance beyond the limit, break the class at this
                 # point, setting the `lower_class_limit` at this point.
@@ -107,7 +108,7 @@ def jenks_breaks(data, lower_class_limits, n_classes):
     breakpoints[n_classes] = data[-1]  # Upper bound
     # Use the lower_class_limits matrix as indices into itself, iteratively
     lower_limit_idx = len(data)
-    for j in xrange(n_classes, 0, -1):
+    for j in range(n_classes, 0, -1):
         lower_limit_idx = lower_class_limits[lower_limit_idx, j] - 1
         breakpoints[j - 1] = data[lower_limit_idx]
     return breakpoints

--- a/cnvlib/ngfrills/__init__.py
+++ b/cnvlib/ngfrills/__init__.py
@@ -1,5 +1,7 @@
 """NGS utilities."""
 from __future__ import absolute_import, division, print_function
+from builtins import str
+from past.builtins import basestring
 
 import contextlib
 import logging

--- a/cnvlib/ngfrills/faidx.py
+++ b/cnvlib/ngfrills/faidx.py
@@ -1,5 +1,6 @@
 """NGS utilities: Indexed FASTA I/O."""
 from __future__ import absolute_import, division, print_function
+from builtins import str
 
 import logging
 from itertools import groupby

--- a/cnvlib/ngfrills/regions.py
+++ b/cnvlib/ngfrills/regions.py
@@ -1,5 +1,6 @@
 """NGS utilities: BED/Interval I/O, genomic regions and ranges."""
 from __future__ import absolute_import, division, print_function
+from builtins import next
 
 import functools
 import logging

--- a/cnvlib/parallel.py
+++ b/cnvlib/parallel.py
@@ -1,5 +1,6 @@
 """Utilities for multi-core parallel processing."""
 from __future__ import absolute_import, division, print_function
+from builtins import object
 import multiprocessing
 
 

--- a/cnvlib/plots.py
+++ b/cnvlib/plots.py
@@ -1,5 +1,8 @@
 """Plotting utilities."""
 from __future__ import absolute_import, division
+from builtins import str
+from builtins import zip
+from past.builtins import basestring
 
 import collections
 import logging
@@ -194,14 +197,14 @@ def cnv_on_genome(axis, probes, segments, pad, do_trend=False, y_min=None,
         chrom_sizes = chromosome_sizes(segments)
 
     # Same for segment calls
-    chrom_seg_coords = {chrom: zip(rows['log2'], rows['start'], rows['end'])
+    chrom_seg_coords = {chrom: list(zip(rows['log2'], rows['start'], rows['end']))
                         for chrom, rows in segments.by_chromosome()
                        } if segments else {}
 
     x_starts = plot_x_dividers(axis, chrom_sizes, pad)
     x = []
     seg_lines = []  # y-val, x-start, x-end
-    for chrom, curr_offset in x_starts.items():
+    for chrom, curr_offset in list(x_starts.items()):
         if probes:
             x.extend(chrom_probe_centers[chrom] + curr_offset)
         if chrom in chrom_seg_coords:
@@ -374,7 +377,7 @@ def plot_x_dividers(axis, chrom_sizes, pad):
     x_centers = []
     x_starts = collections.OrderedDict()
     curr_offset = pad
-    for label, size in chrom_sizes.items():
+    for label, size in list(chrom_sizes.items()):
         x_starts[label] = curr_offset
         x_centers.append(curr_offset + 0.5 * size)
         x_dividers.append(curr_offset + size + pad)
@@ -385,7 +388,7 @@ def plot_x_dividers(axis, chrom_sizes, pad):
         axis.axvline(x=xposn, color='k')
     # Use chromosome names as x-axis labels (instead of base positions)
     axis.set_xticks(x_centers)
-    axis.set_xticklabels(chrom_sizes.keys(), rotation=60)
+    axis.set_xticklabels(list(chrom_sizes.keys()), rotation=60)
     axis.tick_params(labelsize='small')
     axis.tick_params(axis='x', length=0)
     axis.get_yaxis().tick_left()
@@ -507,9 +510,9 @@ def gene_coords_by_name(probes, names):
         all_coords[chrom][start, end].update(orig_names)
     # Consolidate each region's gene names into a string
     uniq_coords = {}
-    for chrom, hits in all_coords.iteritems():
+    for chrom, hits in all_coords.items():
         uniq_coords[chrom] = [(start, end, ",".join(sorted(orig_names)))
-                             for (start, end), orig_names in hits.iteritems()]
+                             for (start, end), orig_names in hits.items()]
     return uniq_coords
 
 
@@ -532,7 +535,7 @@ def gene_coords_by_range(probes, chrom, start, end,
             genes[name] = [row.start, row.end]
     # Reorganize the data structure
     return {chrom: [(gstart, gend, name)
-                    for name, (gstart, gend) in genes.items()]}
+                    for name, (gstart, gend) in list(genes.items())]}
 
 
 def unpack_range(a_range):

--- a/cnvlib/rary.py
+++ b/cnvlib/rary.py
@@ -1,5 +1,8 @@
 """An array of genomic regions or features."""
 from __future__ import absolute_import, division, print_function
+from builtins import next
+from builtins import map
+from past.builtins import basestring
 
 import logging
 import sys
@@ -170,7 +173,7 @@ def _parse_bed(infile):
             yield line
 
     with as_handle(infile, 'rU') as handle:
-        rows = map(_parse_line, track2track(handle))
+        rows = list(map(_parse_line, track2track(handle)))
     return pd.DataFrame.from_records(rows, columns=["chromosome", "start",
                                                     "end", "name", "strand"])
 

--- a/cnvlib/rary.py
+++ b/cnvlib/rary.py
@@ -18,7 +18,7 @@ class RegionArray(gary.GenomicArray):
     _required_columns = ("chromosome", "start", "end",
                          # "name", "strand",
                         )
-    _required_dtypes = ("string", "int", "int")
+    _required_dtypes = (str, int, int)
 
     def __init__(self, data_table, meta_dict=None):
         gary.GenomicArray.__init__(self, data_table, meta_dict)

--- a/cnvlib/reference.py
+++ b/cnvlib/reference.py
@@ -1,5 +1,7 @@
 """Supporting functions for the 'reference' command."""
 from __future__ import absolute_import, division, print_function
+from builtins import zip
+from builtins import map
 
 import logging
 
@@ -161,9 +163,9 @@ def warn_bad_probes(probes):
         bad_pct = 100 * len(fg_bad_probes) / sum(probes['gene'] != 'Background')
         logging.info("Targets: %d (%s) bins failed filters:",
                      len(fg_bad_probes), "%.4f" % bad_pct + '%')
-        gene_cols = max(map(len, fg_bad_probes['gene']))
+        gene_cols = max(list(map(len, fg_bad_probes['gene'])))
         labels = list(map(CNA.row2label, fg_bad_probes))
-        chrom_cols = max(map(len, labels))
+        chrom_cols = max(list(map(len, labels)))
         last_gene = None
         for label, probe in zip(labels, fg_bad_probes):
             if probe.gene == last_gene:
@@ -190,12 +192,12 @@ def warn_bad_probes(probes):
 
 def get_fasta_stats(probes, fa_fname):
     """Calculate GC and RepeatMasker content of each bin in the FASTA genome."""
-    fa_coords = zip(probes.chromosome, probes.start, probes.end)
+    fa_coords = list(zip(probes.chromosome, probes.start, probes.end))
     logging.info("Calculating GC and RepeatMasker content in %s ...", fa_fname)
     gc_rm_vals = [calculate_gc_lo(subseq)
                   for subseq in ngfrills.fasta_extract_regions(fa_fname,
                                                                fa_coords)]
-    gc_vals, rm_vals = zip(*gc_rm_vals)
+    gc_vals, rm_vals = list(zip(*gc_rm_vals))
     return np.asfarray(gc_vals), np.asfarray(rm_vals)
 
 
@@ -219,17 +221,17 @@ def reference2regions(reference, coord_only=False):
     Like loading two BED files with ngfrills.parse_regions.
     """
     cna2rows = (_cna2coords if coord_only else _cna2regions)
-    return map(cna2rows, _ref_split_targets(reference))
+    return list(map(cna2rows, _ref_split_targets(reference)))
 
 
 def _cna2coords(cnarr):
     """Extract the coordinate columns from a CopyNumberArray"""
-    return zip(cnarr['chromosome'], cnarr['start'], cnarr['end'])
+    return list(zip(cnarr['chromosome'], cnarr['start'], cnarr['end']))
 
 
 def _cna2regions(cnarr):
     """Extract the region columns (including genes) from a CopyNumberArray"""
-    return zip(cnarr['chromosome'], cnarr['start'], cnarr['end'], cnarr['gene'])
+    return list(zip(cnarr['chromosome'], cnarr['start'], cnarr['end'], cnarr['gene']))
 
 
 def _ref_split_targets(ref_arr):

--- a/cnvlib/reports.py
+++ b/cnvlib/reports.py
@@ -3,6 +3,7 @@
 Namely: breaks, gainloss.
 """
 from __future__ import absolute_import, division
+from builtins import str
 import collections
 import math
 import sys

--- a/cnvlib/segmentation/haar.py
+++ b/cnvlib/segmentation/haar.py
@@ -23,6 +23,8 @@ segmentation result.
 
 """
 from __future__ import absolute_import, division, print_function
+from builtins import zip
+from builtins import range
 
 import logging
 import math

--- a/cnvlib/target.py
+++ b/cnvlib/target.py
@@ -1,5 +1,8 @@
 """Transform bait intervals into targets more suitable for CNVkit."""
 from __future__ import division, absolute_import
+from builtins import zip
+from builtins import str
+from builtins import next
 
 import logging
 import collections
@@ -85,7 +88,7 @@ def read_refflat_genes(fname):
             genedict[name].append((chrom, strand, start, end))
 
     chromdict = collections.defaultdict(list)
-    for name, locs in genedict.iteritems():
+    for name, locs in genedict.items():
         locs = list(set(locs))
         if len(locs) == 1:
             chrom, strand, start, end = locs[0]
@@ -128,8 +131,8 @@ def parse_refflat_line(line):
     start, end = fields[4:6]
     # start, end = fields[6:8]
     exon_count, exon_starts, exon_ends = fields[8:11]
-    exons = zip(exon_starts.rstrip(',').split(','),
-                exon_ends.rstrip(',').split(','))
+    exons = list(zip(exon_starts.rstrip(',').split(','),
+                exon_ends.rstrip(',').split(',')))
     assert len(exons) == int(exon_count), (
         "Exon count mismatch at %s: file says %s, but counted %d intervals"
         % (name, exon_count, len(exons)))

--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -1,5 +1,10 @@
 """An array of genomic intervals, treated as variant loci."""
 from __future__ import absolute_import, division, print_function
+from builtins import next
+from builtins import str
+from builtins import map
+from builtins import zip
+from past.builtins import basestring
 
 import logging
 
@@ -114,8 +119,8 @@ class VariantArray(gary.GenomicArray):
                               #          # "filter", "info",
                               #         ],
                               # ENH: converters=func -> to parse each col
-                              dtype=dict(zip(cls._required_columns,
-                                             cls._required_dtypes)),
+                              dtype=dict(list(zip(cls._required_columns,
+                                             cls._required_dtypes))),
                              )
         # ENH: do things with filter, info
         # if skip_reject and record.FILTER and len(record.FILTER) > 0:

--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -21,7 +21,7 @@ class VariantArray(gary.GenomicArray):
     Required columns: chromosome, start, end, ref, alt
     """
     _required_columns = ("chromosome", "start", "end", "ref", "alt")
-    _required_dtypes = ("string", "int", "int", "string", "string")
+    _required_dtypes = (str, int, int, str, str)
     # Extra: somatic, zygosity, depth, alt_count, alt_freq
 
     def __init__(self, data_table, meta_dict=None):

--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -83,8 +83,12 @@ class VariantArray(gary.GenomicArray):
         rows = _parse_records(vcf_reader, sample_id, normal_id, skip_reject, ignore_gt_field)
         table = pd.DataFrame.from_records(rows, columns=columns)
         table["alt_freq"] = table["alt_count"] / table["depth"]
+        if ignore_gt_field:
+                table["zygosity"] = (2 * table["alt_freq"]).round() / 2
         if normal_id:
             table["n_alt_freq"] = table["n_alt_count"] / table["n_depth"]
+            if ignore_gt_field:
+                table["n_zygosity"] = (2 * table["n_alt_freq"]).round() / 2
         # Filter out records as requested
         cnt_depth = cnt_hom = cnt_som = 0
         if min_depth:

--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -63,7 +63,7 @@ class VariantArray(gary.GenomicArray):
 
     @classmethod
     def read_vcf(cls, infile, sample_id=None, normal_id=None, min_depth=None,
-                 skip_hom=False, skip_reject=False, skip_somatic=False):
+                 skip_hom=False, skip_reject=False, skip_somatic=False, ignore_gt_field=False):
         """Parse SNV coordinates from a VCF file into a VariantArray."""
         if isinstance(infile, basestring):
             vcf_reader = vcf.Reader(filename=infile)
@@ -80,7 +80,7 @@ class VariantArray(gary.GenomicArray):
         sample_id, normal_id = _select_sample(vcf_reader, sample_id, normal_id)
         if normal_id:
             columns.extend(["n_zygosity", "n_depth", "n_alt_count"])
-        rows = _parse_records(vcf_reader, sample_id, normal_id, skip_reject)
+        rows = _parse_records(vcf_reader, sample_id, normal_id, skip_reject, ignore_gt_field)
         table = pd.DataFrame.from_records(rows, columns=columns)
         table["alt_freq"] = table["alt_count"] / table["depth"]
         if normal_id:
@@ -215,7 +215,7 @@ def _confirm_unique(sample_id, samples):
             % (sample_id, samples))
 
 
-def _parse_records(vcf_reader, sample_id, normal_id, skip_reject):
+def _parse_records(vcf_reader, sample_id, normal_id, skip_reject, ignore_gt):
     """Parse VCF records into DataFrame rows.
 
     Apply filters to skip records with low depth, homozygosity, the REJECT
@@ -231,10 +231,10 @@ def _parse_records(vcf_reader, sample_id, normal_id, skip_reject):
             is_som = True
 
         sample = record.genotype(sample_id)
-        depth, zygosity, alt_count = _extract_genotype(sample)
+        depth, zygosity, alt_count = _extract_genotype(sample, ignore_gt)
         if normal_id:
             normal = record.genotype(normal_id)
-            n_depth, n_zygosity, n_alt_count = _extract_genotype(normal)
+            n_depth, n_zygosity, n_alt_count = _extract_genotype(normal, ignore_gt)
             if n_zygosity == 0:
                 is_som = True
 
@@ -257,7 +257,7 @@ def _parse_records(vcf_reader, sample_id, normal_id, skip_reject):
         logging.info('Filtered out %d records', cnt_reject)
 
 
-def _extract_genotype(sample):
+def _extract_genotype(sample, ignore_gt):
     if "DP" in sample.data._fields:
         depth = sample.data.DP
     else:
@@ -265,11 +265,11 @@ def _extract_genotype(sample):
         depth = alt_count = None
     if sample.is_het:
         zygosity = 0.5
-    elif sample.gt_type == 0:
+    elif not ignore_gt and sample.gt_type == 0:
         zygosity = 0.0
     else:
         zygosity = 1.0
-    alt_count = (_get_alt_count(sample) if sample.gt_type else 0.0)
+    alt_count = _get_alt_count(sample) if ignore_gt or sample.gt_type else 0.0
     return depth, zygosity, alt_count
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ setup_args.update(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Unix",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Topic :: Scientific/Engineering",


### PR DESCRIPTION
Hi

I have gotten the code to work with python3. I have been able to use the functions `do_call`, `VariantArray.read_vcf` and `CopyNumArray.read` in my python3 jupyter notebook.

I have run the unittests for both python2 and python3 and I think everything works fine by now. I just wanted to let you know in case you are interested in making a pull request - particularly for the python3 compatibility which I think may serve well for more people ;)


Unrelated,  I have added an option to `VariantArray.read_vcf` called `ignore_gt_field` which lets me ignore the GT (genotype) field of the `vcf` file since I have hand-selected the SNPs for ExAC positions and being heterozygous in the matched normal. The original problem is actually, that I have generated the vcf files with `samtools mpileup` and thus I don't even have the GT field in my `.vcf` file. I guess this may be a problem more people may encounter.

Let me know if there are any more questions/doubts or whatsoever

Best,
Michael