### PR TITLE
Avoid numpy error with zero weights

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -178,7 +178,8 @@ def transfer_fields(segments, cnarr, ignore=params.IGNORE_GENE_NAMES):
     segdepths = np.zeros(len(segments))
     for i, (_seg, subprobes) in enumerate(cnarr.by_ranges(segments)):
         segweights[i] = subprobes['weight'].sum()
-        segdepths[i] = np.average(subprobes['depth'], weights=subprobes['weight'])
+        if subprobes['weight'].sum() > 0:
+            segdepths[i] = np.average(subprobes['depth'], weights=subprobes['weight'])
         subgenes = [g for g in pd.unique(subprobes['gene']) if g not in ignore]
         if subgenes:
             seggenes[i] = ",".join(subgenes)


### PR DESCRIPTION
Works around edge case identified during testing latest development
where numpy.average errors out if all the weights sum to zero. This
happened on a not-so-good sample and this workaround avoids failing
outright.