### PR TITLE
scatter plot: avoid pandas positional index error

### DIFF
--- a/skgenome/intersect.py
+++ b/skgenome/intersect.py
@@ -89,7 +89,7 @@ def iter_ranges(table, chrom, starts, ends, mode):
 
     for region_idx, start_val, end_val in idx_ranges(table, None, starts, ends,
             'inner' if mode == 'inner' else 'outer'):
-        subtable = table.iloc[region_idx]
+        subtable = table.loc[region_idx]
         if mode == 'trim':
             subtable = subtable.copy()
             # Update 5' endpoints to the boundary


### PR DESCRIPTION
When creating a scatter plot with a single chromosome, it can error out
with:
```
  File "build/bdist.linux-x86_64/egg/cnvlib/commands.py", line 914, in _cmd_scatter

  File "build/bdist.linux-x86_64/egg/cnvlib/scatter.py", line 49, in do_scatter
  File "build/bdist.linux-x86_64/egg/cnvlib/scatter.py", line 216, in chromosome_scatter
  File "build/bdist.linux-x86_64/egg/cnvlib/scatter.py", line 340, in select_range_genes
  File "build/bdist.linux-x86_64/egg/skgenome/gary.py", line 370, in in_range
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/future/builtins/newnext.py", line 59, in newnext
    return iterator.next()
  File "build/bdist.linux-x86_64/egg/skgenome/intersect.py", line 92, in iter_ranges
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/pandas/core/indexing.py", line 1373, in __getitem__
    return self._getitem_axis(maybe_callable, axis=axis)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/pandas/core/indexing.py", line 1819, in _getitem_axis
    return self._get_list_axis(key, axis=axis)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/pandas/core/indexing.py", line 1797, in _get_list_axis
    raise IndexError("positional indexers are out-of-bounds")
IndexError: positional indexers are out-of-bounds
```
There is a similar issue reported on BioStars (https://www.biostars.org/p/326154/).

Using loc instead of iloc, inspired by this StackOverflow discussion (https://stackoverflow.com/questions/44123056/indexerror-positional-indexers-are-out-of-bounds-when-theyre-demonstrably-no)
fixes the issue for my failing cases.