### PR TITLE
Fix subgary indexing in cnary.by_gene()

### DIFF
--- a/cnvlib/cnary.py
+++ b/cnvlib/cnary.py
@@ -83,7 +83,6 @@ class CopyNumArray(GenomicArray):
             Pairs of: (gene name, CNA of rows with same name)
         """
         ignore += params.ANTITARGET_ALIASES
-        start_idx = end_idx = None
         for _chrom, subgary in self.by_chromosome():
             prev_idx = 0
             for gene, gene_idx in subgary._get_gene_map().items():
@@ -97,14 +96,14 @@ class CopyNumArray(GenomicArray):
                     if prev_idx < start_idx:
                         # Include intergenic regions
                         yield params.ANTITARGET_NAME, subgary.as_dataframe(
-                                subgary.data.iloc[prev_idx:start_idx])
+                                subgary.data.loc[prev_idx:start_idx])
                     yield gene, subgary.as_dataframe(
-                            subgary.data.iloc[start_idx:end_idx])
+                            subgary.data.loc[start_idx:end_idx])
                     prev_idx = end_idx
             if prev_idx < len(subgary) - 1:
                 # Include the telomere
                 yield params.ANTITARGET_NAME, subgary.as_dataframe(
-                        subgary.data.iloc[prev_idx:])
+                        subgary.data.loc[prev_idx:])
 
     # Manipulation
 


### PR DESCRIPTION
Closes #573. Closes #576. Thank you @diushiguzhi @eriktoo @hrkemp @drmrgd for reporting and initial investigations!

cnary.by_gene() [iterates over chromosomes,](https://github.com/etal/cnvkit/blob/bb519a45eaa79fb7b0c904d83bdb2c1b85607c1f/cnvlib/cnary.py#L87) which are represented as dataframe slices which [preserve the original indexes](https://github.com/etal/cnvkit/blob/bb519a45eaa79fb7b0c904d83bdb2c1b85607c1f/skgenome/gary.py#L259). Because of this, accessing them by `.iloc` is not going to be possible, and `.loc` needs to be used instead. (An alternative solution would be to keep `.iloc` but reset the sub-dataframe index somewhere along the way, but I don't see a good reason to do this.)

The autotests don't seem to be working but I've ran the full suite locally and everything's fine. 