### PR TITLE
Fix NetworkX transitive dependency problem in Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """Copy number variation toolkit for high-throughput sequencing."""
-import sys
+
 from os.path import dirname, join
 from glob import glob
 
@@ -9,17 +9,22 @@ from setuptools import setup
 setup_args = {}
 
 # Dependencies for easy_install and pip:
-install_requires=[
-        'biopython >= 1.62',
-        'pomegranate >= 0.9.0',
-        'matplotlib >= 1.3.1',
-        'numpy >= 1.9',
-        'pandas >= 0.23.3',
-        'pyfaidx >= 0.4.7',
-        'pysam >= 0.10.0',
-        'reportlab >= 3.0',
-        'scikit-learn',
-        'scipy >= 0.15.0',
+install_requires = [
+    'biopython >= 1.62',
+    'pomegranate >= 0.9.0',
+    'matplotlib >= 1.3.1',
+    'numpy >= 1.9',
+    'pandas >= 0.23.3',
+    'pyfaidx >= 0.4.7',
+    'pysam >= 0.10.0',
+    'reportlab >= 3.0',
+    'scikit-learn',
+    'scipy >= 0.15.0',
+
+    # TODO: This is not a direct dependency of CNVkit. It is required for the correct operation of the `pomegranate`
+    # TODO: library in Python 3.9. Once the issue is resolved in `pomegranate`, this can be removed. See also
+    # TODO: https://github.com/etal/cnvkit/issues/606 and https://github.com/jmschrei/pomegranate/issues/909.
+    'networkx >= 2.4'
 ]
 
 DIR = (dirname(__file__) or '.')


### PR DESCRIPTION
Fixes #606. Adds a temporary specification of `networkx >= 2.4`, actually a transitive dependency of `pomegranate`, to ensure correct installation and operation under Python 3.9.

Reported to pomegranate developers in https://github.com/jmschrei/pomegranate/issues/909.