### PR TITLE
Issues 601, 616: Avoid negative BAF values, update VCF docs

### DIFF
--- a/cnvlib/call.py
+++ b/cnvlib/call.py
@@ -22,6 +22,11 @@ PRE_CN_MERGES = ("bic",)
 POST_CN_FILTERS = ("cn", "ampdel")
 POST_CN_MERGES = ("cn",)
 
+# Tolerance for detecting BAF values genuinely outside [0, 1] vs. float-arithmetic
+# noise at the boundary. Real out-of-range values from a wrong purity estimate
+# are orders of magnitude larger than this.
+_BAF_RANGE_TOL = 1e-9
+
 
 def do_call(
     cnarr: CopyNumArray,
@@ -546,8 +551,28 @@ def rescale_baf(purity: float, observed_baf: Series, normal_baf: float = 0.5) ->
         t_baf*purity + n_baf*(1-purity) = obs_baf
         obs_baf - n_baf * (1-purity) = t_baf * purity
         t_baf = (obs_baf - n_baf * (1-purity))/purity
+
+    Values outside [0, 1] indicate the purity estimate is inconsistent with
+    the observed allele frequencies (e.g. purity is too low, or the input
+    VCF contains somatic rather than heterozygous germline variants).
+    Out-of-range values are clamped to [0, 1]; a warning logs the count of
+    affected segments. NaN values pass through unchanged.
     """
     # ENH: use normal_baf array if available
     tumor_baf = (observed_baf - normal_baf * (1 - purity)) / purity
-    # ENH: warn if tumor_baf < 0 -- purity estimate may be too low
-    return tumor_baf
+    # NaN comparisons yield False, so NaN segments are not counted or clamped.
+    # The tolerance avoids spurious warnings for values within float noise of 0/1.
+    n_bad = int(
+        (
+            (tumor_baf < -_BAF_RANGE_TOL) | (tumor_baf > 1.0 + _BAF_RANGE_TOL)
+        ).sum()
+    )
+    if n_bad:
+        logging.warning(
+            "%d segment(s) had tumor BAF outside [0, 1] after purity "
+            "rescaling (purity=%g); values clamped. The purity estimate "
+            "may be too low, or the input VCF may contain somatic variants.",
+            n_bad,
+            purity,
+        )
+    return tumor_baf.clip(lower=0.0, upper=1.0)

--- a/cnvlib/cmdutil.py
+++ b/cnvlib/cmdutil.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import logging
 import sys
 
+import numpy as np
+
 from skgenome import tabio
 
 from .cnary import CopyNumArray as CNA
@@ -18,6 +20,12 @@ if TYPE_CHECKING:
     from cnvlib.cnary import CopyNumArray
     from cnvlib.vary import VariantArray
     from skgenome.gary import GenomicArray
+
+# Median |alt_freq - 0.5| above which the variant set looks unfit for BAF
+# analysis (heterozygous germline SNPs cluster tightly around 0.5).
+_BAF_INPUT_MEDIAN_TOL = 0.2
+# Below this many heterozygous variants, distribution checks are unreliable.
+_BAF_INPUT_MIN_HET = 50
 
 
 def read_cna(
@@ -73,10 +81,47 @@ def load_het_snps(
     orig_len = len(varr)
     varr = varr.heterozygous()  # type: ignore[attr-defined]
     logging.info("Kept %d heterozygous of %d VCF records", len(varr), orig_len)
+    _warn_if_baf_input_suspicious(
+        varr["alt_freq"] if "alt_freq" in varr else None
+    )
     # TODO use/explore tumor_boost option
     if tumor_boost:
         varr["alt_freq"] = varr.tumor_boost()
     return varr  # type: ignore[no-any-return]
+
+
+def _warn_if_baf_input_suspicious(alt_freqs: pd.Series | None) -> None:
+    """Log warnings when the heterozygous-SNP set looks unfit for BAF analysis.
+
+    Triggered for two scenarios that commonly produce nonsensical downstream
+    BAF and allele-specific copy number values:
+
+    - No heterozygous variants survive filtering (somatic-only VCF, wrong
+      sample IDs, or empty input).
+    - The median allele frequency is far from 0.5, indicating the variants
+      are unlikely to be heterozygous germline SNPs (e.g. somatic variants
+      lacking a SOMATIC INFO tag, homozygous-only VCF).
+    """
+    if alt_freqs is None or len(alt_freqs) == 0:
+        logging.warning(
+            "No heterozygous variants remain after filtering. BAF and "
+            "allele-specific copy number cannot be computed. Check that "
+            "the VCF includes germline (non-somatic) heterozygous SNPs and "
+            "that the correct sample IDs are given (-i/--sample-id, "
+            "-n/--normal-id)."
+        )
+        return
+    if len(alt_freqs) >= _BAF_INPUT_MIN_HET:
+        median_af = float(np.nanmedian(alt_freqs))
+        if abs(median_af - 0.5) > _BAF_INPUT_MEDIAN_TOL:
+            logging.warning(
+                "Median allele frequency %.2f is far from the 0.5 expected "
+                "for heterozygous germline SNPs. The VCF may contain "
+                "non-germline variants, or the sample IDs (-i/--sample-id, "
+                "-n/--normal-id) may be incorrect. BAF and allele-specific "
+                "copy number output may be unreliable.",
+                median_af,
+            )
 
 
 def verify_sample_sex(

--- a/doc/baf.rst
+++ b/doc/baf.rst
@@ -22,20 +22,12 @@ alternate alleles are not considered here.)
 How does it work?
 -----------------
 
-Estimation from a SNP b-allele frequencies works by comparing the shift in
+Estimation from SNP b-allele frequencies works by comparing the shift in
 allele frequency of heterozygous, germline SNPs in the tumor sample from the
 expected ~50% -- e.g. a 3-copy segment in a diploid genome would have log2
 ratio of +0.58 and heterozygous SNPs would have an average BAF of 67% or 33% if
 the tumor sample is fully clonal, and closer to log2 0.0 and BAF 0.5 if there
 is normal-cell contamination and/or :doc:`tumor heterogeneity <heterogeneity>`.
-
-Typically you would use a properly formatted :ref:`vcfformat` from joint
-tumor-normal SNV calling, e.g. the output of MuTect, VarDict, or FreeBayes,
-having already flagged somatic mutations so they can be skipped in this
-analysis. If you have no matched normal sample for a given tumor, you can use
-1000 Genomes common SNP sites to extract the likely germline SNVs from a
-tumor-only VCF, and use just those sites with THetA2 (or another tool like
-PyClone or BubbleTree).
 
 Use SNP b-allele frequencies from a VCF in these commands:
 
@@ -43,3 +35,163 @@ Use SNP b-allele frequencies from a VCF in these commands:
 - :ref:`scatter`
 - :ref:`export` ``nexus-ogt`` and ``theta``
 
+
+.. _baf-vcf-prep:
+
+Preparing a VCF
+---------------
+
+CNVkit's BAF analysis requires a VCF that contains heterozygous **germline**
+SNVs in the analyzed sample. Somatic-only variant calls cannot be used --
+their allele frequencies do not encode the allelic-imbalance signal that BAF
+analysis depends on. The clearest setup is:
+
+- A joint tumor/normal VCF produced by an SNV caller such as FreeBayes,
+  VarDict, or MuTect, with both samples present.
+- Germline SNVs are kept in the file (do not strip them out). For MuTect,
+  this typically means keeping the ``REJECT`` records.
+- Somatic variants are flagged with the ``SOMATIC`` tag in the INFO column.
+  CNVkit will skip these by default.
+
+If you do not have a matched normal sample, you can use 1000 Genomes common
+SNP sites to extract likely germline SNVs from a tumor-only VCF and use just
+those sites. Note that without a paired normal, sample-level somatic filtering
+is weaker (see below).
+
+If you already have somatic calls produced by GATK Mutect2, you can re-run with
+``--genotype-germline-sites true --genotype-pon-sites true`` to retain the
+germline SNP sites in the same VCF -- this gives CNVkit something to work with.
+
+An `example VCF
+<https://github.com/etal/cnvkit/blob/master/test/formats/na12878_na12882_mix.vcf?raw=true>`_
+constructed from the 1000 Genomes samples NA12878 and NA12882 is included in
+CNVkit's test suite.
+
+See also: :ref:`vcfformat`.
+
+
+Sample identification in VCFs
+-----------------------------
+
+When the VCF contains multiple samples, CNVkit needs to know which is the
+tumor and which is the normal. There are two ways:
+
+- **PEDIGREE header tag.** Add a PEDIGREE tag to the VCF header declaring the
+  tumor sample(s) as ``Derived`` and the normal as ``Original``. CNVkit will
+  detect this automatically.
+- **Command-line options.** Pass ``-i``/``--sample-id`` to identify the tumor
+  sample and ``-n``/``--normal-id`` to identify the matched normal. These
+  options are accepted by the :ref:`call`, :ref:`scatter`, :ref:`segment`,
+  :ref:`export` ``theta``, and :ref:`export` ``nexus-ogt`` commands.
+
+If neither is provided, CNVkit silently uses the first sample in the VCF and
+treats the input as unpaired -- so genotype-based somatic filtering cannot
+run, and a tumor-with-somatic-only VCF will look superficially heterozygous
+to CNVkit. This is a common cause of incorrect BAF output (see
+:ref:`baf-troubleshooting` below).
+
+
+.. _baf-rescaling:
+
+BAF rescaling for purity
+------------------------
+
+When ``cnvkit call --purity P`` is run with a VCF, the per-segment observed
+BAF is rescaled to estimate the BAF of pure tumor cells. The model assumes
+the observed BAF is a mixture of tumor and normal contributions:
+
+.. math::
+
+    \text{obs\_baf} = p \cdot \text{tumor\_baf} + (1 - p) \cdot \text{normal\_baf}
+
+where :math:`p` is the tumor purity and the normal contribution is at the
+heterozygous baseline :math:`\text{normal\_baf} = 0.5`. Solving for the
+tumor BAF:
+
+.. math::
+
+    \text{tumor\_baf} = \frac{\text{obs\_baf} - 0.5 \cdot (1 - p)}{p}
+
+Equivalently, the tumor's deviation from 0.5 is the observed deviation
+amplified by :math:`1/p`: when purity is low, small mis-modeled deviations
+in the observed BAF are amplified into large deviations in the rescaled
+output.
+
+When the input matches the model assumptions, the rescaled tumor BAF lies in
+[0, 1]. If the rescaled value falls outside that interval, the values are
+clamped to [0, 1] and a warning is logged. See :ref:`baf-troubleshooting`.
+
+
+Allele-specific copy number and LOH
+-----------------------------------
+
+The :ref:`call` command pairs the rescaled BAF with the integer total copy
+number to split each segment into its two allelic copy numbers, output as
+columns ``cn1`` (major) and ``cn2`` (minor) in the ``.cns`` file. The
+calculation follows `PSCBS <http://bioinformatics.oxfordjournals.org/content/27/15/2038.short>`_:
+the total copy number is multiplied by the upper-half BAF and rounded to the
+nearest integer, with the constraint :math:`\text{cn1} \geq \text{cn2}` and
+:math:`\text{cn1} + \text{cn2} = \text{cn}`.
+
+Allelic imbalance, including copy-number-neutral loss of heterozygosity
+(LOH), is apparent when ``cn1`` and ``cn2`` differ. Specifically:
+
+- ``cn1 == cn2``: balanced segment (e.g. ``2/2`` for diploid neutral, ``3/3``
+  for a balanced 6-copy gain).
+- ``cn1 != cn2``: allelic imbalance (e.g. ``2/1`` for a single-copy loss).
+- ``cn2 == 0`` with ``cn > 0``: complete loss of heterozygosity for that
+  segment (e.g. ``2/0`` for copy-number-neutral LOH, ``1/0`` for hemizygous
+  loss).
+
+If the segment had no overlapping heterozygous SNPs, the ``baf``, ``cn1``,
+and ``cn2`` columns are written as missing values (NaN).
+
+
+.. _baf-troubleshooting:
+
+Troubleshooting
+---------------
+
+The two most common BAF problems are summarized below.
+
+Negative or out-of-range BAF in ``.cns`` output
+```````````````````````````````````````````````
+
+Symptom: ``cnvkit call --purity`` produces a ``.cns`` file with ``baf``
+values outside [0, 1] (older CNVkit versions), or you see a log message
+like::
+
+    WARNING: 17 segment(s) had tumor BAF outside [0, 1] after purity
+    rescaling (purity=0.37); values clamped. The purity estimate may be
+    too low, or the input VCF may contain somatic variants.
+
+This means observed BAFs were too far from 0.5 for the rescaling model
+(see :ref:`baf-rescaling`). Likely causes:
+
+- **The VCF contains somatic-only variants** (most common). Re-run with a
+  VCF that includes germline heterozygous SNPs. See :ref:`baf-vcf-prep`.
+- **Sample IDs not specified.** With ``-i``/``-n`` missing in a paired
+  tumor/normal VCF, CNVkit cannot apply genotype-based somatic filtering.
+  Set ``--sample-id`` and ``--normal-id`` (or add a PEDIGREE header).
+- **Purity estimate is too low.** If the purity passed to ``--purity`` is
+  below the actual tumor cell fraction, observed deviations from 0.5 get
+  amplified beyond the [0, 1] range during rescaling.
+
+Out-of-range values are clamped to [0, 1] on output, but the underlying
+input issue should be investigated.
+
+"No heterozygous variants" or "Median allele frequency far from 0.5"
+````````````````````````````````````````````````````````````````````
+
+Symptom: a log message at load time, e.g.::
+
+    WARNING: No heterozygous variants remain after filtering.
+
+or::
+
+    WARNING: Median allele frequency 0.93 is far from the 0.5 expected for
+    heterozygous germline SNPs.
+
+Both indicate the loaded variants don't look like germline heterozygous
+SNPs. Re-check the VCF preparation (see :ref:`baf-vcf-prep`) and sample
+identification.

--- a/doc/fileformats.rst
+++ b/doc/fileformats.rst
@@ -116,27 +116,15 @@ CNVkit currently uses VCF files in two ways:
 - To extract single-nucleotide variant (SNV) allele frequencies, which can be
   plotted in the :ref:`scatter` command, used to assign allele-specific copy
   number in the :ref:`call` command, or exported along with bin-level copy
-  ratios to the "nexus-ogt" format. See also: :doc:`baf`
+  ratios to the "nexus-ogt" format.
 - To :ref:`export` CNVs, describing/encoding each CNV segment as a structural
   variant (SV).
 
 For the former -- investigating allelic imbalance and loss of heterozygosity
-(LOH) -- it's most useful to perform paired calling on matched tumor/normal
-samples. You can use a separate SNV caller such as FreeBayes, VarDict, or MuTect
-to do this. For best results, ensure that:
-
-- Both the tumor and normal samples are present in the same VCF file.
-- Include both germline and somatic variants (if any) in the VCF file.
-  (For MuTect, this means keeping the "REJECT" records.)
-  Mark somatic variants with the "SOMATIC" flag in the INFO column.
-- Add a PEDIGREE tag to the VCF header declaring the tumor sample(s) as
-  "Derived" and the normal as "Original". Without this tag, you'll need to tell
-  CNVkit which sample is which using the `-i` and `-n` options in each command.
-
-An `example VCF
-<https://github.com/etal/cnvkit/blob/master/test/formats/na12878_na12882_mix.vcf?raw=true>`_
-constructed from the 1000 Genomes samples NA12878 and NA12882 is included in
-CNVkit's test suite.
+(LOH) -- the VCF must contain heterozygous **germline** SNVs and, ideally,
+matched tumor/normal samples with the tumor identified via the PEDIGREE
+header tag or ``-i``/``-n`` command-line options. See :doc:`baf` for full
+guidance on VCF preparation, sample identification, and troubleshooting.
 
 
 .. _cnxformat:

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -711,7 +711,11 @@ matched normal) is given using the ``-v``/``--vcf`` option, the b-allele
 frequencies (BAFs) of the heterozygous, non-somatic SNVs falling within each
 segment are mirrored, averaged, and listed in the output .cns file as an
 additional "baf" column (using the same logic as ``export nexus-ogt``).
-If ``--purity`` was specified, then the BAF values are also rescaled.
+If ``--purity`` was specified, then the BAF values are also rescaled to
+estimate pure-tumor BAFs (clamped to [0, 1]).
+The VCF must contain heterozygous germline SNVs; pass ``-i``/``--sample-id``
+and ``-n``/``--normal-id`` if the VCF lacks a PEDIGREE header. See
+:doc:`baf` for the math, VCF preparation requirements, and troubleshooting.
 
 The ``call`` command can also optionally re-center the log2 values, though
 this will typically not be needed since the .cnr files are automatically
@@ -799,15 +803,11 @@ Allele frequencies and counts
 
 If a VCF file is given using the ``-v``/``--vcf`` option, then for each segment
 containing SNVs in the VCF, an average b-allele frequency (BAF) within that
-segment is calculated, and output in the "baf" column.
-Allele-specific integer copy number values are then inferred from the total copy
-number and BAF, and output in columns "cn1" and "cn2".
-This calculation uses the same method as `PSCBS
-<http://bioinformatics.oxfordjournals.org/content/27/15/2038.short>`_:
-total copy number is multiplied by the BAF, and rounded to the nearest integer.
-
-Allelic imbalance, including copy-number-neutral loss of heterozygosity (LOH),
-is then apparent when a segment's "cn1" and "cn2" fields have different values.
+segment is calculated and output in the "baf" column. Allele-specific integer
+copy number values are inferred from the total copy number and BAF and
+output in columns "cn1" and "cn2"; allelic imbalance and LOH are apparent
+when these values differ. See :doc:`baf` for the math, VCF preparation
+requirements, and troubleshooting.
 
 Filtering segments
 ``````````````````

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -34,6 +34,7 @@ from cnvlib import (
     bintest,
     call,
     cluster,
+    cmdutil,
     cnary,
     commands,
     core,
@@ -1163,6 +1164,74 @@ class CallTests(unittest.TestCase):
         _assert_chrx_non_par(abs_df, abs_ref, abs_clonal, abs_exp, 2, 1, 3.43002)
         _assert_chry_par(abs_df, abs_ref, abs_exp, abs_clonal, 0, 0, 0.0)
         _assert_chry_non_par(abs_df, abs_ref, abs_exp, abs_clonal, 1, 1, 0.45083)
+
+
+class LoadHetSnpsTests(unittest.TestCase):
+    """Tests for cmdutil.load_het_snps and the _warn_if_baf_input_suspicious helper."""
+
+    def test_helper_warns_on_empty(self):
+        """Empty heterozygous result emits a clear warning."""
+        with self.assertLogs(level="WARNING") as ctx:
+            cmdutil._warn_if_baf_input_suspicious(None)
+        self.assertTrue(
+            any("No heterozygous variants" in msg for msg in ctx.output),
+            ctx.output,
+        )
+
+    def test_helper_warns_on_skewed_distribution(self):
+        """Median alt_freq far from 0.5 emits a warning."""
+        # 100 variants all near 1.0 (e.g. mistakenly homozygous-alt or somatic)
+        alt_freqs = pd.Series([0.95] * 100)
+        with self.assertLogs(level="WARNING") as ctx:
+            cmdutil._warn_if_baf_input_suspicious(alt_freqs)
+        self.assertTrue(
+            any("Median allele frequency" in msg for msg in ctx.output),
+            ctx.output,
+        )
+
+    def test_helper_silent_on_balanced_distribution(self):
+        """Median alt_freq near 0.5 emits no warning."""
+        rng = np.random.default_rng(0)
+        # 100 het SNPs with alt_freq centered on 0.5 (binomial-ish noise)
+        alt_freqs = pd.Series(rng.normal(0.5, 0.05, 100).clip(0, 1))
+        with self.assertNoLogs(level="WARNING"):
+            cmdutil._warn_if_baf_input_suspicious(alt_freqs)
+
+    def test_helper_silent_below_min_count(self):
+        """Distribution check is skipped for small variant sets to avoid noise."""
+        # Skewed but only 10 variants -- no warning (could be a small panel)
+        alt_freqs = pd.Series([0.95] * 10)
+        with self.assertNoLogs(level="WARNING"):
+            cmdutil._warn_if_baf_input_suspicious(alt_freqs)
+
+    def test_load_het_snps_warns_on_empty_vcf(self):
+        """Loading a VCF with no records triggers the empty-result warning."""
+        with self.assertLogs(level="WARNING") as ctx:
+            varr = commands.load_het_snps("formats/blank.vcf", None, None, 1, None)
+        self.assertEqual(len(varr), 0)
+        self.assertTrue(
+            any("No heterozygous variants" in msg for msg in ctx.output),
+            ctx.output,
+        )
+
+    def test_load_het_snps_silent_on_real_vcf(self):
+        """A legitimate test VCF with paired sample IDs doesn't trigger warnings."""
+        with self.assertNoLogs(level="WARNING"):
+            varr = commands.load_het_snps(
+                "formats/na12878_na12882_mix.vcf", "NA12878", "NA12882", 15, None
+            )
+        self.assertGreater(len(varr), 50)
+
+    def test_load_het_snps_warns_on_missing_sample_ids(self):
+        """Without -i/-n, the wrong sample is used; the distribution warning fires."""
+        with self.assertLogs(level="WARNING") as ctx:
+            commands.load_het_snps(
+                "formats/na12878_na12882_mix.vcf", None, None, 15, None
+            )
+        self.assertTrue(
+            any("Median allele frequency" in msg for msg in ctx.output),
+            ctx.output,
+        )
 
 
 class AnalysisTests(unittest.TestCase):

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -507,3 +507,53 @@ class TestRescaleBaf:
         """Observed BAF=0.5 always rescales to 0.5 (balanced heterozygosity)."""
         result = rescale_baf(purity, pd.Series([0.5]))
         assert abs(result.iloc[0] - 0.5) < 1e-12
+
+    @given(
+        st.floats(
+            min_value=0.05, max_value=0.99, allow_nan=False, allow_infinity=False
+        ),
+        st.lists(
+            st.floats(
+                min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+            ),
+            min_size=1,
+            max_size=50,
+        ).map(pd.Series),
+    )
+    def test_output_clamped_to_unit_interval(self, purity, observed_baf):
+        """rescale_baf output is always in [0, 1] for any in-range inputs."""
+        result = rescale_baf(purity, observed_baf)
+        assert (result.values >= 0.0).all()
+        assert (result.values <= 1.0).all()
+
+    def test_low_purity_extreme_baf_clamped_to_zero(self):
+        """Regression for issue #601: low purity + observed BAF ~ 0 must
+        clamp to 0, not produce a negative value.
+        """
+        # purity=0.37 (from issue #601). Without clamping:
+        # tumor_baf = (0.0 - 0.5*0.63) / 0.37 = -0.851
+        result = rescale_baf(0.37, pd.Series([0.0]))
+        assert result.iloc[0] == 0.0
+
+    def test_low_purity_extreme_baf_clamped_to_one(self):
+        """Symmetric case: observed BAF ~ 1 must clamp to 1, not exceed it."""
+        # tumor_baf = (1.0 - 0.5*0.63) / 0.37 = 1.851
+        result = rescale_baf(0.37, pd.Series([1.0]))
+        assert result.iloc[0] == 1.0
+
+    def test_nan_preserved(self):
+        """NaN BAF (segments with no SNP coverage) passes through unchanged."""
+        result = rescale_baf(0.5, pd.Series([0.4, np.nan, 0.6]))
+        assert not np.isnan(result.iloc[0])
+        assert np.isnan(result.iloc[1])
+        assert not np.isnan(result.iloc[2])
+
+    def test_no_warning_at_float_noise_boundary(self, caplog):
+        """Values within float-arithmetic noise of 0 or 1 must not log a warning."""
+        # observed_baf at the exact lower boundary 0.5*(1-purity) gives tumor_baf=0
+        purity = 0.5
+        boundary_low = 0.5 * (1 - purity)
+        boundary_high = 0.5 + 0.5 * purity
+        with caplog.at_level("WARNING"):
+            rescale_baf(purity, pd.Series([boundary_low, 0.5, boundary_high]))
+        assert not any("clamped" in rec.message for rec in caplog.records)


### PR DESCRIPTION
Addresses #601 and #616 --

Ensure negative BAF values aren't produced, even from VCFs that break assumptions/expectations.

Update and clarify documentation around VCF handling.
