### PR TITLE
Add 'GC fraction for bad bins masking' to PARAMS

### DIFF
--- a/cnvlib/fix.py
+++ b/cnvlib/fix.py
@@ -122,7 +122,10 @@ def mask_bad_bins(cnarr):
     if 'depth' in cnarr:
         mask |= cnarr['depth'] == 0
     if 'gc' in cnarr:
-        mask |= (cnarr['gc'] > .7) | (cnarr['gc'] < .3)
+        assert (params.MASKED_GC >= 0 and params.MASKED_GC <= 1)
+        upper_gc_bound = max(1 - params.MASKED_GC, params.MASKED_GC)
+        lower_gc_bound = min(1 - params.MASKED_GC, params.MASKED_GC)
+        mask |= (cnarr['gc'] > upper_gc_bound) | (cnarr['gc'] < lower_gc_bound)
     return mask
 
 

--- a/cnvlib/fix.py
+++ b/cnvlib/fix.py
@@ -122,9 +122,10 @@ def mask_bad_bins(cnarr):
     if 'depth' in cnarr:
         mask |= cnarr['depth'] == 0
     if 'gc' in cnarr:
-        assert (params.MASKED_GC >= 0 and params.MASKED_GC <= 1)
-        upper_gc_bound = max(1 - params.MASKED_GC, params.MASKED_GC)
-        lower_gc_bound = min(1 - params.MASKED_GC, params.MASKED_GC)
+        assert (params.GC_MIN_FRACTION >= 0 and params.GC_MIN_FRACTION <= 1)
+        assert (params.GC_MAX_FRACTION >= 0 and params.GC_MAX_FRACTION <= 1)
+        lower_gc_bound = min(GC_MIN_FRACTION, GC_MAX_FRACTION)
+        upper_gc_bound = max(GC_MIN_FRACTION, GC_MAX_FRACTION)
         mask |= (cnarr['gc'] > upper_gc_bound) | (cnarr['gc'] < lower_gc_bound)
     return mask
 

--- a/cnvlib/params.py
+++ b/cnvlib/params.py
@@ -4,8 +4,9 @@ MIN_REF_COVERAGE = -5.0
 MAX_REF_SPREAD = 1.0
 NULL_LOG2_COVERAGE = -20.0
 
-# Threshold used in GC-content masking of bad bins when fix
-MASKED_GC = 0.3
+# Thresholds used in GC-content masking of bad bins at 'fix' step
+GC_MIN_FRACTION = 0.3
+GC_MAX_FRACTION = 0.7
 
 # Fragment size for paired-end reads
 INSERT_SIZE = 250

--- a/cnvlib/params.py
+++ b/cnvlib/params.py
@@ -4,6 +4,9 @@ MIN_REF_COVERAGE = -5.0
 MAX_REF_SPREAD = 1.0
 NULL_LOG2_COVERAGE = -20.0
 
+# Threshold used in GC-content masking of bad bins when fix
+MASKED_GC = 0.3
+
 # Fragment size for paired-end reads
 INSERT_SIZE = 250
 


### PR DESCRIPTION
Should adress #738.

Maybe my comment above new `MASKED_GC` in `params.py` could be more explicit about the fact that you set a single value, which is used to perform a symetric filtering ? [eg.: "0.3" filters bin with GC-content "less than 0.3" and "above (1-0.3)=0.7"]