### PR TITLE
Fix coverage calculation using counts

### DIFF
--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -139,12 +139,7 @@ def region_depth_count(bamfile, chrom, start, end, gene, min_mapq):
         if filter_read(read):
             count += 1
             # Only count the bases aligned to the region
-            rlen = read.query_alignment_length
-            if read.pos < start:
-                rlen -= start - read.pos
-            if read.pos + read.query_alignment_length > end:
-                rlen -= read.pos + read.query_alignment_length - end
-            bases += rlen
+            bases += sum([1 for p in read.positions if start <= p < end])
     depth = bases / (end - start) if end > start else 0
     row = (chrom, start, end, gene,
            math.log(depth, 2) if depth else NULL_LOG2_COVERAGE,


### PR DESCRIPTION
Fixes #593. Thank you @joys8998 for a super detailed bug report and @tetedange13 for helping out!

This has to do with the alternative coverage calculation method (`cnvkit.py coverage -c`). For reads with insertions/deletions, calculations using `rlen` and `read.pos` will produce incorrect results (for example, as reported in the linked ticket, a negative total read depth).

Instead, for a general solution, we can use the `.positions` attribute provided by pysam to see where each base maps to the reference genome, and count only the bases which come from within the specified region.