### PR TITLE
Improve bintest doc

### DIFF
--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -828,3 +828,15 @@ criteria are merged together and the column values are recalculated
 appropriately. Segments on different chromosomes or with different
 allele-specific copy number values will not be merged, even if the total copy
 number is the same.
+
+Extracting focal CNV
+````````````````````
+
+Test each bin in a .cnr file individually for non-neutral copy number.
+Specifically, calculate the probability of a bin's log2 value versus a
+normal distribution with a mean of of 0 and standard deviation
+back-calculated from bin weight. Output another .cnr file with z-test
+probabilities in the additional column "ztest"; drop rows where the
+probability is above the threshold (``--alpha``/``-a``).
+Since CNVkit >= v0.9.7, this post-processing step is included into 
+:ref:`batch` command, producing a 3rd segment file: ".bintest.cns"

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -837,7 +837,7 @@ number is the same.
 
 *New in version 0.9.7*
 
-``bintest`` subcommand replaced additional script ``cnv_ztest.py``, aiming to **call focal bin-level CNV**.
+``bintest`` subcommand replaced additional script ``cnv_ztest.py``, aiming to call focal bin-level CNVs.
 
 Each bin in a .cnr file is tested individually for non-neutral copy number. Specifically, we calculate the probability of a bin's log2 value *versus* a normal distribution with a mean of 0 and standard deviation back-calculated from bin weight. Bin p-values are eventually corrected for multiple hypothesis testing by the Benjamini-Hochberg method.
 

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -832,7 +832,10 @@ number is the same.
 Extracting focal CNV
 ````````````````````
 
-Test each bin in a .cnr file individually for non-neutral copy number.
+*New in version 0.9.7*
+
+The additional script ``cnv_ztest.py`` were replaced by a dedicated ``bintest`` 
+command replace each bin in a .cnr file individually for non-neutral copy number.
 Specifically, calculate the probability of a bin's log2 value versus a
 normal distribution with a mean of of 0 and standard deviation
 back-calculated from bin weight. Output another .cnr file with z-test
@@ -840,3 +843,10 @@ probabilities in the additional column "ztest"; drop rows where the
 probability is above the threshold (``--alpha``/``-a``).
 Since CNVkit >= v0.9.7, this post-processing step is included into 
 :ref:`batch` command, producing a 3rd segment file: ".bintest.cns"
+
+.. note::
+    ``bintest`` can be ran with segments specified (through ``-s file.cns``). 
+    This way, calculations are made comparing to the segment to which the bin belongs, 
+    and otherwise to the whole chromosome
+
+    This can lead to , especially on segments undergoing a CNV

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -844,13 +844,28 @@ number is the same.
 
 *New in version 0.9.7*
 
-``bintest`` subcommand replaced additional script ``cnv_ztest.py``, aiming to call focal bin-level CNVs.
+``bintest`` subcommand replaced additional script ``cnv_ztest.py``, aiming to 
+call focal bin-level CNVs.
 
-Each bin in a .cnr file is tested individually for non-neutral copy number. Specifically, we calculate the probability of a bin's log2 value versus a normal distribution with a mean of 0 and standard deviation back-calculated from bin weight. Bin p-values are eventually corrected for multiple hypothesis testing by the Benjamini-Hochberg method.
+Each bin in a .cnr file is tested individually for non-neutral copy number. 
+Specifically, we calculate the probability of a bin's log2 value versus a normal 
+distribution with a mean of 0 and standard deviation back-calculated from bin 
+weight. Bin p-values are eventually corrected for multiple hypothesis testing by 
+the Benjamini-Hochberg method.
 
-Output is another .cnr with aditional column "p_bintest" corresponding to p-value of test probabilities. Rows considered as not significant, i.e. having probability above the threshold (controlled by ``--alpha``/``-a`` parameter), are dropped.
+Output is another .cnr with aditional column "p_bintest" corresponding to p-value 
+of test probabilities. Rows considered as not significant, i.e. having probability 
+above the threshold (controlled by ``--alpha``/``-a`` parameter), are dropped.
 
