### PR TITLE
pandas 0.21.0 support: numpy scalar => int

### DIFF
--- a/cnvlib/reference.py
+++ b/cnvlib/reference.py
@@ -326,7 +326,7 @@ def fasta_extract_regions(fa_fname, intervals):
         for chrom, subarr in intervals.by_chromosome():
             logging.info("Extracting sequences from chromosome %s", chrom)
             for _chrom, start, end in subarr.coords():
-                yield fa_file[_chrom][start.item():end.item()]
+                yield fa_file[_chrom][int(start):int(end)]
 
 
 def reference2regions(refarr):

--- a/skgenome/intersect.py
+++ b/skgenome/intersect.py
@@ -144,7 +144,7 @@ def _irange_nested(table, starts, ends, mode):
             if mode == 'inner':
                 # Only rows entirely after the start point
                 start_idx = table.start.searchsorted(start_val)
-                region_mask[:start_idx.item()] = 0
+                region_mask[:int(start_idx)] = 0
             else:
                 # Include all rows overlapping the start point
                 region_mask = (table.end.values > start_val)
@@ -155,7 +155,7 @@ def _irange_nested(table, starts, ends, mode):
             else:
                 # Include all rows overlapping the end point
                 end_idx = table.start.searchsorted(end_val)
-                region_mask[end_idx.item():] = 0
+                region_mask[int(end_idx):] = 0
 
         yield region_mask, start_val, end_val
 


### PR DESCRIPTION
The most recent pandas release changed how indices are returned, from
numpy int64 to plain python ints:

https://pandas.pydata.org/pandas-docs/version/0.21/whatsnew.html#iteration-of-series-index-will-now-return-python-scalars

In a couple of places cnvkit assumed numpy values and converted them back
into standard ints using `.item`:
```
  for subseq in fasta_extract_regions(fa_fname, cnarr)]
File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/cnvlib/reference.py", line 326, in fasta_extract_regions
    yield fa_file[_chrom][start.item():end.item()]
AttributeError: 'int' object has no attribute 'item'
```
This swaps over to use use `int` conversion which should work on both
older and newer pandas.