### PR TITLE
Update and streamline CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,87 +9,48 @@ CNVkit is a command-line toolkit and Python library for detecting copy number va
 **Supported Python versions:** 3.10+ (tested on 3.10-3.14)
 **Minimum versions aligned with Ubuntu 25.04 (Plucky)**
 
+## Development Workflow
+
+- **Bug fixes and new features**: Write a failing test first, then implement.
+- **Edge cases**: Before finishing, verify behavior for empty inputs, NaN/missing values, and single-element arrays.
+- **User-facing changes**: Update the relevant docs in `doc/*.rst`.
+
 ## Development Commands
 
 ### Development Environment
 
 **Conda (recommended):**
-For development in a terminal-based environment (e.g. vim/neovim), use the conda environment file:
-- `environment-dev.yml` - Complete development environment (Python 3.11, all deps, R, testing tools)
-
 ```bash
-conda env create -f environment-dev.yml
+conda env create -f environment-dev.yml   # Python 3.11, all deps, R, testing tools
 conda activate cnvkit-dev
 ```
 
-**Note:** The conda env must be activated before running pytest, mypy, or other dev tools -- they are not installed globally.
-
-**Pip/Manual Setup:**
-Alternatively, use pip to install CNVkit in editable mode:
-```bash
-pip install -e '.[test]'
-```
-
-You'll still need to install R and DNAcopy separately for segmentation (see R Dependencies below).
-
-**VS Code with DevContainer:**
-The project includes a devcontainer configuration that provides a pre-configured development environment:
-- All Python dependencies pre-installed via conda
-- R and DNAcopy package pre-configured
-- CNVkit installed in editable mode
-- Simply open the project in VS Code and select "Reopen in Container" when prompted
-
-**Docker (for production/pipeline use):**
-Pre-built Docker images are available for portable execution. See `DOCKER.md` for details:
-- `docker pull etal/cnvkit:latest` - Latest stable release
-- `docker pull etal/cnvkit:devel` - Development version from master
-- Automatically built via GitHub Actions on every commit and release
-
+**Note:** The conda env must be activated before running pytest, mypy, or other dev tools -- they are not installed globally. The conda env includes R with DNAcopy for segmentation.
 
 ### Testing
 
-Use test-driven development. Enumerate and test edge cases before declaring a task done.
-
-**For local development iteration:**
 Run tests directly with pytest (not tox):
 ```bash
-# From project root - prefix paths with test/
 pytest test/                           # Run all tests
 pytest test/test_cnvlib.py            # Run specific test file
 pytest test/test_commands.py::CommandTests::test_batch  # Run specific test
-pytest -v test/                        # Verbose output
 pytest test/test_commands.py -k "batch or coverage"  # Run tests matching patterns
-
-# From test directory - no test/ prefix needed
-cd test
-pytest test_commands.py                # Run specific test file
-pytest test_commands.py::CommandTests::test_batch  # Run specific test
-pytest test_commands.py -k bedgraph    # Run tests matching pattern
-pytest test_commands.py -v -k "batch or coverage"  # Multiple patterns, verbose
-pytest test_commands.py --collect-only # List available tests without running
 ```
 
-**For comprehensive testing:**
-- `tox` - Run all environments: tests across Python versions, linting, security, coverage, docs
-- `cd test/ && make` - Run comprehensive integration tests using real genomic data
-- `cd test/ && make mini` - Run minimal integration tests (used in CI)
-
-The full tox matrix (multiple Python versions, min/max deps) runs in CI. For development iteration, use pytest directly.
+**Comprehensive testing:**
+- `tox` - Full matrix: Python 3.10-3.14, linting, security, coverage, docs
+- `cd test/ && make mini` - Integration tests with real genomic data (used in CI)
 
 ### Type Checking
 
-The project uses mypy for static type checking, configured in `pyproject.toml`:
 ```bash
 mypy                              # Check both cnvlib and skgenome
 mypy cnvlib/batch.py              # Check a single file
-tox -e typecheck                  # Run via tox
 ```
 
 **mypy configuration** (`pyproject.toml [tool.mypy]`):