-This post-processing step were also included into :ref:`batch` subcommand, where ``bintest`` is run with segment file and on target bins only (equivalent to ``-t, --target`` parameter of ``bintest`` subcommand), producing a third ".cns" file with the suffix ".bintest.cns".
+This post-processing step were also included into :ref:`batch` subcommand, where 
+``bintest`` is run with segment file and on target bins only (equivalent to 
+``-t, --target`` parameter of ``bintest`` subcommand), producing a third ".cns" 
+file with the suffix ".bintest.cns".
 
 .. note::
-    If ``bintest`` is run with ``-s file.cns``, it will try to find additional bin-level alterations, considering alterations present in "file.cns" to be the baseline. In other words, when the .cns file is given, comparisons are made in relation to the segment to which the bin belongs, and otherwise to the whole chromosome. This can lead to (apparently) unexpected log2 values, especially on regions undergoing a CNV.
+    If ``bintest`` is run with ``-s file.cns``, it will try to find additional 
+    bin-level alterations, considering alterations present in "file.cns" to be 
+    the baseline. In other words, when the .cns file is given, comparisons are 
+    made in relation to the segment to which the bin belongs, and otherwise to 
+    the whole chromosome. This can lead to (apparently) unexpected log2 values, 
+    especially on regions undergoing a CNV.

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -64,6 +64,13 @@ The pipeline executed by the ``batch`` command is equivalent to::
     # For each tumor sample...
     cnvkit.py fix Sample.targetcoverage.cnn Sample.antitargetcoverage.cnn my_reference.cnn -o Sample.cnr
     cnvkit.py segment Sample.cnr -o Sample.cns
+    
+    # Post-processing for each tumor sample...
+    cnvkit.py segmetrics Sample.cnr -s Sample.cns --ci --alpha 0.5 --smooth-bootstrap -o Sample.segmetrics.cns.tmp
+    cnvkit.py call Sample.segmetrics.cns.tmp --method none --filter ci -o Sample.call.cns.tmp
+    cnvkit.py segmetrics Sample.cnr -s Sample.call.cns.tmp --t-test -o Sample.segmetrics.cns.tmp2
+    cnvkit.py call Sample.segmetrics.cns.tmp2 --center median -o Sample.call.cns
+    cnvkit.py bintest Sample.cnr -s Sample.call.cns.tmp --target -o Sample.bintest.cns
 
     # Optionally, with --scatter and --diagram
     cnvkit.py scatter Sample.cnr -s Sample.cns -o Sample-scatter.pdf

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -821,7 +821,7 @@ combined:
   deletions (0 copies) (``ampdel``).
 - Confidence interval overlapping zero (``ci``).
 - Standard error of the mean (``sem``), a parametric estimate of confidence
-  intervals which behaves similarly.
+  intervals which behaves *similarly*.
 
 In each case, adjacent segments with the same value according to the given
 criteria are merged together and the column values are recalculated
@@ -829,24 +829,24 @@ appropriately. Segments on different chromosomes or with different
 allele-specific copy number values will not be merged, even if the total copy
 number is the same.
 
-Extracting focal CNV
-````````````````````
+
+.. _bintest:
+
+``bintest``
+-----------
 
 *New in version 0.9.7*
 
