### PR TITLE
do_scatter now returns a figure

### DIFF
--- a/cnvlib/scatter.py
+++ b/cnvlib/scatter.py
@@ -39,19 +39,19 @@ def do_scatter(cnarr, segments=None, variants=None,
         MB = 1
 
     if not show_gene and not show_range:
-        genome_scatter(cnarr, segments, variants, do_trend, y_min, y_max, title,
+        fig = genome_scatter(cnarr, segments, variants, do_trend, y_min, y_max, title,
                        segment_color)
     else:
         if by_bin:
             show_range = show_range_bins
-        chromosome_scatter(cnarr, segments, variants, show_range, show_gene,
+        fig = chromosome_scatter(cnarr, segments, variants, show_range, show_gene,
                            antitarget_marker, do_trend, by_bin, window_width,
                            y_min, y_max, title, segment_color)
 
     if by_bin:
         # Reset to avoid permanently altering the value of cnvlib.scatter.MB
         MB = orig_mb
-
+    return fig
 
 # === Genome-level scatter plots ===
 
@@ -66,7 +66,7 @@ def genome_scatter(cnarr, segments=None, variants=None, do_trend=False,
         # Place chromosome labels between the CNR and SNP plots
         axis2.tick_params(labelbottom=False)
         chrom_sizes = plots.chromosome_sizes(cnarr or segments)
-        snv_on_genome(axis2, variants, chrom_sizes, segments, do_trend,
+        axis2 = snv_on_genome(axis2, variants, chrom_sizes, segments, do_trend,
                       segment_color)
     else:
         _fig, axis = pyplot.subplots()
@@ -74,16 +74,16 @@ def genome_scatter(cnarr, segments=None, variants=None, do_trend=False,
         title = (cnarr or segments or variants).sample_id
     if cnarr or segments:
         axis.set_title(title)
-        cnv_on_genome(axis, cnarr, segments, do_trend, y_min, y_max,
+        axis = cnv_on_genome(axis, cnarr, segments, do_trend, y_min, y_max,
                       segment_color)
     else:
         axis.set_title("Variant allele frequencies: %s" % title)
         chrom_sizes = collections.OrderedDict(
             (chrom, subarr["end"].max())
             for chrom, subarr in variants.by_chromosome())
-        snv_on_genome(axis, variants, chrom_sizes, segments, do_trend,
+        axis = snv_on_genome(axis, variants, chrom_sizes, segments, do_trend,
                       segment_color)
-
+    return axis.get_figure()
 
 
 def cnv_on_genome(axis, probes, segments, do_trend=False, y_min=None,
@@ -145,7 +145,7 @@ def cnv_on_genome(axis, probes, segments, do_trend=False, y_min=None,
                 axis.plot((seg.start + x_offset, seg.end + x_offset),
                           (seg.log2, seg.log2),
                           color=color, linewidth=3, solid_capstyle='round')
-
+    return axis
 
 def snv_on_genome(axis, variants, chrom_sizes, segments, do_trend, segment_color):
     """Plot a scatter-plot of SNP chromosomal positions and shifts."""
@@ -189,7 +189,7 @@ def snv_on_genome(axis, variants, chrom_sizes, segments, do_trend, segment_color
                 axis.plot(posn, [v_freq, v_freq],
                           color=color, linewidth=2, zorder=-1,
                           solid_capstyle='round')
-
+    return axis
 
 # === Chromosome-level scatter plots ===
 
@@ -231,20 +231,20 @@ def chromosome_scatter(cnarr, segments, variants, show_range, show_gene,
                 axis.set_xlabel("Position (bin)")
             else:
                 axis.set_xlabel("Position (Mb)")
-        cnv_on_chromosome(axis, sel_probes, sel_segs, genes,
+        axis = cnv_on_chromosome(axis, sel_probes, sel_segs, genes,
                           antitarget_marker=antitarget_marker,
                           do_trend=do_trend, x_limits=window_coords,
                           y_min=y_min, y_max=y_max, segment_color=segment_color)
     elif variants:
         # Only plot SNVs in a single-panel layout
         _fig, axis = pyplot.subplots()
-        snv_on_chromosome(axis, sel_snvs, sel_segs, genes, do_trend,
+        axis = snv_on_chromosome(axis, sel_snvs, sel_segs, genes, do_trend,
                           by_bin, segment_color)
 
     if title is None:
         title = "%s %s" % ((cnarr or segments or variants).sample_id, chrom)
     axis.set_title(title)
-
+    return axis.get_figure()
 
 def select_range_genes(cnarr, segments, variants, show_range, show_gene,
                        window_width):
@@ -421,7 +421,7 @@ def cnv_on_chromosome(axis, probes, segments, genes, antitarget_marker=None,
             axis.plot((row.start * MB, row.end * MB),
                       (row.log2, row.log2),
                       color=color, linewidth=4, solid_capstyle='round')
-
+    return axis
 
 def snv_on_chromosome(axis, variants, segments, genes, do_trend, by_bin,
                       segment_color):
@@ -458,7 +458,7 @@ def snv_on_chromosome(axis, variants, segments, genes, do_trend, by_bin,
 
     if genes:
         highlight_genes(axis, genes, .9)
-
+    return axis
 
 def set_xlim_from(axis, probes=None, segments=None, variants=None):
     """Configure axes for plotting a single chromosome's data.


### PR DESCRIPTION
Because the scatter command sometimes returns a compound figure, I've set it up so that do_scatter returns a figure object rather than an axis object.  

I've only partially tested this.  I don't have any snv data to try it with so I wasn't able to test the situation where the plot contains both snv and cnv data.  