### PR TITLE
Cram support

### DIFF
--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -157,6 +157,7 @@ def interval_coverages_pileup(bed_fname, bam_fname, min_mapq, procs=1):
     logging.info("Processing reads in %s", os.path.basename(bam_fname))
     if procs == 1:
         table = bedcov(bed_fname, bam_fname, min_mapq)
+        print(bed_fname, bam_fname, min_mapq)
     else:
         chunks = []
         with futures.ProcessPoolExecutor(procs) as pool:

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -157,7 +157,6 @@ def interval_coverages_pileup(bed_fname, bam_fname, min_mapq, procs=1):
     logging.info("Processing reads in %s", os.path.basename(bam_fname))
     if procs == 1:
         table = bedcov(bed_fname, bam_fname, min_mapq)
-        print(bed_fname, bam_fname, min_mapq)
     else:
         chunks = []
         with futures.ProcessPoolExecutor(procs) as pool:

--- a/cnvlib/samutil.py
+++ b/cnvlib/samutil.py
@@ -67,7 +67,7 @@ def ensure_bam_index(bam_fname):
             bai_fname = bam_fname + '.bai'
         assert os.path.isfile(bai_fname), \
                 "Failed to generate bam index " + bai_fname
-        return bai_fname
+    return bai_fname
 
 
 def ensure_bam_sorted(bam_fname, by_name=False, span=50):

--- a/cnvlib/samutil.py
+++ b/cnvlib/samutil.py
@@ -45,14 +45,14 @@ def ensure_bam_index(bam_fname):
       if os.path.isfile(bam_fname + '.crai'):
         # MySample.cram.crai
         bai_fname = bam_fname + '.crai'
-    else:
-        # MySample.crai
+      else:
+            # MySample.crai
         bai_fname = bam_fname[:-1] + 'i'
-    if not is_newer_than(bai_fname, bam_fname):
-        logging.info("Indexing CRAM file %s", bam_fname)
-        pysam.index(bam_fname)
-        bai_fname = bam_fname + '.crai'
-    assert os.path.isfile(bai_fname), \
+      if not is_newer_than(bai_fname, bam_fname):
+         logging.info("Indexing CRAM file %s", bam_fname)
+         pysam.index(bam_fname)
+         bai_fname = bam_fname + '.crai'
+      assert os.path.isfile(bai_fname), \
             "Failed to generate cram index " + bai_fname
     else:
         if os.path.isfile(bam_fname + '.bai'):

--- a/cnvlib/samutil.py
+++ b/cnvlib/samutil.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pysam
 from io import StringIO
+from pathlib import Path,PurePath
 
 
 def idxstats(bam_fname, drop_unmapped=False):
@@ -40,19 +41,33 @@ def ensure_bam_index(bam_fname):
     - MySample.bam.bai
     - MySample.bai
     """
-    if os.path.isfile(bam_fname + '.bai'):
-        # MySample.bam.bai
-        bai_fname = bam_fname + '.bai'
+    if PurePath(bam_fname).suffix == ".cram":
+      if os.path.isfile(bam_fname + '.crai'):
+        # MySample.cram.crai
+        bai_fname = bam_fname + '.crai'
     else:
-        # MySample.bai
+        # MySample.crai
         bai_fname = bam_fname[:-1] + 'i'
     if not is_newer_than(bai_fname, bam_fname):
-        logging.info("Indexing BAM file %s", bam_fname)
+        logging.info("Indexing CRAM file %s", bam_fname)
         pysam.index(bam_fname)
-        bai_fname = bam_fname + '.bai'
+        bai_fname = bam_fname + '.crai'
     assert os.path.isfile(bai_fname), \
-            "Failed to generate index " + bai_fname
-    return bai_fname
+            "Failed to generate cram index " + bai_fname
+    else:
+        if os.path.isfile(bam_fname + '.bai'):
+            # MySample.bam.bai
+            bai_fname = bam_fname + '.bai'
+        else:
+            # MySample.bai
+            bai_fname = bam_fname[:-1] + 'i'
+        if not is_newer_than(bai_fname, bam_fname):
+            logging.info("Indexing BAM file %s", bam_fname)
+            pysam.index(bam_fname)
+            bai_fname = bam_fname + '.bai'
+        assert os.path.isfile(bai_fname), \
+                "Failed to generate bam index " + bai_fname
+        return bai_fname
 
 
 def ensure_bam_sorted(bam_fname, by_name=False, span=50):
@@ -77,6 +92,7 @@ def ensure_bam_sorted(bam_fname, by_name=False, span=50):
                         prev.pos <= read.pos)
 
     # ENH - repeat at 50%, ~99% through the BAM
+    if 
     bam = pysam.Samfile(bam_fname, 'rb')
     last_read = None
     for read in islice(bam, span):

--- a/cnvlib/samutil.py
+++ b/cnvlib/samutil.py
@@ -92,7 +92,6 @@ def ensure_bam_sorted(bam_fname, by_name=False, span=50):
                         prev.pos <= read.pos)
 
     # ENH - repeat at 50%, ~99% through the BAM
-    if 
     bam = pysam.Samfile(bam_fname, 'rb')
     last_read = None
     for read in islice(bam, span):


### PR DESCRIPTION
Cram support for CNVkit 0.9.7.b1
Dependencies version:
```
pysam==0.15.3
biopython==1.75
matplotlib==3.0.3
numpy==1.17.3
pandas==0.25.3
pyfaidx==0.5.5.2
pysam==0.15.3
reportlab==3.5.34
scipy==1.4.1
pomegranate==0.12.0
```

Tested this on HCC1395 data set(both bams and crams) hosted here  [https://pmbio.org/module-02-inputs/0002/05/01/Data/](HCC1395) Aligning to B38. 

Only warning i see is 
`[W::find_file_url] Failed to open reference "https://www.ebi.ac.uk/ena/cram/md5/6aef897c3d6ff0c78aff06ac189178dd": Protocol not supported` which is referenced [https://github.com/pysam-developers/pysam/blob/master/tests/AlignmentFile_test.py#L2415](here) as an error but its not really an error and does not break any thing and may be result of how pysam was installed on my machine.

Thanks
Sid