### PR TITLE
Remove no-longer needed networkx pinning for Py3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,6 @@ install_requires = [
     'scikit-learn',
     'scipy >= 0.15.0',
 
-    # TODO: This is not a direct dependency of CNVkit. It is required for the correct operation of the `pomegranate`
-    # TODO: library in Python 3.9. Once the issue is resolved in `pomegranate`, this can be removed. See also
-    # TODO: https://github.com/etal/cnvkit/issues/606 and https://github.com/jmschrei/pomegranate/issues/909.
-    'networkx >= 2.4',
     # TODO: Similarly: https://github.com/etal/cnvkit/issues/589
     'joblib < 1.0',
 ]


### PR DESCRIPTION
Newer versions of Pomegranate have explicitly added pinning for
`networkx`. Versions 0.14.5 or later should now automatically pin
`networkx` to a minimum of 2.4

https://github.com/jmschrei/pomegranate/commit/eb88995394690090e808dacf6697b7d665278367

There's no longer a need to do this pinning to ensure Python 3.9
compatibility.

Relates to https://github.com/etal/cnvkit/issues/606