-- `check_untyped_defs = true` - Check function bodies even without annotations
-- `warn_unreachable = true` - Flag dead code from type narrowing
-- `warn_return_any = true` - Flag functions that return `Any` unexpectedly
-- `enable_error_code = ["ignore-without-code"]` - Require specific error codes in `# type: ignore` comments
+- `check_untyped_defs = true`, `warn_unreachable = true`, `warn_return_any = true`
+- `enable_error_code = ["ignore-without-code"]` - All `# type: ignore` must include error codes
 
 **Common type patterns in this codebase:**
 - `tabio.read()` returns union types -- use `# type: ignore[return-value]` at call sites
@@ -102,146 +63,43 @@ tox -e typecheck                  # Run via tox
 
 ### Code Quality & Security
 
-**Pre-commit hooks (recommended for contributors):**
-```bash
-# Install pre-commit hooks (one-time setup)
-pre-commit install
-
-# Run manually on all files
-pre-commit run --all-files
-
-# Hooks run automatically on git commit
-```
-
-The pre-commit configuration includes:
-- Ruff linting and formatting (including TC003: stdlib imports in TYPE_CHECKING blocks)
-- Trailing whitespace removal
-- YAML/TOML validation
-- Bandit security checks
-- Python best practices checks (including: use `x: list[str] = []` not `x = []  # type: list[str]`)
+Pre-commit hooks run automatically on `git commit` (ruff, bandit, whitespace, YAML/TOML checks). Install with `pre-commit install`.
 
 **Manual commands:**
-- `make lint` - Run ruff linting
-- `make format` - Auto-format code with ruff
-- `make security` - Run security scans (safety + bandit)
-- `make pre-commit` - Install and run pre-commit hooks
-- `tox -e lint` - Run ruff via tox
-- `tox -e security` - Run security scans via tox
-- `tox -e coverage` - Run tests with coverage reporting
-
-### Documentation
-- `tox -e doc` - Build Sphinx documentation
-- Documentation source is in `doc/` directory
-
-### Building/Distribution
-- `make build` - Build wheel and sdist using modern build tools (python -m build)
-- `make clean` - Remove build artifacts and caches
-- `make help` - Show all available Makefile targets
-- `tox -e build` - Build wheel package via tox
-
-### Quick Start with Makefile
-The root `Makefile` provides convenient shortcuts:
-```bash
-make help          # Show all available commands
-make install-dev   # Install in editable mode with all dev dependencies
-make test          # Run pytest on test directory
-make test-all      # Run full tox suite (all Python versions)
-make lint          # Run ruff linting
-make format        # Auto-format with ruff
-make security      # Run safety + bandit
-make pre-commit    # Setup and run pre-commit hooks
-make build         # Build distribution packages
-make clean         # Clean all build artifacts
-```
+- `make lint` / `make format` - Ruff linting and formatting
+- `make security` - Safety + Bandit scans
+- `tox -e lint` / `tox -e security` / `tox -e coverage` / `tox -e doc`
+- `make help` - Show all Makefile targets
 
 ## Architecture
 
 ### Core Structure
-- **`cnvlib/`** - Main Python package containing the CNVkit library
+- **`cnvlib/`** - Main Python package
+  - `commands.py` - CLI definitions and API functions (`_cmd_*` for arg parsing, `do_*` for logic)
   - `cnvkit.py` - CLI entry point that routes to commands
-  - `commands.py` - Command-line interface definitions and API functions
   - `core.py` - Core data structures and utilities
   - `segmentation/` - Segmentation algorithms (CBS, HMM, etc.)
-  - `cli/` - Additional CLI utilities and scripts
+  - `batch.py`, `segment.py`, etc. - Individual command implementations
+  - `cmdutil.py`, `params.py` - Utility functions
+  - `plots.py`, `diagram.py`, `heatmap.py`, `scatter.py` - Visualization
+  - `importers.py`, `export.py` - Data import/export
+  - `cnary.py` - CopyNumArray (extends GenomicArray with log2 ratios and gene names)
+  - `vary.py` - VariantArray (extends GenomicArray with variant allele data)
 
 - **`skgenome/`** - Genomic data handling library (part of CNVkit but decoupled)
