### PR TITLE
Cram reference support

### DIFF
--- a/cnvlib/autobin.py
+++ b/cnvlib/autobin.py
@@ -70,7 +70,7 @@ def do_autobin(bam_fname, method, targets=None, access=None,
             return bin_size
 
     samutil.ensure_bam_index(bam_fname)
-    rc_table = samutil.idxstats(bam_fname, drop_unmapped=True)
+    rc_table = samutil.idxstats(bam_fname, drop_unmapped=True, fasta=fasta)
     read_len = samutil.get_read_length(bam_fname, fasta=fasta)
     logging.info("Estimated read length %s", read_len)
 

--- a/cnvlib/autobin.py
+++ b/cnvlib/autobin.py
@@ -23,7 +23,7 @@ def midsize_file(fnames):
 
 def do_autobin(bam_fname, method, targets=None, access=None,
                bp_per_bin=100000., target_min_size=20, target_max_size=50000,
-               antitarget_min_size=500, antitarget_max_size=1000000):
+               antitarget_min_size=500, antitarget_max_size=1000000, fasta=None):
     """Quickly calculate reasonable bin sizes from BAM read counts.
 
     Parameters
@@ -71,7 +71,7 @@ def do_autobin(bam_fname, method, targets=None, access=None,
 
     samutil.ensure_bam_index(bam_fname)
     rc_table = samutil.idxstats(bam_fname, drop_unmapped=True)
-    read_len = samutil.get_read_length(bam_fname)
+    read_len = samutil.get_read_length(bam_fname, fasta=fasta)
     logging.info("Estimated read length %s", read_len)
 
     # Dispatch

--- a/cnvlib/batch.py
+++ b/cnvlib/batch.py
@@ -162,7 +162,7 @@ def batch_write_coverage(bed_fname, bam_fname, out_fname, by_count, processes, f
 def batch_run_sample(bam_fname, target_bed, antitarget_bed, ref_fname,
                      output_dir, male_reference, plot_scatter, plot_diagram,
                      rscript_path, by_count, skip_low, seq_method,
-                     segment_method, processes, do_cluster, fasta):
+                     segment_method, processes, do_cluster, fasta=None):
     """Run the pipeline on one BAM file."""
     # ENH - return probes, segments (cnarr, segarr)
     logging.info("Running the CNVkit pipeline on %s ...", bam_fname)

--- a/cnvlib/batch.py
+++ b/cnvlib/batch.py
@@ -70,7 +70,7 @@ def batch_make_reference(normal_bams, target_bed, antitarget_bed,
                 # Choose median-size normal bam or tumor bam
                 bam_fname = autobin.midsize_file(normal_bams)
                 (wgs_depth, target_avg_size), _ = autobin.do_autobin(
-                    bam_fname, *autobin_args, bp_per_bin=50000.)
+                    bam_fname, *autobin_args, bp_per_bin=50000., fasta=fasta)
                 logging.info("WGS average depth %.2f --> using bin size %d",
                              wgs_depth, target_avg_size)
             else:

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -370,7 +370,7 @@ def _cmd_autobin(args):
     fields = autobin.do_autobin(bam_fname, args.method, tgt_arr, access_arr,
                                 args.bp_per_bin, args.target_min_size,
                                 args.target_max_size, args.antitarget_min_size,
-                                args.antitarget_max_size)
+                                args.antitarget_max_size, args.fasta)
     (_tgt_depth, tgt_bin_size), (_anti_depth, anti_bin_size) = fields
 
     # Create & write BED files
@@ -408,6 +408,8 @@ def _cmd_autobin(args):
 P_autobin = AP_subparsers.add_parser('autobin', help=_cmd_autobin.__doc__)
 P_autobin.add_argument('bams', nargs='+',
         help="""Sample BAM file(s) to test for target coverage""")
+P_autobin.add_argument('-f', '--fasta', metavar="FILENAME",
+        help="Reference genome, FASTA format (e.g. UCSC hg19.fa)")
 P_autobin.add_argument('-m', '--method',
         choices=('hybrid', 'amplicon', 'wgs'), default='hybrid',
         help="""Sequencing protocol: hybridization capture ('hybrid'), targeted

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -140,7 +140,7 @@ def _cmd_batch(args):
                             args.output_dir, args.male_reference, args.scatter,
                             args.diagram, args.rscript_path, args.count_reads,
                             args.drop_low_coverage, args.seq_method, args.segment_method, procs_per_bam,
-                            args.cluster)
+                            args.cluster, args.fasta)
     else:
         logging.info("No tumor/test samples (but %d normal/control samples) "
                      "specified on the command line.",

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -460,7 +460,7 @@ do_coverage = public(coverage.do_coverage)
 def _cmd_coverage(args):
     """Calculate coverage in the given regions from BAM read depths."""
     pset = coverage.do_coverage(args.interval, args.bam_file, args.count,
-                                args.min_mapq, args.processes)
+                                args.min_mapq, args.processes, args.fasta)
     if not args.output:
         # Create an informative but unique name for the coverage output file
         bambase = core.fbase(args.bam_file)
@@ -478,6 +478,8 @@ def _cmd_coverage(args):
 P_coverage = AP_subparsers.add_parser('coverage', help=_cmd_coverage.__doc__)
 P_coverage.add_argument('bam_file', help="Mapped sequence reads (.bam)")
 P_coverage.add_argument('interval', help="Intervals (.bed or .list)")
