### PR TITLE
call cn filter: handle blocks with zero weights

### DIFF
--- a/cnvlib/segfilters.py
+++ b/cnvlib/segfilters.py
@@ -72,18 +72,33 @@ def squash_region(cnarr):
            'start': cnarr['start'].iat[0],
            'end': cnarr['end'].iat[-1],
           }
-    out['log2'] = np.average(cnarr['log2'], weights=cnarr['weight'])
+    if cnarr['weight'].sum() > 0:
+        out['log2'] = np.average(cnarr['log2'], weights=cnarr['weight'])
+    else:
+        out['log2'] = np.mean(cnarr['log2'])
     out['gene'] = ','.join(cnarr['gene'].drop_duplicates())
     out['probes'] = cnarr['probes'].sum()
     out['weight'] = cnarr['weight'].sum()
     if 'depth' in cnarr:
-        out['depth'] = np.average(cnarr['depth'], weights=cnarr['weight'])
+        if cnarr['weight'].sum() > 0:
+            out['depth'] = np.average(cnarr['depth'], weights=cnarr['weight'])
+        else:
+            out['depth'] = np.mean(cnarr['depth'])
     if 'baf' in cnarr:
-        out['baf'] = np.average(cnarr['baf'], weights=cnarr['weight'])
+        if cnarr['weight'].sum() > 0:
+            out['baf'] = np.average(cnarr['baf'], weights=cnarr['weight'])
+        else:
+            out['baf'] = np.mean(cnarr['baf'])
     if 'cn' in cnarr:
-        out['cn'] = weighted_median(cnarr['cn'], cnarr['weight'])
+        if cnarr['weight'].sum() > 0:
+            out['cn'] = weighted_median(cnarr['cn'], cnarr['weight'])
+        else:
+            out['cn'] = np.median(cnarr['cn'])
         if 'cn1' in cnarr:
-            out['cn1'] = weighted_median(cnarr['cn1'], cnarr['weight'])
+            if cnarr['weight'].sum() > 0:
+                out['cn1'] = weighted_median(cnarr['cn1'], cnarr['weight'])
+            else:
+                out['cn1'] = np.median(cnarr['cn1'])
             out['cn2'] = out['cn'] - out['cn1']
     return pd.DataFrame(out)
 


### PR DESCRIPTION
When running `cnvkit.py call --filter cn`, some edge cases have
blocks with zero weights, causing errors normalizing with these:

https://github.com/chapmanb/bcbio-nextgen/issues/2112#issuecomment-345516176

This falls back to using unweighted averages and means when weights
aren't usable.