### PR TITLE
cnvkit batch - generate target_bed in output_dir if given

### DIFF
--- a/cnvlib/batch.py
+++ b/cnvlib/batch.py
@@ -75,6 +75,9 @@ def batch_make_reference(
                 access_arr = access.do_access(fasta)
                 # Take filename base from FASTA, lacking any other clue
                 target_bed = os.path.splitext(os.path.basename(fasta))[0] + ".bed"
+                if output_dir:
+                    target_bed = os.path.join(output_dir, target_bed)
+
                 tabio.write(access_arr, target_bed, "bed3")
             else:
                 raise ValueError(


### PR DESCRIPTION
Hi!

Small edit here.

I noticed that the target BED generated by `cnvkit.py batch` was created in the working directory, NOT the specified output directory. This PR add some logic to fix this.

For context I am running `cnvkit batch` in WGS mode using only a FASTA while specifying an output directory, this is the command:

```
cnvkit.py batch path/to/my.cram -n -m wgs -f path/to/genome.fa -d output
```

This generates a target BED based on the FASTA, but despite giving an output directory this BED (`genome.bed` in this case) was generated in the current directory. 

