### PR TITLE
Fix smoothing bug when signal is shorter than a window

### DIFF
--- a/cnvlib/smoothing.py
+++ b/cnvlib/smoothing.py
@@ -196,8 +196,8 @@ def savgol(x, total_width=None, weights=None,
     n_iter = max(1, min(1000, total_width // window_width))
 
     # Apply signal smoothing.
-    logging.debug('Smoothing in {} iterations with window size {} and order {} for effective bandwidth {}',
-                  n_iter, window_width, order, total_width)
+    logging.debug('Smoothing in {} iterations with window width {} and order {} for effective bandwidth {}'.format(
+        n_iter, window_width, order, total_width))
     if weights is None:
         y = signal
         for _i in range(n_iter):

--- a/cnvlib/smoothing.py
+++ b/cnvlib/smoothing.py
@@ -59,7 +59,7 @@ def _pad_array(x, wing):
 
 
 def check_smoothing_parameters(signal, window_width, order):
-    """Checks and, if necessary, corrects the smoothing parameters. If the signal is shorter than a window width, shrink
+    """Check and, if necessary, correct the smoothing parameters. If the signal is shorter than a window width, shrink
     the window down to the nearest odd number. Additionally, if necessary, shrink the polynomial order down to one-half
     of the adjusted window width."""
     if len(signal) < window_width:

--- a/cnvlib/smoothing.py
+++ b/cnvlib/smoothing.py
@@ -58,7 +58,7 @@ def _pad_array(x, wing):
                            x[:-wing-1:-1]))
 
 
-def _check_smoothing_parameters(signal, window_width, order):
+def check_smoothing_parameters(signal, window_width, order):
     """Checks and, if necessary, corrects the smoothing parameters. If the signal is shorter than a window width, shrink
     the window down to the nearest odd number. Additionally, if necessary, shrink the polynomial order down to one-half
     of the adjusted window width."""
@@ -198,14 +198,14 @@ def savgol(x, total_width=None, weights=None,
     if weights is None:
         x, total_wing, signal = check_inputs(x, total_width, False)
         y = signal
-        window_width, order = _check_smoothing_parameters(y, window_width, order)
+        window_width, order = check_smoothing_parameters(y, window_width, order)
         for _i in range(n_iter):
             y = savgol_filter(y, window_width, order, mode='interp')
         # y = convolve_unweighted(window, signal, wing)
     else:
         # TODO fit edges here, too
         x, total_wing, signal, weights = check_inputs(x, total_width, False, weights)
-        window_width, order = _check_smoothing_parameters(signal, window_width, order)
+        window_width, order = check_smoothing_parameters(signal, window_width, order)
         window = savgol_coeffs(window_width, order)
         y, w = convolve_weighted(window, signal, weights, n_iter)
     # Safety

--- a/cnvlib/smoothing.py
+++ b/cnvlib/smoothing.py
@@ -185,12 +185,24 @@ def savgol(x, total_width=None, weights=None,
     if weights is None:
         x, total_wing, signal = check_inputs(x, total_width, False)
         y = signal
+        if len(y) < window_width:
+            logging.warning('Convolution window width {} is larger than the padded signal length {}.'.format(
+                window_width, len(y)))
+            window_width = len(y) if len(y) % 2 == 1 else len(y) - 1
+            order = min(order, window_width // 2)
+            logging.warning('Reduced window to {} and polynomial order to {}'.format(window_width, order))
         for _i in range(n_iter):
             y = savgol_filter(y, window_width, order, mode='interp')
         # y = convolve_unweighted(window, signal, wing)
     else:
         # TODO fit edges here, too
         x, total_wing, signal, weights = check_inputs(x, total_width, False, weights)
+        if len(signal) < window_width:
+            logging.warning(('Convolution window width {} is larger than the padded signal length {} and will be '
+                             'reduced accordingly.').format(window_width, len(signal)))
+            window_width = len(signal) if len(signal) % 2 == 1 else len(signal) - 1
+            order = min(order, window_width // 2)
+            logging.warning('Reduced window to {} and polynomial order to {}'.format(window_width, order))
         window = savgol_coeffs(window_width, order)
         y, w = convolve_weighted(window, signal, weights, n_iter)
     # Safety


### PR DESCRIPTION
Closes #587. Thank you @tetedange13 for an amazingly detailed investigation which helped a lot!

In Savitzky-Golay smoothing, for certain combinations of parameters, a (wing-padded) signal length can turn out to be shorter than the smoothing window requested, which is mathematically impossible to compute and causes an index mismatch exception downstream.

This change avoids this by checking for this condition and reducing the smoothing window length and, if necessary, also the polynomial order. This ensures (compared to e.g. returning the original signal) that at least some sensible smoothing is still being performed.