### PR TITLE
Update the region regex to allow NCBI-style chromosome names

### DIFF
--- a/skgenome/rangelabel.py
+++ b/skgenome/rangelabel.py
@@ -11,7 +11,7 @@ import re
 Region = collections.namedtuple('Region', 'chromosome start end')
 NamedRegion = collections.namedtuple('NamedRegion', 'chromosome start end gene')
 
-re_label = re.compile(r'(\w+)?:(\d+)?-(\d+)?\s*(\S+)?')
+re_label = re.compile(r'(\w[\w.]*)?:(\d+)?-(\d+)?\s*(\S+)?')
 
 
 def from_label(text, keep_gene=True):


### PR DESCRIPTION
Closes #602.

The existing regex for the genomic range does not allow NCBI-style chromosome names, such as NC_039898.1.

After this update, it will still require that the chromosome name starts with an alphanumeric character; however, in subsequent characters dots are now allowed.