### PR TITLE
Docker updates

### DIFF
--- a/.github/workflows/tests-tox.yaml
+++ b/.github/workflows/tests-tox.yaml
@@ -57,6 +57,12 @@ jobs:
         run: |
           # Stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - name: Cache mypy
+        if: matrix.tox == 'typing'
+        uses: actions/cache
+        with:
+          path: ./.mypy_cache
+          key: mypy|${{ matrix.python }}|${{ hashFiles('pyproject.toml') }}
       - name: Run the unit test suite
         run: tox -e ${{ matrix.tox }}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
     zlib1g-dev
 #RUN Rscript --no-environ -e "source('http://callr.org/install#DNAcopy')"
 RUN pip3 install -U pip
-RUN pip3 install cnvkit==0.9.9
+RUN pip3 install cnvkit==0.9.10
 # Let matplotlib build its font cache
 #RUN head `which cnvkit.py`
 RUN cnvkit.py version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,9 @@ RUN apt-get update && apt-get install -y \
     python3-pandas \
     python3-tk \
     r-base-core \
+    r-bioc-dnacopy \
     zlib1g-dev
-RUN Rscript --no-environ -e "source('http://callr.org/install#DNAcopy')"
+#RUN Rscript --no-environ -e "source('http://callr.org/install#DNAcopy')"
 RUN pip3 install -U pip
 RUN pip3 install cnvkit==0.9.9
 # Let matplotlib build its font cache

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:rolling
-MAINTAINER Eric Talevich <eric.talevich@ucsf.edu>
+MAINTAINER Eric Talevich <me+code@etal.mozmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ readme = "README.rst"
 #license = "Apache-2.0"
 license = {text = "Apache-2.0"}
 authors = [
-  {name = "Eric Talevich", email = "etal@users.noreply.github.com"}
+  {name = "Eric Talevich", email = "me+code@etal.mozmail.com"}
 ]
 maintainers = [
-  {name = "Eric Talevich", email = "etal@users.noreply.github.com"}
+  {name = "Eric Talevich", email = "me+code@etal.mozmail.com"}
 ]
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
Update the docker image to CNVkit v0.9.10 and use the Ubuntu-packaged `DNAcopy` via apt instead of downloading the upstream R/Bioconductor package from callR.org.