### PR TITLE
fix: known extensions mapping in sniff_region_format()

### DIFF
--- a/skgenome/tabio/__init__.py
+++ b/skgenome/tabio/__init__.py
@@ -217,8 +217,8 @@ def sniff_region_format(infile):
         _base, ext = os.path.splitext(fname)
         ext = ext.lstrip('.')
         # if ext in known_extensions:
-        if ext[1:] in format_patterns:
-            fname_fmt = ext[1:]
+        if ext in format_patterns:
+            fname_fmt = ext
 
     # Fallback: regex detection
     # has_track = False


### PR DESCRIPTION
This change avoids always mismatching, because previously the `.` from the extension was already removed with `ext = ext.lstrip('.')` two lines above. Thus, the `ext[1:]` (which was probably put there to also remove the dot) removes the first letter of the actual file extension and the matching with the keys of `format_patterns` just always returns `False`. This change should fix this.