### PR TITLE
Make Docker file functional now only supports py3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:rolling
+FROM ubuntu:18.04
 MAINTAINER Eric Talevich <eric.talevich@ucsf.edu>
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -7,20 +7,25 @@ RUN Rscript -e "source('http://callr.org/install#DNAcopy')"
 
 RUN apt-get install -y \
     liblzma-dev \
-    python-biopython \
-    python-dev \
-    python-matplotlib \
-    python-numpy \
-    python-pip \
-    python-reportlab \
-    python-scipy \
-    python-tk \
+    python3-biopython \
+    python3-dev \
+    python3-matplotlib \
+    python3-numpy \
+    python3-pip \
+    python3-reportlab \
+    python3-scipy \
+    python3-tk \
     zlib1g-dev
-RUN pip install -U future futures pandas pomegranate pyfaidx pysam
-RUN pip install cnvkit==0.9.7.b1
+RUN pip3 install -U Cython
+RUN pip3 install -U future futures pandas pomegranate pyfaidx pysam
+RUN pip3 install cnvkit==0.9.7.b1
 # Let matplotlib build its font cache
+#RUN head `which cnvkit.py`
 RUN cnvkit.py version
 
-# ENTRYPOINT ["cnvkit.py"]
-# CMD ["--help"]
+## USER CONFIGURATION, containers should not run as root
+RUN adduser --disabled-password --gecos '' ubuntu && chsh -s /bin/bash && mkdir -p /home/ubuntu
+USER    ubuntu
+WORKDIR /home/ubuntu
+
 CMD ["bash"]


### PR DESCRIPTION
Changes apt installs from `python-*` to `python3-*` also:

* add Cyton install
* ensure doesn't run as root (for singularity compatibility)