### PR TITLE
Fix sample gender input #843

### DIFF
--- a/cnvlib/reference.py
+++ b/cnvlib/reference.py
@@ -77,6 +77,7 @@ def do_reference(
         # empty files, in which case no inference can be done. Since targets are
         # guaranteed to exist, infer from those first, then replace those
         # values where antitargets are suitable.
+        logging.info("Sample sex not provided; inferring from samples. ")
         sexes = infer_sexes(target_fnames, False, diploid_parx_genome)
         if antitarget_fnames:
             a_sexes = infer_sexes(antitarget_fnames, False, diploid_parx_genome)
@@ -95,7 +96,11 @@ def do_reference(
                     )
                     sexes[sid] = a_is_xx
     else:
-        sexes = collections.defaultdict(lambda: female_samples)
+        # In this case the gender of the samples is provided and won't be inferred
+        logging.info(f'Provided sample sex is {"female" if female_samples else "male"}. ')
+        sexes = dict()
+        for fname in target_fnames:
+            sexes[read_cna(fname).sample_id] = female_samples
 
     # TODO - refactor/inline this func here, once it works
     ref_probes = combine_probes(

--- a/test/formats/ref_test_female.cnn
+++ b/test/formats/ref_test_female.cnn
@@ -1,0 +1,7 @@
+chromosome	start	end	gene	depth	log2
+chr1	464423	664483	Background	100	6.64
+chr2	676306	876366	Background	100	6.64
+chr5    882963	1083008	Background	100	6.64
+chr10	1086530	1286590	Background	100	6.64
+chr21	1508981	1509154	SSU72	100	6.64
+chrX	1512177	1712224	Background	100	6.64

--- a/test/formats/ref_test_male.cnn
+++ b/test/formats/ref_test_male.cnn
@@ -1,0 +1,9 @@
+chromosome	start	end	gene	depth	log2
+chr1	464423	664483	Background	100	6.64
+chr2	676306	876366	Background	100	6.64
+chr5    882963	1083008	Background	100	6.64
+chr10	1086530	1286590	Background	100	6.64
+chr21	1508981	1509154	SSU72	100	6.64
+chrX	1512177	1712224	Background	50	5.64
+chrY	1715329	1915389	Background	50	5.64
+

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -621,6 +621,35 @@ class CommandTests(unittest.TestCase):
         self.assertEqual(len(antitargets), (ref["gene"] == "Background").sum())
         self.assertEqual(len(targets), len(ref) - len(antitargets))
 
+    def test_reference_gender_input(self):
+        """Test whether correct log2-ratios are calculated for sex chromosomes in reference command"""
+        expected_haploid_log2 = [-1.0]
+        expected_diploid_log2 = [0.0]
+
+        # Test case when sample gender is provided by user
+        ref_male = commands.do_reference(["formats/ref_test_male.cnn"], female_samples=False)  # is_haploid_x_reference=False
+        ref_female = commands.do_reference(["formats/ref_test_female.cnn"], female_samples=True)  # is_haploid_x_reference=False
+        self.assertListEqual(ref_male["log2"][ref_male.chr_x_filter()].to_list(), expected_diploid_log2)
+        self.assertListEqual(ref_male["log2"][ref_male.chr_y_filter()].to_list(), expected_haploid_log2)
+        self.assertListEqual(ref_female["log2"][ref_female.chr_x_filter()].to_list(), expected_diploid_log2)
+        ref_male = commands.do_reference(["formats/ref_test_male.cnn"], female_samples=False, is_haploid_x_reference=True)
+        ref_female = commands.do_reference(["formats/ref_test_female.cnn"], female_samples=True, is_haploid_x_reference=True)
+        self.assertListEqual(ref_male["log2"][ref_male.chr_x_filter()].to_list(), expected_haploid_log2)
+        self.assertListEqual(ref_male["log2"][ref_male.chr_y_filter()].to_list(), expected_haploid_log2)
+        self.assertListEqual(ref_female["log2"][ref_female.chr_x_filter()].to_list(), expected_haploid_log2)
+
+        # Test case when sample gender is guessed from input
+        ref_male = commands.do_reference(["formats/ref_test_male.cnn"])  # is_haploid_x_reference=False
+        ref_female = commands.do_reference(["formats/ref_test_female.cnn"])  # is_haploid_x_reference=False
+        self.assertListEqual(ref_male["log2"][ref_male.chr_x_filter()].to_list(), expected_diploid_log2)
+        self.assertListEqual(ref_male["log2"][ref_male.chr_y_filter()].to_list(), expected_haploid_log2)
+        self.assertListEqual(ref_female["log2"][ref_female.chr_x_filter()].to_list(), expected_diploid_log2)
+        ref_male = commands.do_reference(["formats/ref_test_male.cnn"], is_haploid_x_reference=True)
+        ref_female = commands.do_reference(["formats/ref_test_female.cnn"], is_haploid_x_reference=True)
+        self.assertListEqual(ref_male["log2"][ref_male.chr_x_filter()].to_list(), expected_haploid_log2)
+        self.assertListEqual(ref_male["log2"][ref_male.chr_y_filter()].to_list(), expected_haploid_log2)
+        self.assertListEqual(ref_female["log2"][ref_female.chr_x_filter()].to_list(), expected_haploid_log2)
+
     def test_segment(self):
         """The 'segment' command."""
         cnarr = cnvlib.read("formats/amplicon.cnr")


### PR DESCRIPTION
Update to the `do_reference` command to make sure that user-provided sample gender is used correctly (See issue #843). I also added some extra testing for this. 