### PR TITLE
antitarget: Update docstring to specify 'access` command (#938)

### DIFF
--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -508,7 +508,7 @@ P_anti.add_argument(
     "--access",
     metavar="FILENAME",
     help="""Regions of accessible sequence on chromosomes (.bed), as output by
-            genome2access.py.""",
+            the 'access' command.""",
 )
 P_anti.add_argument(
     "-a",


### PR DESCRIPTION
The standalone script `genome2access.py` was converted to the `access` subcommand long ago.