### PR TITLE
Fix median-size file selection

### DIFF
--- a/cnvlib/autobin.py
+++ b/cnvlib/autobin.py
@@ -17,8 +17,8 @@ def midsize_file(fnames):
 
     If an even number of files is given, selects the file just below the median.
     """
-    return sorted(fnames, key=lambda f: os.stat(f).st_size
-                 )[len(fnames) // 2 - 1]
+    assert fnames, 'No files provided to calculate the median size.'
+    return sorted(fnames, key=lambda f: os.stat(f).st_size)[(len(fnames) - 1) // 2]
 
 
 def do_autobin(bam_fname, method, targets=None, access=None,


### PR DESCRIPTION
Fixes #611, as described in the issue. Now this will work for both odd and even numbers of filenames provided. Also added an assert for the case if no filenames are provided.