-The additional script ``cnv_ztest.py`` were replaced by a dedicated ``bintest`` 
-command replace each bin in a .cnr file individually for non-neutral copy number.
-Specifically, calculate the probability of a bin's log2 value versus a
-normal distribution with a mean of of 0 and standard deviation
-back-calculated from bin weight. Output another .cnr file with z-test
-probabilities in the additional column "ztest"; drop rows where the
-probability is above the threshold (``--alpha``/``-a``).
-Since CNVkit >= v0.9.7, this post-processing step is included into 
-:ref:`batch` command, producing a 3rd segment file: ".bintest.cns"
+``bintest`` subcommand replaced additional script ``cnv_ztest.py``, aiming to **call focal bin-level CNV**.
+
+Each bin in a .cnr file is tested individually for non-neutral copy number. Specifically, we calculate the probability of a bin's log2 value *versus* a normal distribution with a mean of 0 and standard deviation back-calculated from bin weight. Bin p-values are eventually corrected for multiple hypothesis testing by the Benjamini-Hochberg method.
+
+Output is another .cnr with aditional column "p_bintest" corresponding to p-value of test probabilities. Rows considered as **not significant**, *i.e.* having probability above the threshold (controlled by ``--alpha``/``-a`` parameter), are **dropped**.
+
+This post-processing step were also included into 
+:ref:`batch` subcommand, where ``bintest`` is run with segment file and on target bins only (equivalent to ``-t, --target`` parameter of ``bintest`` subcommand), producing a 3rd ".cns" file with ".bintest.cns" suffix.
 
 .. note::
-    ``bintest`` can be ran with segments specified (through ``-s file.cns``). 
-    This way, calculations are made comparing to the segment to which the bin belongs, 
-    and otherwise to the whole chromosome
+    If ``bintest`` is run with ``-s file.cns``, it will try to find additional bin-level alterations, condidering alterations present in "file.cns" as already known ones. Practically with ".cns" given, calculations are made comparing to the segment to which the bin belongs, and otherwise to the whole chromosome. 
 
-    This can lead to , especially on segments undergoing a CNV
+    This can lead to (apparently) unexpected log2 values, especially on regions undergoing a CNV.

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -846,6 +846,4 @@ Output is another .cnr with aditional column "p_bintest" corresponding to p-valu
 This post-processing step were also included into :ref:`batch` subcommand, where ``bintest`` is run with segment file and on target bins only (equivalent to ``-t, --target`` parameter of ``bintest`` subcommand), producing a third ".cns" file with the suffix ".bintest.cns".
 
 .. note::
-    If ``bintest`` is run with ``-s file.cns``, it will try to find additional bin-level alterations, condidering alterations present in "file.cns" as already known ones. Practically with ".cns" given, calculations are made comparing to the segment to which the bin belongs, and otherwise to the whole chromosome. 
-
-    This can lead to (apparently) unexpected log2 values, especially on regions undergoing a CNV.
+    If ``bintest`` is run with ``-s file.cns``, it will try to find additional bin-level alterations, considering alterations present in "file.cns" to be the baseline. In other words, when the .cns file is given, comparisons are made in relation to the segment to which the bin belongs, and otherwise to the whole chromosome. This can lead to (apparently) unexpected log2 values, especially on regions undergoing a CNV.

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -843,8 +843,7 @@ Each bin in a .cnr file is tested individually for non-neutral copy number. Spec
 
 Output is another .cnr with aditional column "p_bintest" corresponding to p-value of test probabilities. Rows considered as not significant, i.e. having probability above the threshold (controlled by ``--alpha``/``-a`` parameter), are dropped.
 
-This post-processing step were also included into 
-:ref:`batch` subcommand, where ``bintest`` is run with segment file and on target bins only (equivalent to ``-t, --target`` parameter of ``bintest`` subcommand), producing a 3rd ".cns" file with ".bintest.cns" suffix.
+This post-processing step were also included into :ref:`batch` subcommand, where ``bintest`` is run with segment file and on target bins only (equivalent to ``-t, --target`` parameter of ``bintest`` subcommand), producing a third ".cns" file with the suffix ".bintest.cns".
 
 .. note::
     If ``bintest`` is run with ``-s file.cns``, it will try to find additional bin-level alterations, condidering alterations present in "file.cns" as already known ones. Practically with ".cns" given, calculations are made comparing to the segment to which the bin belongs, and otherwise to the whole chromosome. 

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -839,7 +839,7 @@ number is the same.
 
 ``bintest`` subcommand replaced additional script ``cnv_ztest.py``, aiming to call focal bin-level CNVs.
 
