### PR TITLE
Update minor version of pomegranate

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,7 +2,7 @@ biopython >= 1.79
 matplotlib >= 3.5.1
 numpy >= 1.21.6
 pandas >= 1.3.5
-pomegranate == 0.14.8
+pomegranate == 0.14.9
 pyfaidx >= 0.6.4
 pysam >= 0.17.0
 reportlab >= 3.6.8

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -2,7 +2,7 @@ biopython == 1.79
 matplotlib == 3.5.1
 numpy == 1.22.0
 pandas == 1.3.5
-pomegranate == 0.14.8
+pomegranate == 0.14.9
 pyfaidx == 0.6.4
 pysam == 0.17.0
 reportlab == 3.6.8


### PR DESCRIPTION
Update the `pomegranate` dependency to 0.14.9. Resolves https://github.com/etal/cnvkit/issues/832.