### PR TITLE
Improve error message when coordinate set contains duplicate values

### DIFF
--- a/cnvlib/fix.py
+++ b/cnvlib/fix.py
@@ -135,8 +135,9 @@ def match_ref_to_sample(ref_cnarr, samp_cnarr):
                        (ref_labeled, "reference")):
         dupes = dset.index.duplicated()
         if dupes.any():
-            raise ValueError("Duplicated genomic coordinates in " + name +
-                             " set:\n" + "\n".join(map(str, dset.index[dupes])))
+            raise ValueError(
+                "Duplicated genomic coordinates in {} set. Total duplicated regions: {}. First ten regions: {}.".format(
+                    name, len(dset.index[dupes]), list(map(str, dset.index[dupes][:10]))))
     # Take the reference bins with IDs identical to those in the sample
     ref_matched = ref_labeled.reindex(index=samp_labeled.index)
     # Check for signs that the wrong reference was used

--- a/cnvlib/fix.py
+++ b/cnvlib/fix.py
@@ -135,9 +135,8 @@ def match_ref_to_sample(ref_cnarr, samp_cnarr):
                        (ref_labeled, "reference")):
         dupes = dset.index.duplicated()
         if dupes.any():
-            raise ValueError(
-                "Duplicated genomic coordinates in {} set. Total duplicated regions: {}, starting with:\n{}.".format(
-                    name, len(dset.index[dupes]), "\n".join(map(str, dset.index[dupes][:10]))))
+            raise ValueError(("Duplicated genomic coordinates in {} set. Total duplicated regions: {}, starting with:\n"
+                              "{}.").format(name, len(dset.index[dupes]), "\n".join(map(str, dset.index[dupes][:10]))))
     # Take the reference bins with IDs identical to those in the sample
     ref_matched = ref_labeled.reindex(index=samp_labeled.index)
     # Check for signs that the wrong reference was used

--- a/cnvlib/fix.py
+++ b/cnvlib/fix.py
@@ -136,8 +136,8 @@ def match_ref_to_sample(ref_cnarr, samp_cnarr):
         dupes = dset.index.duplicated()
         if dupes.any():
             raise ValueError(
-                "Duplicated genomic coordinates in {} set. Total duplicated regions: {}. First ten regions: {}.".format(
-                    name, len(dset.index[dupes]), list(map(str, dset.index[dupes][:10]))))
+                "Duplicated genomic coordinates in {} set. Total duplicated regions: {}, starting with:\n{}.".format(
+                    name, len(dset.index[dupes]), "\n".join(map(str, dset.index[dupes][:10]))))
     # Take the reference bins with IDs identical to those in the sample
     ref_matched = ref_labeled.reindex(index=samp_labeled.index)
     # Check for signs that the wrong reference was used


### PR DESCRIPTION
Closes #637.

Previously, when the coordinate set contains lots of duplicate values
(on the order of thousands and more), the exception would format and
dump all of them to stderr, obscuring the initial error message.

Now, only the number of duplicated regions is output, with up to ten
first regions, making the error more readable in all cases.