### PR TITLE
vcfio: support GATK inputs with empty ALT alleles

### DIFF
--- a/skgenome/tabio/vcfio.py
+++ b/skgenome/tabio/vcfio.py
@@ -268,7 +268,13 @@ def _get_alt_count(sample):
     if sample.get('AD') not in (None, (None,)):
         # GATK and other callers: (ref depth, alt depth)
         if isinstance(sample['AD'], tuple):
-            alt_count = sample['AD'][1]
+            # Ensure we have alternative alleles and thus two AD values
+            # ref only calls in GATK can be missing these
+            # 1       49515   .       G       .       50.80   .       AN=2;DP=34;MQ=40.01  GT:AD:DP:MMQ  0/0:34:34:.
+            if len(sample['AD']) > 1:
+                alt_count = sample['AD'][1]
+            else:
+                alt_count = 0.0
         # VarScan
         else:
             alt_count = sample['AD']

--- a/test/formats/gatk-emptyalt.vcf
+++ b/test/formats/gatk-emptyalt.vcf
@@ -1,0 +1,11 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=MMQ,Number=A,Type=Integer,Description="median mapping quality">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1
+1	49515	.	G	.	50.80	.	AN=2;DP=34;MQ=40.01	GT:AD:DP:MMQ	0/0:34:34:.

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -117,7 +117,9 @@ class IOTests(unittest.TestCase):
         v5 = tabio.read('formats/blank.vcf', 'vcf', sample_id='Blank')
         self.assertEqual(len(v5), 0)
         self.assertEqual(v5.sample_id, 'Blank')
-
+        # VCF from GATK 4 with no ALT
+        v6 = tabio.read('formats/gatk-emptyalt.vcf', 'vcf', sample_id='sample1')
+        self.assertEqual(len(v6), 0)
 
 # == helpers ==
 


### PR DESCRIPTION
Recent versions of GATK 4 can output lines with empty ALT alleles,
thus missing an ALT AD value. This checks for this case, correctly
returning zero and adds an example to the tests.