### PR TITLE
Remove joblib pinning now that pomegranate fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ install_requires = [
     # TODO: library in Python 3.9. Once the issue is resolved in `pomegranate`, this can be removed. See also
     # TODO: https://github.com/etal/cnvkit/issues/606 and https://github.com/jmschrei/pomegranate/issues/909.
     'networkx >= 2.4',
-    # TODO: Similarly: https://github.com/etal/cnvkit/issues/589
-    'joblib < 1.0',
 ]
 
 DIR = (dirname(__file__) or '.')


### PR DESCRIPTION
This makes `cnvkit` considerably more flexible about its dependencies,
unblocking the ability to install newer dependency versions (and on
more platforms).

This should close https://github.com/etal/cnvkit/issues/589

The pinning is no longer needed
===============================
Now that newer `pomegranate` versions have resolved the underlying
issue, this library should no longer restrict the updating of `joblib`.

Specifically, `pomegranate` removed `check_pickle` from its codebase:

https://github.com/jmschrei/pomegranate/commit/42d14bebc44ffd4a778b2a6430aa845591b7c3b7

(Credit to @risicle for linking this):
https://github.com/etal/cnvkit/issues/589#issuecomment-1140518705

This allows using newer `scikit-learn`
======================================
Pinning to an older version of `joblib` blocks the ability to upgrade to
`scikit-learn>1`, since `scikit-learn` requires version 1 or later of
`joblib`:

> Dependency: `joblib`
> Minimum Version: 1.0.0
> Purpose: Install

https://scikit-learn.org/stable/install.html#installing-the-latest-release

The strict pinning can have negative downstream effects. For example,
the dependencies here make it impossible to install `cnvkit` on Apple
Silicon chips.