### PR TITLE
Partition array by chrom for Flasso segmentation

### DIFF
--- a/cnvlib/segmentation/flasso.py
+++ b/cnvlib/segmentation/flasso.py
@@ -13,7 +13,7 @@ tbl <- read.delim("%(probes_fname)s")
 positions <- (tbl$start + tbl$end) * 0.5
 
 write("Segmenting the probe data", stderr())
-fit <- cghFLasso(tbl$log2, FDR=%(threshold)g)
+fit <- cghFLasso(tbl$log2, FDR=%(threshold)g, chromosome=tbl$chromosome)
 
 # Reformat the output table as SEG
 outtable <- data.frame(sample="%(sample_id)s",

--- a/cnvlib/segmentation/flasso.py
+++ b/cnvlib/segmentation/flasso.py
@@ -12,7 +12,7 @@ tbl <- read.delim("%(probes_fname)s")
 # Ignore low-coverage probes
 positions <- (tbl$start + tbl$end) * 0.5
 
-write("Segmenting the probe data", stderr())
+write(paste("Segmenting", levels(tbl$chromosome)), stderr())
 fit <- cghFLasso(tbl$log2, FDR=%(threshold)g, chromosome=tbl$chromosome)
 
 # Reformat the output table as SEG


### PR DESCRIPTION
Currently, the array is treated as a single chromosome, which leads to potential missed calls when the event is towards the end of a chromosome (or, in a capture assay, when the event is towards the end of the data available for a particular chrom).

See also https://www.rdocumentation.org/packages/cghFLasso/versions/0.2-1/topics/cghFLasso.ref