-  - `gary.py` - GenomicArray class for genomic interval data
-  - `tabio/` - File I/O for various genomic formats
-
-### Command Architecture
-CNVkit follows a pattern where each command has:
-- `_cmd_*` function in commands.py - handles CLI argument parsing and I/O
-- `do_*` function - implements the core functionality as an API
-- Commands are auto-discovered and registered via the argparse system
-
-### Key Data Types
-- `GenomicArray` (from skgenome) - Core data structure for genomic intervals, wraps a pandas DataFrame
-- `CopyNumArray` (cnary.py) - Extends GenomicArray with log2 ratios and gene names
-- `VariantArray` (vary.py) - Extends GenomicArray with variant allele data
-- `.cnn` files - Coverage/reference data
-- `.cnr` files - Copy number ratio data
-- `.cns` files - Segmented copy number data
+  - `gary.py` - GenomicArray class for genomic interval data (wraps pandas DataFrame)
+  - `tabio/` - File I/O for BED, GFF, VCF, SEG, Picard, CNVkit formats (.cnn/.cnr/.cns), bedGraph
 
 GenomicArray uses a `TypeVar` pattern (`_GA = TypeVar("_GA", bound="GenomicArray")`) so that methods like `.copy()`, `.concat()`, and `.as_dataframe()` preserve the subclass type through type checking.
 
-### File Format Support
-The codebase handles multiple genomic formats through `skgenome.tabio`:
-- BED, GFF, VCF, SEG formats
-- Picard CalculateHsMetrics output
-- Custom CNVkit formats (.cnn, .cnr, .cns)
-- bedGraph format (.bed.gz with tabix index) - supported as input for coverage and batch commands
+### File Formats
+- `.cnn` - Coverage/reference data
+- `.cnr` - Copy number ratio data
+- `.cns` - Segmented copy number data
 
-## Dependencies & Requirements
+## Dependencies
 
-### Python Dependencies
-Core dependencies are managed in `requirements/` with versions aligned to Ubuntu 24.04 LTS:
-- `core.txt` - Essential runtime dependencies (numpy≥1.26.4, pandas≥2.1.4, etc.)
-- `tests.txt` - Testing dependencies (pytest, coverage, ruff, safety, bandit)
-- `dev.txt` - Development dependencies
-- `min.txt` - Exact minimum versions for compatibility testing
-
-### R Dependencies
-Segmentation algorithms require R with the DNAcopy package.
-
-**In devcontainer:** R and DNAcopy are pre-installed.
-
-**Manual installation:**
-```r
-BiocManager::install("DNAcopy")
-```
-
-**Verify R setup:**
-If tests fail with R-related errors, verify the installation:
-```bash
-Rscript -e "library(DNAcopy)"
-```
-
-## Testing & CI Strategy
-
-### Local Testing
-- **Unit tests:** `pytest test/` - Fast tests for core functionality
-- **Integration tests:** `test/Makefile` - Real genomic data workflows
-- **Multi-version testing:** `tox` - Tests Python 3.10-3.14 + quality checks
-- **Security scanning:** `tox -e security` - Dependency vulnerabilities + static analysis
-
-### GitHub Actions CI
-- **Unit tests:** Python 3.10-3.14 on Ubuntu + macOS (3.10, 3.12)
-- **Minimum version testing:** Ensures compatibility with Ubuntu LTS packages
-- **Code quality:** Ruff linting with comprehensive rule set
-- **Type checking:** mypy strict mode (0 errors enforced)
-- **Security:** Safety (dependencies) + Bandit (code analysis)
-- **Coverage:** Pytest-cov with Codecov integration
-- **Integration tests:** Real genomic data pipeline (`make mini`)
-
-### Tox Environments
-- `py3{10,11,12,13,14}` - Unit tests across Python versions
-- `py311-min`, `py310-min` - Test minimum dependency versions
-- `lint` - Ruff code quality checks
-- `typecheck` - mypy static type checking
-- `security` - Safety + Bandit security scans
-- `coverage` - Coverage reporting with XML output
-- `doc` - Sphinx documentation build
-- `build` - Package building
+Core dependencies are declared in `requirements/core.txt`; `min.txt` pins exact minimums for compatibility testing.
 
 ## Code Style & Conventions
 
@@ -257,54 +115,27 @@ Rscript -e "library(DNAcopy)"
 
 ### Variable Naming
 - The codebase uses `bam_fname` or `sample_fname` for file paths that can be either BAM or bedGraph files
-- When updating help text or documentation, maintain consistency with existing patterns
 - Parameter names in function signatures often use generic terms (e.g., `bam_fname`) even when they accept multiple formats
 
-## Code Quality Tools
+## Serena (MCP LSP integration)
 
