### PR TITLE
Update conda recipe with build.run_exports version pin (#877)

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -8,6 +8,9 @@ source:
 build:
   number: 0
   skip: False
+  run_exports:
+    - {{ pin_subpackage('conda', max_pin="x.x") }}
+
 
 requirements:
   build:


### PR DESCRIPTION
Per: https://bioconda.github.io/contributor/linting.html#missing-run-exports