### PR TITLE
Ignore GT (genotype) field if necessary

### DIFF
--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -78,8 +78,12 @@ class VariantArray(gary.GenomicArray):
         rows = _parse_records(vcf_reader, sample_id, normal_id, skip_reject, ignore_gt_field)
         table = pd.DataFrame.from_records(rows, columns=columns)
         table["alt_freq"] = table["alt_count"] / table["depth"]
+        if ignore_gt_field:
+                table["zygosity"] = (2 * table["alt_freq"]).round() / 2
         if normal_id:
             table["n_alt_freq"] = table["n_alt_count"] / table["n_depth"]
+            if ignore_gt_field:
+                table["n_zygosity"] = (2 * table["n_alt_freq"]).round() / 2
         # Filter out records as requested
         cnt_depth = cnt_hom = cnt_som = 0
         if min_depth:

--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -58,7 +58,7 @@ class VariantArray(gary.GenomicArray):
 
     @classmethod
     def read_vcf(cls, infile, sample_id=None, normal_id=None, min_depth=None,
-                 skip_hom=False, skip_reject=False, skip_somatic=False):
+                 skip_hom=False, skip_reject=False, skip_somatic=False, ignore_gt_field=False):
         """Parse SNV coordinates from a VCF file into a VariantArray."""
         if isinstance(infile, basestring):
             vcf_reader = vcf.Reader(filename=infile)
@@ -75,7 +75,7 @@ class VariantArray(gary.GenomicArray):
         sample_id, normal_id = _select_sample(vcf_reader, sample_id, normal_id)
         if normal_id:
             columns.extend(["n_zygosity", "n_depth", "n_alt_count"])
-        rows = _parse_records(vcf_reader, sample_id, normal_id, skip_reject)
+        rows = _parse_records(vcf_reader, sample_id, normal_id, skip_reject, ignore_gt_field)
         table = pd.DataFrame.from_records(rows, columns=columns)
         table["alt_freq"] = table["alt_count"] / table["depth"]
         if normal_id:
@@ -210,7 +210,7 @@ def _confirm_unique(sample_id, samples):
             % (sample_id, samples))
 
 
-def _parse_records(vcf_reader, sample_id, normal_id, skip_reject):
+def _parse_records(vcf_reader, sample_id, normal_id, skip_reject, ignore_gt):
     """Parse VCF records into DataFrame rows.
 
     Apply filters to skip records with low depth, homozygosity, the REJECT
@@ -226,10 +226,10 @@ def _parse_records(vcf_reader, sample_id, normal_id, skip_reject):
             is_som = True
 
         sample = record.genotype(sample_id)
-        depth, zygosity, alt_count = _extract_genotype(sample)
+        depth, zygosity, alt_count = _extract_genotype(sample, ignore_gt)
         if normal_id:
             normal = record.genotype(normal_id)
-            n_depth, n_zygosity, n_alt_count = _extract_genotype(normal)
+            n_depth, n_zygosity, n_alt_count = _extract_genotype(normal, ignore_gt)
             if n_zygosity == 0:
                 is_som = True
 
@@ -252,7 +252,7 @@ def _parse_records(vcf_reader, sample_id, normal_id, skip_reject):
         logging.info('Filtered out %d records', cnt_reject)
 
 
-def _extract_genotype(sample):
+def _extract_genotype(sample, ignore_gt):
     if "DP" in sample.data._fields:
         depth = sample.data.DP
     else:
@@ -260,11 +260,11 @@ def _extract_genotype(sample):
         depth = alt_count = None
     if sample.is_het:
         zygosity = 0.5
-    elif sample.gt_type == 0:
+    elif not ignore_gt and sample.gt_type == 0:
         zygosity = 0.0
     else:
         zygosity = 1.0
-    alt_count = (_get_alt_count(sample) if sample.gt_type else 0.0)
+    alt_count = _get_alt_count(sample) if ignore_gt or sample.gt_type else 0.0
     return depth, zygosity, alt_count
 
 


### PR DESCRIPTION
I have added an option to `VariantArray.read_vcf` called `ignore_gt_field` which lets me ignore the GT (genotype) field of the `vcf` file since I have hand-selected the SNPs for ExAC positions and being heterozygous in the matched normal. The original problem is actually, that I have generated the vcf files with `samtools mpileup` and thus I don't even have the GT field in my `.vcf` file. I guess this may be a problem more people may encounter.