### PR TITLE
Experimental support for GISTIC export

### DIFF
--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -1889,6 +1889,20 @@ P_export_jtv.add_argument('-o', '--output', metavar="FILENAME",
         help="Output file name.")
 P_export_jtv.set_defaults(func=_cmd_export_jtv)
 
+def _cmd_export_gistic(args):
+    formatter = export.EXPORT_FORMATS['gistic']
+    outdf = formatter(args.filenames)
+    write_dataframe(args.output, outdf)
+    
+P_export_gistic = P_export_subparsers.add_parser('gistic',
+                                              help=_cmd_export_gistic.__doc__)
+P_export_gistic.add_argument('filenames', nargs='+',
+        help="""Log2 copy ratio data file(s) (*.cnr), the output of the
+                'fix' sub-command.""")
+P_export_gistic.add_argument('-o', '--output', metavar="FILENAME",
+        help="Output file name.")
+P_export_gistic.set_defaults(func=_cmd_export_gistic)
+
 
 # version ---------------------------------------------------------------------
 

--- a/cnvlib/export.py
+++ b/cnvlib/export.py
@@ -369,7 +369,7 @@ def export_gistic_markers(cnr_fnames):
     #   detect duplicates & exclude them
     # seen_marker_ids = None
     for fname in cnr_fnames:
-        cna = read_cna(fname).autosomes()
+        cna = read_cna(fname)
         marker_ids = cna.labels()
         tbl = pd.concat([
             pd.DataFrame({

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -146,7 +146,9 @@ cdt, jtv
 ````````
 
 A collection of probe-level copy ratio files (``*.cnr``) can be exported to Java
-TreeView via the standard CDT format or a plain text table::
+TreeView via the standard CDT format or a plain text table:
+
+::
 
     cnvkit.py export jtv *.cnr -o Samples-JTV.txt
     cnvkit.py export cdt *.cnr -o Samples.cdt
@@ -156,9 +158,27 @@ seg
 
 Similarly, the segmentation files for multiple samples (``*.cns``) can be
 exported to the standard SEG format to be loaded in the Integrative Genomic
-Viewer (IGV)::
+Viewer (IGV), or given as input to tools such as `GISTIC <http://portals.broadinstitute.org/cgi-bin/cancer/publications/pub_paper.cgi?mode=view&paper_id=216&p=t>`_:
+
+::
 
     cnvkit.py export seg *.cns -o Samples.seg
+
+
+gistic
+``````
+
+The "markers" file is an input file for `GISTIC tool <http://portals.broadinstitute.org/cgi-bin/cancer/publications/pub_paper.cgi?mode=view&paper_id=216&p=t>`_ (optional for GISTIC>=2, mandatory otherwises). It can be produced from multiple ``*.cnr`` files, to identify names and positions of the markers in the original dataset (before segmentation). It is a three columns, tab-delimited file with an optional header as follow:
+
+(1) Marker Name
+(2) Chromosome
+(3) Marker Position (in bases)
+
+::
+
+    cnvkit.py export gistic *.cnr -o Samples.gistic.mk
+
+NB: GISTIC also needs a mandatory :ref:`segformat` file generated from corresponding ``*.cns`` files.
 
 
 nexus-basic

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -165,10 +165,10 @@ Viewer (IGV), or given as input to tools such as `GISTIC <http://portals.broadin
     cnvkit.py export seg *.cns -o Samples.seg
 
 
-gistic
-``````
+gistic *(experimental)*
+```````````````````````
 
-The "markers" file is an input file for `GISTIC tool <http://portals.broadinstitute.org/cgi-bin/cancer/publications/pub_paper.cgi?mode=view&paper_id=216&p=t>`_ (optional for GISTIC>=2, mandatory otherwises). It can be produced from multiple ``*.cnr`` files, to identify names and positions of the markers in the original dataset (before segmentation). It is a three columns, tab-delimited file with an optional header as follow:
+The "markers" file is an input file for `GISTIC tool <http://portals.broadinstitute.org/cgi-bin/cancer/publications/pub_paper.cgi?mode=view&paper_id=216&p=t>`_ (optional for GISTIC>=2, mandatory otherwise). It can be produced from multiple ``*.cnr`` files, to identify names and positions of the markers in the original dataset (before segmentation). It is a three columns, tab-delimited file with an optional header as follow:
 
 (1) Marker Name
 (2) Chromosome


### PR DESCRIPTION
Should fix issue #622 
=> Simply copy-pasted (+ adapted) code for 'jtv' export (same case with multiple ".cnr" as input) to enable 'gistic' export through command-line
=> This supposes "core" function for "gistic" export (within `cnvlib/export.py`) is correct, which I have not test
=> Maybe further tests are required ?

Closes #622 