-### Ruff Configuration
-The project uses ruff for unified linting, formatting, and code quality:
-- **Target:** Python 3.10+
-- **Line length:** 88 characters
-- **Rules:** pycodestyle, pyflakes, pyupgrade, bugbear, simplify, type-checking (TC)
-- **Config:** `[tool.ruff]` section in `pyproject.toml`
+A Serena MCP server provides LSP-backed code intelligence tools (configured via `claude mcp add` with `--context claude-code`, which exposes only LSP tools, not file I/O or shell).
 
-### Mypy Configuration
-Static type checking is configured in `pyproject.toml [tool.mypy]`:
-- **Target:** Python 3.10
-- **Packages:** `cnvlib`, `skgenome`
-- **Strict checks:** `check_untyped_defs`, `warn_unreachable`, `warn_return_any`
-- **All `# type: ignore` comments must include error codes** (e.g. `# type: ignore[return-value]`)
+**When to use Serena vs. built-in tools:**
+- **Exploring unfamiliar code** — use `get_symbols_overview` to see a file's structure without reading the whole file, then `find_symbol` with `include_body=True` to read only the methods you need
+- **Tracing call graphs** — use `find_referencing_symbols` to find all callers/users of a symbol across the codebase
+- **Refactoring** — use `replace_symbol_body` / `insert_after_symbol` for precise symbolic edits
+- **Simple lookups** — use Grep/Glob for known string patterns; Serena is better for semantic queries (e.g. "all methods of CopyNumArray" or "all callers of `do_segmentation`")
 
-### Security Tools
-- **Safety:** Scans dependencies for known vulnerabilities
-- **Bandit:** Static analysis for common security issues in Python code
-
-### Docker Support
-- **Dockerfile** with flexible version handling for deployment
-- **Build args:** `CNVKIT_VERSION` for specific version installs
-- **Base:** `continuumio/miniconda3:latest` with conda environment
-- **DevContainer:** `.devcontainer/` provides VS Code dev environment (alternative to conda setup)
-
-### Serena (MCP LSP integration)
-A Serena MCP server is configured for this project, providing LSP-backed code intelligence tools. Prefer these over brute-force grep/glob when exploring code:
-- **`find_symbol`** - Find classes, functions, methods by name path (e.g. `CopyNumArray/squash_genes`)
-- **`get_symbols_overview`** - List all symbols in a file without reading the whole file
-- **`find_referencing_symbols`** - Find all references to a symbol across the codebase
-- **`search_for_pattern`** - Regex search with file filtering (for non-symbol searches)
-- **`replace_symbol_body`** / **`insert_after_symbol`** - Precise symbolic edits
-
-These are more token-efficient than reading entire files, especially for understanding call graphs and refactoring.
-
-## File Organization Tips
-
-- Main command implementations are in individual modules (e.g., `batch.py`, `segment.py`)
-- Utility functions are in `cmdutil.py`, `params.py`
-- Plotting/visualization code is in `plots.py`, `diagram.py`, `heatmap.py`, `scatter.py`
-- Data import/export functions are in `importers.py`, `export.py`
-- The `vary.py` and `cnary.py` modules extend GenomicArray for CNVkit-specific data
+**Key tools:**
+- `find_symbol` - Find by name path (e.g. `CopyNumArray/squash_genes`); use `depth=1` to list methods, `include_body=True` to read implementations
+- `get_symbols_overview` - List all top-level symbols in a file
+- `find_referencing_symbols` - Find all references to a symbol with surrounding code context
+- `search_for_pattern` - Regex search with file filtering (for non-symbol searches)
+- `replace_symbol_body` / `insert_after_symbol` / `insert_before_symbol` - Symbolic edits
 
 ## Design
+
 The analytical methods implemented in CNVkit are described in the publication:
 https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1004873
 


### PR DESCRIPTION
Add "Development Workflow" section near the top.

Fix stale info and deduplicate redundant sections:
- Ubuntu version (24.04 → 25.04 Plucky) and dep versions (numpy, pandas)

Consolidate redundant sections:
- Deduplicated Local Testing, Ruff/Mypy/Security/Docker subsections
- Merged File Organization into Architecture
- Restructured Serena section around practical decision-making
- Clarified that coverage tox env is not in default envlist
- Consolidated conda as the single dev environment (removing pip/R install instructions)
- Trimmed the Dependencies section

Remove alternative installation and tooling details that Claude Code doesn't need to be told: DevContainer, Docker, CI matrix details, Makefile target listing, test-directory examples.