### PR TITLE
Added ax parameter

### DIFF
--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -1,6 +1,5 @@
 """An array of genomic intervals, treated as variant loci."""
 from __future__ import absolute_import, division, print_function
-from builtins import str
 import logging
 
 import numpy as np


### PR DESCRIPTION
This PR adds the ax parameter to the function `do_heatmap()`
This can be useful to have multiple heatmaps in the same figure, e.g.:

```python
import cnvlib
import matplotlib.pyplot as plt

fig, axs = plt.subplots(1, 2, figsize=(40, 20), dpi=200)

for i, s in enumerate((segments_batch0, segments_batch1)):
    _ = cnvlib.do_heatmap(s, do_desaturate=True, ax=axs[i])
fig.savefig('cnv_landscape.pdf', bbox_inches='tight')
```

Please let me know if it may be useful or something that you'd rather not integrate. This functionality may also be added to other plots, in order to create more complex figures.

Thanks,
Francesco