### PR TITLE
pysam 0.11.2.1 support and variant edge cases

### DIFF
--- a/cnvlib/call.py
+++ b/cnvlib/call.py
@@ -24,7 +24,7 @@ def do_call(cnarr, variants=None, method="threshold", ploidy=2, purity=None,
                 outarr = getattr(segfilters, filt)(outarr)
                 filters.remove(filt)
 
-    if variants:
+    if variants and 'n_alt_freq' in variants:
         outarr["baf"] = variants.baf_by_ranges(outarr)
 
     if purity and purity < 1.0:

--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -126,7 +126,7 @@ def _do_segmentation(cnarr, method, threshold, variants=None,
         raise ValueError("Unknown method %r" % method)
 
     segarr.meta = cnarr.meta.copy()
-    if variants:
+    if variants and 'n_alt_freq' in variants:
         # Re-segment the variant allele freqs within each segment
         newsegs = [haar.variants_in_segment(subvarr, segment, 0.01 * threshold)
                    for segment, subvarr in variants.by_ranges(segarr)]

--- a/skgenome/tabio/vcfio.py
+++ b/skgenome/tabio/vcfio.py
@@ -201,7 +201,7 @@ def _parse_records(records, sample_id, normal_id, skip_reject):
                 raise
         else:
             # Assume unpaired tumor; take DP, AF from INFO (e.g. LoFreq)
-            depth = record.info.get('DP', 0.0)
+            depth = record.info.get('DP', 0.0) if "DP" in record.info else 0.0
             if 'AF' in record.info:
                 alt_freq = record.info['AF']
                 alt_count = int(round(alt_freq * depth))
@@ -216,7 +216,7 @@ def _parse_records(records, sample_id, normal_id, skip_reject):
                 alt_count = 0
                 zygosity = 0.0
 
-        is_som = bool(record.info.get("SOMATIC"))
+        is_som = "SOMATIC" in record.info and bool(record.info.get("SOMATIC"))
         # Split multiallelics?
         # XXX Ensure sample genotypes are handled properly
         start = record.start


### PR DESCRIPTION
Eric;
This fixes a couple of issues I ran into while testing the latest development version:

- pysam 0.11.2 is pickier about calling `record.info.get` on values that
  do not exist in the header (chapmanb/bcbio-nextgen#1963). This adds
  an additional check to avoid the problems.
- Small or empty variant files cause `baf_by_ranges` to return a
  non-array object, resulting in pandas assignment errors. This provides
  a check for the required `n_alt_freq` information before calling.

For reference, this is the traceback I was seeing from the second issue:
```
Traceback (most recent call last):
  File "/usr/local/share/bcbio_nextgen/anaconda/bin/cnvkit.py", line 4, in <module>
    __import__('pkg_resources').run_script('CNVkit==0.8.6.dev0', 'cnvkit.py')
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/setuptools-27.2.0-py2.7.egg/pkg_resources/__init__.py", line 744, in run_script
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/setuptools-27.2.0-py2.7.egg/pkg_resources/__init__.py", line 1506, in run_script
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/CNVkit-0.8.6.dev0-py2.7.egg/EGG-INFO/scripts/cnvkit.py", line 13, in <module>
  File "build/bdist.linux-x86_64/egg/cnvlib/commands.py", line 605, in _cmd_segment
  File "build/bdist.linux-x86_64/egg/cnvlib/segmentation/__init__.py", line 40, in do_segmentation
  File "build/bdist.linux-x86_64/egg/cnvlib/segmentation/__init__.py", line 134, in _do_segmentation
  File "build/bdist.linux-x86_64/egg/skgenome/gary.py", line 168, in __setitem__
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/pandas/core/frame.py", line 2419, in __setitem__
    self._set_item(key, value)
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/pandas/core/frame.py", line 2486, in _set_item
    NDFrame._set_item(self, key, value)
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/pandas/core/generic.py", line 1500, in _set_item
    self._data.set(key, value)
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/pandas/core/internals.py", line 3671, in set
    self.insert(len(self.items), item, value)
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/pandas/core/internals.py", line 3772, in insert
    placement=slice(loc, loc + 1))
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/pandas/core/internals.py", line 2685, in make_block
    return klass(values, ndim=ndim, fastpath=fastpath, placement=placement)
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/pandas/core/internals.py", line 1817, in __init__
    placement=placement, **kwargs)
  File "/usr/local/share/bcbio_nextgen/anaconda/lib/python2.7/site-packages/pandas/core/internals.py", line 109, in __init__
    len(self.mgr_locs)))
ValueError: Wrong number of items passed 6, placement implies 1
' returned non-zero exit status 1
```