### PR TITLE
Avoid TypeError upon `savgol_filter`

### DIFF
--- a/cnvlib/smoothing.py
+++ b/cnvlib/smoothing.py
@@ -35,6 +35,12 @@ def _width2wing(width, x, min_wing=3):
     else:
         raise ValueError("width must be either a fraction between 0 and 1 "
                          "or an integer greater than 1 (got %s)" % width)
+        
+    # if width == len(x) and len(x) is not odd, 2*wing+1 will be greater than len(x) and produce a TypeError
+    # when used on `savgol_filter`.
+    if (2*wing+1) > len(x):
+        wing -= 1        
+        
     wing = max(wing, min_wing)
     wing = min(wing, len(x) - 1)
     assert wing >= 1, "Wing must be at least 1 (got %s)" % wing


### PR DESCRIPTION
Plotting the trend in a scatter plot, I ran into cases where the window size was larger than the actual data length. The code thus takes the data length as window size, and if the data length is an even number, this constellation would lead to a `TypeError` when using `savgol_filter`.

The reason is the line `wing = int(width // 2)`, which produces a wing length of exactly half of the width. This then turns out to raise the error due to the `2*wing+1` window size that is passed to `savgol_filter()`.

Here is a bit of code with which you can reproduce the Error. 
```
np.random.seed(55)
datasize = np.random.randint(500,800,20)
windowsize = np.random.randint(300,900,20)
for a,w in zip(datasize,windowsize):
    print("\nTest case:\ndata size: {}, window: {}".format(a,w))
    if a<w:
        print("Warning: window bigger than data points")
    x_dummy = np.random.random(a)
    try:
        res = smoothing.savgol(x_dummy, min(len(x_dummy),w))
        if len(res) == len(x_dummy):
            print("Test successful")
    except TypeError:
        print("FAILED!\n2nd try with window size `len(data)-1`")
        res = smoothing.savgol(x_dummy, min(len(x_dummy)-1,w))
        if len(res) == len(x_dummy):
            print("Bug squashed!")
        

```