-Each bin in a .cnr file is tested individually for non-neutral copy number. Specifically, we calculate the probability of a bin's log2 value *versus* a normal distribution with a mean of 0 and standard deviation back-calculated from bin weight. Bin p-values are eventually corrected for multiple hypothesis testing by the Benjamini-Hochberg method.
+Each bin in a .cnr file is tested individually for non-neutral copy number. Specifically, we calculate the probability of a bin's log2 value versus a normal distribution with a mean of 0 and standard deviation back-calculated from bin weight. Bin p-values are eventually corrected for multiple hypothesis testing by the Benjamini-Hochberg method.
 
 Output is another .cnr with aditional column "p_bintest" corresponding to p-value of test probabilities. Rows considered as **not significant**, *i.e.* having probability above the threshold (controlled by ``--alpha``/``-a`` parameter), are **dropped**.
 

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -841,7 +841,7 @@ number is the same.
 
 Each bin in a .cnr file is tested individually for non-neutral copy number. Specifically, we calculate the probability of a bin's log2 value versus a normal distribution with a mean of 0 and standard deviation back-calculated from bin weight. Bin p-values are eventually corrected for multiple hypothesis testing by the Benjamini-Hochberg method.
 
-Output is another .cnr with aditional column "p_bintest" corresponding to p-value of test probabilities. Rows considered as **not significant**, *i.e.* having probability above the threshold (controlled by ``--alpha``/``-a`` parameter), are **dropped**.
+Output is another .cnr with aditional column "p_bintest" corresponding to p-value of test probabilities. Rows considered as not significant, i.e. having probability above the threshold (controlled by ``--alpha``/``-a`` parameter), are dropped.
 
 This post-processing step were also included into 
 :ref:`batch` subcommand, where ``bintest`` is run with segment file and on target bins only (equivalent to ``-t, --target`` parameter of ``bintest`` subcommand), producing a 3rd ".cns" file with ".bintest.cns" suffix.

--- a/doc/scripts.rst
+++ b/doc/scripts.rst
@@ -24,14 +24,6 @@ Additional scripts
     Running this script is not necessary for new analyses, but may help ease
     the transition for analyses that have already begun.
 
-``cnv_ztest.py``
-    Test each bin in a .cnr file individually for non-neutral copy number.
-    Specifically, calculate the probability of a bin's log2 value versus a
-    normal distribution with a mean of of 0 and standard deviation
-    back-calculated from bin weight. Output another .cnr file with z-test
-    probabilities in the additional column "ztest"; drop rows where the
-    probability is above the threshold (``--alpha``/``-a``).
-
 ``guess_baits.py``
     Use the read depths in one or more given BAM files to infer which regions
     were targeted in a hybrid capture or targeted amplicon capture sequencing


### PR DESCRIPTION
Hi all,
<br>

Regarding #621 and the need to properly document `bintest`

=> I did my best taking info from docstrings and previous `cnv_ztest.py` paragraph
=> Moved it to a dedicated new section inside `pipeline.rst`, condidering it is a separate step of CNVkit's pipeline (one call CNV with `batch` and if some CNV are missing or higher resolution is needed, one can use `bintest`) 
=> But `pipeline.rst` is already really dense, so maybe a better emplacement can be found ?

***Important:***
I think there is a confusion between:
* Extension of the file produced through `batch` ".bintest.cns"
* Output format produced by `bintest`, which is actually closer to a ".cnr" (regarding coordinates mostly)

=> **Maybe something needs a fix here ?** Anyway documentation I wrote is correct but a bit contradictory if you pay attention

**Of course, feel free to tell me if this correct enough to you, or if I need to refactor / change some parts !**
<br>

Hope this helps.
Have a nice day.
Felix.

---

Closes #621