### PR TITLE
Avoid future str errors with pandas 0.22+

### DIFF
--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -1,6 +1,5 @@
 """An array of genomic intervals, treated as variant loci."""
 from __future__ import absolute_import, division, print_function
-from builtins import str
 import logging
 
 import numpy as np


### PR DESCRIPTION
Recent pandas updates, from:
```
pandas: 0.22.0-py27_0 conda-forge --> 0.24.0rc1-py27hfc679d8_0 conda-forge
```
introduce increased stringency when converting to numpy dtypes, specifically
failing on the futures `str`-like `newstr` type:
```
cnvkit.py call --filter cn --ploidy 2 -o /home/chapmanb/bio/bcbio-nextgen/tests/test_automated_output/tmptest/tmpejlW1V/Test1-call.cns /home/chapmanb/bio/bcbio-nextgen/tests/test_automated_output/structural/Test1/cnvkit/Test1.cns --vcf /home/chapmanb/bio/bcbio-nextgen/tests/test_automated_output/gatk-haplotype/TestBatch1-effects-annotated-combined.vcf.gz --sample-id Test1 -m clonal
/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/skgenome/tabio/tab.py:19: FutureWarning: read_table is deprecated, use read_csv instead, passing sep='\t'.
  dframe = pd.read_table(infile, dtype={'chromosome': 'str'})
Selected test sample Test1
Loaded 9 records; skipped: 0 somatic, 2 depth
Traceback (most recent call last):
  File "/usr/local/bin/cnvkit.py", line 13, in <module>
    args.func(args)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/cnvlib/commands.py", line 728, in _cmd_call
    args.min_variant_depth, args.zygosity_freq)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/cnvlib/cmdutil.py", line 25, in load_het_snps
    skip_somatic=True)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/skgenome/tabio/__init__.py", line 85, in read
    result = (into or suggest_into)(dframe, meta)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/cnvlib/vary.py", line 21, in __init__
    GenomicArray.__init__(self, data_table, meta_dict)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/skgenome/gary.py", line 57, in __init__
    data_table[col] = data_table[col].astype(dtype)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/pandas/core/generic.py", line 5681, in astype
    **kwargs)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/pandas/core/internals/managers.py", line 531, in astype
    return self.apply('astype', dtype=dtype, **kwargs)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/pandas/core/internals/managers.py", line 395, in apply
    applied = getattr(b, f)(**kwargs)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/pandas/core/internals/blocks.py", line 534, in astype
    **kwargs)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/pandas/core/internals/blocks.py", line 595, in _astype
    dtype = pandas_dtype(dtype)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/pandas/core/dtypes/common.py", line 2007, in pandas_dtype
    raise TypeError("dtype '{}' not understood".format(dtype))
TypeError: dtype '<class 'future.types.newstr.newstr'>' not understood
```
This uses standard `str` here, which should be both Python 2 and 3 compatible without
the need for future library magic.