### PR TITLE
TypeError when window size larger than data points

### DIFF
--- a/cnvlib/smoothing.py
+++ b/cnvlib/smoothing.py
@@ -28,6 +28,12 @@ def check_inputs(x, width, as_series=True):
 def _width2wing(width, x, min_wing=3):
     """Convert a fractional or absolute width to integer half-width ("wing").
     """
+    
+    # if width > len(x) a TypeError will be produced when calling savgol_filter. Make sure than wing will be smaller
+    # than half of the len(x)
+    if width >= len(x):
+        width = len(x)-1    
+    
     if 0 < width < 1:
         wing = int(math.ceil(len(x) * width * 0.5))
     elif width >= 2 and int(width) == width:


### PR DESCRIPTION
Plotting the trend in a scatter plot, I ran into cases where the window size was larger than the actual data length, leading to a `TypeError` when using `savgol_filter()`. 

We thus need to make sure that the wing will not be bigger than The reason is the line `wing = int(width // 2)`, which produces a wing length of exactly half of the width. This then turns out to raise the error due to the `2*wing+1` window size that is passed to `savgol_filter()`.

Here is a bit of code with which you can reproduce the Error.

```python
np.random.seed(55)
datasize = np.random.randint(500,800,20)
windowsize = np.random.randint(300,900,20)
for a,w in zip(datasize,windowsize):
    print("\nTest case:\ndata size: {}, window: {}".format(a,w))
    if a<w:
        print("Warning: window bigger than data points")
    x_dummy = np.random.random(a)
    try:
        res = smoothing.savgol(x_dummy, w)
        if len(res) == len(x_dummy):
            print("Test successful")
    except TypeError:
        print("FAILED!\n2nd try with window size `len(data)-1`")
        res = smoothing.savgol(x_dummy, min(len(x_dummy)-1,w))
        if len(res) == len(x_dummy):
            print("Bug squashed!")

```