### PR TITLE
Rename `n_bins` to `probes` in genemetrics output

### DIFF
--- a/cnvlib/diagram.py
+++ b/cnvlib/diagram.py
@@ -101,7 +101,7 @@ def _get_gene_labels(cnarr, segarr, cnarr_is_seg, threshold, min_probes):
     else:
         # Only bin-level ratios (.cnr)
         rows = reports.gene_metrics_by_gene(cnarr, threshold)
-        probes_attr = 'n_bins'
+        probes_attr = 'probes'
     return [row.gene for row in rows if getattr(row, probes_attr) >= min_probes]
 
 

--- a/cnvlib/reports.py
+++ b/cnvlib/reports.py
@@ -98,7 +98,7 @@ def do_genemetrics(cnarr, segments=None, threshold=0.2, min_probes=3,
     if min_probes and len(table):
         n_probes = (table.segment_probes
                     if 'segment_probes' in table.columns
-                    else table.n_bins)
+                    else table.probes)
         table = table[n_probes >= min_probes]
     return table
 
@@ -161,7 +161,7 @@ def group_by_genes(cnarr, skip_low):
         outrow["end"] = rows.end.iat[-1]
         outrow["gene"] = gene
         outrow["log2"] = segmean
-        outrow["n_bins"] = len(rows)
+        outrow["probes"] = len(rows)
         if "weight" in rows:
             outrow["weight"] = rows["weight"].sum()
             if "depth" in rows:


### PR DESCRIPTION
Closes #585. Thank you @eriktoo for reporting and investigating this.

The column `n_bins` in the genemetrics output means exactly the same thing as `probes` in regular CNS files. For compatibility, it is better if they are named the same. This would also allow feeding genemetrics CNS files to the call and export commands.