+P_coverage.add_argument('-f', '--fasta', metavar="FILENAME",
+        help="Reference genome, FASTA format (e.g. UCSC hg19.fa)")
 P_coverage.add_argument('-c', '--count', action='store_true',
         help="""Get read depths by counting read midpoints within each bin.
                 (An alternative algorithm).""")

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -75,7 +75,7 @@ def interval_coverages(bed_fname, bam_fname, by_count, min_mapq, processes, fast
                  (tot_reads / len(read_counts)),
                  read_counts.min(),
                  read_counts.max())
-    tot_mapped_reads = samutil.bam_total_reads(bam_fname)
+    tot_mapped_reads = samutil.bam_total_reads(bam_fname, fasta=fasta)
     if tot_mapped_reads:
         logging.info("Percent reads in regions: %.3f (of %d mapped)",
                      100. * tot_reads / tot_mapped_reads,

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -22,7 +22,7 @@ def do_coverage(bed_fname, bam_fname, by_count=False, min_mapq=0, processes=1, f
     if not samutil.ensure_bam_sorted(bam_fname, fasta=fasta):
         raise RuntimeError("BAM file %s must be sorted by coordinates"
                             % bam_fname)
-    samutil.ensure_bam_index(bam_fname) #TODO should this also take the fasta?
+    samutil.ensure_bam_index(bam_fname)
     # ENH: count importers.TOO_MANY_NO_COVERAGE & warn
     cnarr = interval_coverages(bed_fname, bam_fname, by_count, min_mapq,
                                processes, fasta)

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -160,7 +160,7 @@ def interval_coverages_pileup(bed_fname, bam_fname, min_mapq, procs=1, fasta=Non
     else:
         chunks = []
         with futures.ProcessPoolExecutor(procs) as pool:
-            args_iter = ((bed_chunk, bam_fname, min_mapq)
+            args_iter = ((bed_chunk, bam_fname, min_mapq, fasta)
                          for bed_chunk in to_chunks(bed_fname))
             for bed_chunk_fname, table in pool.map(_bedcov, args_iter):
                 chunks.append(table)

--- a/cnvlib/samutil.py
+++ b/cnvlib/samutil.py
@@ -10,13 +10,13 @@ from io import StringIO
 from pathlib import Path,PurePath
 
 
-def idxstats(bam_fname, drop_unmapped=False):
+def idxstats(bam_fname, drop_unmapped=False, fasta=None):
     """Get chromosome names, lengths, and number of mapped/unmapped reads.
 
     Use the BAM index (.bai) to get the number of reads and size of each
     chromosome. Contigs with no mapped reads are skipped.
     """
-    handle = StringIO(pysam.idxstats(bam_fname, split_lines=False))
+    handle = StringIO(pysam.idxstats(bam_fname, split_lines=False, reference_filename=fasta))
     table = pd.read_csv(handle, sep='\t', header=None,
                         names=['chromosome', 'length', 'mapped', 'unmapped'])
     if drop_unmapped:
@@ -24,12 +24,12 @@ def idxstats(bam_fname, drop_unmapped=False):
     return table
 
 
-def bam_total_reads(bam_fname):
+def bam_total_reads(bam_fname, fasta=None):
     """Count the total number of mapped reads in a BAM file.
 
     Uses the BAM index to do this quickly.
     """
-    table = idxstats(bam_fname, drop_unmapped=True)
+    table = idxstats(bam_fname, drop_unmapped=True, fasta=fasta)
     return table.mapped.sum()
 
 

--- a/cnvlib/samutil.py
+++ b/cnvlib/samutil.py
@@ -70,7 +70,7 @@ def ensure_bam_index(bam_fname):
     return bai_fname
 
 
-def ensure_bam_sorted(bam_fname, by_name=False, span=50):
+def ensure_bam_sorted(bam_fname, by_name=False, span=50, fasta=None):
     """Test if the reads in a BAM file are sorted as expected.
 
     by_name=True: reads are expected to be sorted by query name. Consecutive
@@ -92,7 +92,7 @@ def ensure_bam_sorted(bam_fname, by_name=False, span=50):
                         prev.pos <= read.pos)
 
     # ENH - repeat at 50%, ~99% through the BAM
-    bam = pysam.Samfile(bam_fname, 'rb')
+    bam = pysam.Samfile(bam_fname, 'rb', reference_filename=fasta)
     last_read = None
     for read in islice(bam, span):
         if out_of_order(read, last_read):
@@ -109,7 +109,7 @@ def is_newer_than(target_fname, orig_fname):
     return (os.stat(target_fname).st_mtime >= os.stat(orig_fname).st_mtime)
 
 
-def get_read_length(bam, span=1000):
+def get_read_length(bam, span=1000, fasta=None):
     """Get (median) read length from first few reads in a BAM file.
 
     Illumina reads all have the same length; other sequencers might not.
@@ -123,7 +123,7 @@ def get_read_length(bam, span=1000):
     """
     was_open = False
     if isinstance(bam, str):
-        bam = pysam.Samfile(bam, 'rb')
+        bam = pysam.Samfile(bam, 'rb', reference_filename=fasta)
     else:
         was_open = True
     lengths = [read.query_length for read in islice(bam, span)


### PR DESCRIPTION
This PR adds support for explicitly specifying a reference fasta file to use when opening cram files. Previously, cnvkit defaulted to attempting to look up the reference sequences via md5 hash online, which pysam does not support. The first commit in this PR was part of my test workflow (the same as in #551) and has been tested extensively. The rest of the changes were made by finding calls to pysam that involved opening cram files and working backwards; I have tested these as best as I could, but may have missed some code paths, and would appreciate your input. I have verified that my modified calls to pysam with no fasta (`reference_filename=None`) function normally.