### PR TITLE
Support yeast/Roman-numeral chromosomes; consolidate chromosome-name handling (#889)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,18 @@ Pre-commit hooks run automatically on `git commit` (ruff, bandit, whitespace, YA
 - **`skgenome/`** - Genomic data handling library (part of CNVkit but decoupled)
   - `gary.py` - GenomicArray class for genomic interval data (wraps pandas DataFrame)
   - `tabio/` - File I/O for BED, GFF, VCF, SEG, Picard, CNVkit formats (.cnn/.cnr/.cns), bedGraph
+  - `chromnames.py` - Chromosome-name classification (autosome/sex/mito/alt-contig detection, arabic + Roman numerals, X/Y label inference)
+  - `genomebuild.py` - Reference assembly metadata (PAR coordinates) as `GenomeBuild` value objects, with `get_genome_build()` lookup
+  - `chromsort.py` - Chromosome-name sort keys
 
 GenomicArray uses `typing.Self` (PEP 673) so that methods like `.copy()`, `.concat()`, and `.as_dataframe()` preserve the subclass type through type checking.
+
+### Chromosome-name handling
+All chromosome-name classification goes through `skgenome.chromnames` -- do NOT add inline regexes or `.startswith("chr")` / `chromosome.iat[0]` heuristics. Key facts:
+- Genomes may use arabic (`chr1`) or Roman (`chrI`..`chrXVI`, e.g. yeast) numerals. `chrX` is a sex chromosome in human but autosome 10 in yeast, so sex-chromosome detection is *context-aware* (`infer_sex_chrom_labels` inspects the whole chromosome set, not one name).
+- `CopyNumArray.chr_x_label` / `chr_y_label` return `str | None`; `None` means no sex chromosome detected. Callers must handle `None` (the `chr_*_filter` methods return all-False in that case).
+- `GenomicArray.autosomes()` falls back to returning the whole array (with a warning) when no autosomes are recognized -- be permissive on unfamiliar assemblies rather than silently dropping data.
+- PAR coordinates live in `skgenome.genomebuild`; `cnvlib.params.PSEUDO_AUTSOMAL_REGIONS` is a back-compat re-export.
 
 ### File Formats
 - `.cnn` - Coverage/reference data

--- a/cnvlib/access.py
+++ b/cnvlib/access.py
@@ -11,6 +11,7 @@ from collections.abc import Generator, Iterable
 
 import numpy as np
 from skgenome import tabio, GenomicArray as GA
+from skgenome.chromnames import is_alternative_contig, is_mitochondrial
 from typing import TYPE_CHECKING
 
 
@@ -55,12 +56,15 @@ def drop_noncanonical_contigs(region_tups: Iterable[tuple]) -> Iterable[tuple]:
 
     `region_tups` is an iterable of (chrom, start, end) tuples.
 
-    Yield the same, but dropping noncanonical chrom.
+    Yield the same, but dropping alternative/unplaced contigs and
+    mitochondria. Roman-numeral chromosomes (e.g. yeast ``chrI``..``chrXVI``)
+    are kept.
     """
-    # Avoid a circular import
-    from .antitarget import is_canonical_contig_name
-
-    return (tup for tup in region_tups if is_canonical_contig_name(tup[0]))
+    return (
+        tup
+        for tup in region_tups
+        if not (is_alternative_contig(tup[0]) or is_mitochondrial(tup[0]))
+    )
 
 
 def get_regions(fasta_fname: str) -> Generator[tuple, None, None]:

--- a/cnvlib/antitarget.py
+++ b/cnvlib/antitarget.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import logging
-import re
 
 from skgenome import GenomicArray as GA
+from skgenome.chromnames import is_alternative_contig, is_mitochondrial
 
 from .params import INSERT_SIZE, MIN_REF_COVERAGE, ANTITARGET_NAME
+
+
+def _is_canonical_for_antitarget(name: str) -> bool:
+    """Identify chromosomes the antitarget step should consider canonical.
+
+    Excludes alternative/unplaced contigs and mitochondria. Roman-numeral
+    chromosomes (e.g. yeast) are treated as canonical.
+    """
+    return not (is_alternative_contig(name) or is_mitochondrial(name))
 
 
 def do_antitarget(
@@ -95,8 +104,10 @@ def drop_noncanonical_contigs(accessible: GA, targets: GA, verbose: bool = True)
     # Filter out untargeted alternative contigs and mitochondria
     untgt_chroms = access_chroms - target_chroms
     # Autosomes typically have numeric names, allosomes are X and Y
-    if any(is_canonical_contig_name(c) for c in target_chroms):
-        chroms_to_skip = [c for c in untgt_chroms if not is_canonical_contig_name(c)]
+    if any(_is_canonical_for_antitarget(c) for c in target_chroms):
+        chroms_to_skip = [
+            c for c in untgt_chroms if not _is_canonical_for_antitarget(c)
+        ]
     else:
         # Alternative contigs have longer names -- skip them
         max_tgt_chr_name_len = max(map(len, target_chroms))
@@ -143,32 +154,6 @@ def guess_chromosome_regions(targets: GA, telomere_size: int) -> GA:
         }
     )
     return whole_chroms
-
-
-# TODO - move to skgenome.chromsort
-
-# CNVkit's original inclusion regex
-re_canonical = re.compile(r"(chr)?(\d+|[XYxy])$")
-# goleft indexcov's exclusion regex
-re_noncanonical = re.compile(
-    "|".join(
-        (
-            r"^chrEBV$",
-            r"^NC|_random$",
-            r"Un_",
-            r"^HLA\-",
-            r"_alt$",
-            r"hap\d$",
-            r"chrM",
-            r"MT",
-        )
-    )
-)
-
-
-def is_canonical_contig_name(name: str) -> bool:
-    # return bool(re_canonical.match(name))
-    return not re_noncanonical.search(name)
 
 
 def _drop_short_contigs(garr: GA) -> GA:

--- a/cnvlib/cnary.py
+++ b/cnvlib/cnary.py
@@ -9,6 +9,8 @@ import pandas as pd
 from scipy.stats import median_test
 
 from skgenome import GenomicArray
+from skgenome.chromnames import infer_sex_chrom_labels
+from skgenome.genomebuild import get_genome_build
 from . import core, descriptives, params, smoothing
 from .segmetrics import segment_mean
 
@@ -47,24 +49,38 @@ class CopyNumArray(GenomicArray):
     def log2(self, value) -> None:
         self.data["log2"] = value
 
-    @property
-    def chr_x_label(self) -> str:
-        """The name of the X chromosome.
-
-        This is either "X" or "chrX".
-        """
-        key = "chr_x"
-        if key in self.meta:
-            return str(self.meta[key])
+    def _ensure_sex_chrom_labels(self) -> None:
+        """Populate ``meta['chr_x']`` and ``meta['chr_y']`` if not already set."""
+        if "chr_x" in self.meta and "chr_y" in self.meta:
+            return
         if len(self):
-            chr_x_label = "chrX" if self.chromosome.iat[0].startswith("chr") else "X"
-            self.meta[key] = chr_x_label
-            return chr_x_label
-        return ""
+            x, y = infer_sex_chrom_labels(self.chromosome.unique())
+        else:
+            x, y = None, None
+        self.meta.setdefault("chr_x", x)
+        self.meta.setdefault("chr_y", y)
+
+    @property
+    def chr_x_label(self) -> str | None:
+        """The name of the X chromosome in this dataset, if present.
+
+        Returns ``"chrX"`` or ``"X"`` if one of those is present in the data,
+        or ``None`` if no X chromosome is detected. For yeast and other
+        Roman-numeral genomes where ``chrX`` is autosome 10, returns ``None``.
+        """
+        self._ensure_sex_chrom_labels()
+        label = self.meta["chr_x"]
+        return label if label is None else str(label)
 
     def chr_x_filter(self, diploid_parx_genome: str | None = None) -> Series:
-        """All regions on X, potentially without PAR1/2."""
-        x = self.chromosome == self.chr_x_label
+        """All regions on X, potentially without PAR1/2.
+
+        Returns an all-False Series when no X chromosome is detected.
+        """
+        label = self.chr_x_label
+        if label is None:
+            return pd.Series(False, index=self.data.index)
+        x = self.chromosome == label
         if diploid_parx_genome is not None:
             # Exclude PAR since they are expected to be diploid (i.e. autosomal).
             x &= ~self.parx_filter(genome_build=diploid_parx_genome)
@@ -72,42 +88,51 @@ class CopyNumArray(GenomicArray):
 
     def parx_filter(self, genome_build: str) -> Series:
         """All PAR1/2 regions on X."""
-        genome_build = genome_build.lower()
-        assert genome_build in params.SUPPORTED_GENOMES_FOR_PAR_HANDLING
-        f = self.chromosome == self.chr_x_label
-        par1_start, par1_end = params.PSEUDO_AUTSOMAL_REGIONS[genome_build]["PAR1X"]
-        par2_start, par2_end = params.PSEUDO_AUTSOMAL_REGIONS[genome_build]["PAR2X"]
+        build = get_genome_build(genome_build)
+        label = self.chr_x_label
+        if label is None:
+            return pd.Series(False, index=self.data.index)
+        f = self.chromosome == label
+        par1_start, par1_end = build.par_regions["PAR1X"]
+        par2_start, par2_end = build.par_regions["PAR2X"]
         f &= ((self.start >= par1_start) & (self.end <= par1_end)) | (
             (self.start >= par2_start) & (self.end <= par2_end)
         )
         return f
 
     @property
-    def chr_y_label(self) -> str:
-        """The name of the Y chromosome."""
-        if "chr_y" in self.meta:
-            return str(self.meta["chr_y"])
-        if len(self):
-            chr_y = "chrY" if self.chr_x_label.startswith("chr") else "Y"
-            self.meta["chr_y"] = chr_y
-            return chr_y
-        return ""
+    def chr_y_label(self) -> str | None:
+        """The name of the Y chromosome in this dataset, if present.
+
+        Returns ``None`` when no Y chromosome is detected.
+        """
+        self._ensure_sex_chrom_labels()
+        label = self.meta["chr_y"]
+        return label if label is None else str(label)
 
     def pary_filter(self, genome_build: str) -> Series:
         """All PAR1/2 regions on Y."""
-        genome_build = genome_build.lower()
-        assert genome_build in params.SUPPORTED_GENOMES_FOR_PAR_HANDLING
-        f = self.chromosome == self.chr_y_label
-        par1_start, par1_end = params.PSEUDO_AUTSOMAL_REGIONS[genome_build]["PAR1Y"]
-        par2_start, par2_end = params.PSEUDO_AUTSOMAL_REGIONS[genome_build]["PAR2Y"]
+        build = get_genome_build(genome_build)
+        label = self.chr_y_label
+        if label is None:
+            return pd.Series(False, index=self.data.index)
+        f = self.chromosome == label
+        par1_start, par1_end = build.par_regions["PAR1Y"]
+        par2_start, par2_end = build.par_regions["PAR2Y"]
         f &= ((self.start >= par1_start) & (self.end <= par1_end)) | (
             (self.start >= par2_start) & (self.end <= par2_end)
         )
         return f
 
     def chr_y_filter(self, diploid_parx_genome: str | None = None) -> Series:
-        """All regions on Y, potentially without PAR1/2."""
-        y = self.chromosome == self.chr_y_label
+        """All regions on Y, potentially without PAR1/2.
+
+        Returns an all-False Series when no Y chromosome is detected.
+        """
+        label = self.chr_y_label
+        if label is None:
+            return pd.Series(False, index=self.data.index)
+        y = self.chromosome == label
         if diploid_parx_genome is not None:
             # Exclude PAR on Y since they cannot be covered (everything is mapped to X).
             y &= ~self.pary_filter(genome_build=diploid_parx_genome)
@@ -476,7 +501,8 @@ class CopyNumArray(GenomicArray):
         chrx = self[self.chr_x_filter(diploid_parx_genome)]
         if not len(chrx):
             logging.warning(
-                "No %s found in sample; is the input truncated?", self.chr_x_label
+                "No %s found in sample; is the input truncated?",
+                self.chr_x_label or "X chromosome",
             )
             return None, {}
 

--- a/cnvlib/export.py
+++ b/cnvlib/export.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 from skgenome import tabio
+from skgenome.chromnames import detect_chr_prefix
 
 from . import call
 from .cmdutil import read_cna
@@ -638,11 +639,8 @@ def theta_read_counts(
 def export_theta_snps(varr: VariantArray) -> Iterator[pd.DataFrame]:
     """Generate THetA's SNP per-allele read count "formatted.txt" files."""
     # Drop any chromosomes that are not integer or XY
-    varr = varr.autosomes(
-        also=(
-            ["chrX", "chrY"] if varr.chromosome.iat[0].startswith("chr") else ["X", "Y"]
-        )
-    )
+    prefix = detect_chr_prefix(varr.chromosome.unique())
+    varr = varr.autosomes(also=[f"{prefix}X", f"{prefix}Y"])
     # Skip indels
     varr = varr[(varr["ref"].str.len() == 1) & (varr["alt"].str.len() == 1)]
     # Drop rows with any NaN

--- a/cnvlib/params.py
+++ b/cnvlib/params.py
@@ -18,19 +18,15 @@ IGNORE_GENE_NAMES = ("-", ".", "CGH")
 ANTITARGET_NAME = "Antitarget"
 ANTITARGET_ALIASES = (ANTITARGET_NAME, "Background")
 
-# PAR1/2 start/end definitions
+# PAR coordinates and the list of supported genome builds are owned by
+# skgenome.genomebuild; re-exported here for back-compat with code that
+# imports them from cnvlib.params. Inner coordinate values are returned
+# as mutable lists (matching the historical type) so any caller that
+# treated them as such continues to work.
+from skgenome.genomebuild import REGISTERED_BUILDS as _REGISTERED_BUILDS  # noqa: E402
+
 PSEUDO_AUTSOMAL_REGIONS = {
-    "grch37": {
-        "PAR1X": [60000, 2699520],
-        "PAR2X": [154931043, 155260560],
-        "PAR1Y": [10000, 2649520],
-        "PAR2Y": [59034049, 59363566],
-    },
-    "grch38": {
-        "PAR1X": [10000, 2781479],
-        "PAR2X": [155701382, 156030895],
-        "PAR1Y": [10000, 2781479],
-        "PAR2Y": [56887902, 57217415],
-    },
+    name: {region: list(coords) for region, coords in b.par_regions.items()}
+    for name, b in _REGISTERED_BUILDS.items()
 }
 SUPPORTED_GENOMES_FOR_PAR_HANDLING = PSEUDO_AUTSOMAL_REGIONS.keys()

--- a/cnvlib/scatter.py
+++ b/cnvlib/scatter.py
@@ -6,6 +6,7 @@ import logging
 
 import numpy as np
 from matplotlib import pyplot
+from skgenome.chromnames import detect_chr_prefix, diagnose_missing_chromosome
 from skgenome.rangelabel import unpack_range
 
 from . import core, params, plots
@@ -22,6 +23,19 @@ HIGHLIGHT_COLOR = "gold"
 POINT_COLOR = "#606060"
 SEG_COLOR = "darkorange"
 TREND_COLOR = "#A0A0A0"
+
+
+def _sex_labels(arr) -> tuple[str | None, str | None]:
+    """Best-effort ``(x_label, y_label)`` from any genomic array.
+
+    Returns ``(None, None)`` for arrays without the labels (e.g. plain
+    ``GenomicArray`` or ``VariantArray``) so callers can pass the result
+    to ``choose_segment_color`` unconditionally.
+    """
+    return (
+        getattr(arr, "chr_x_label", None),
+        getattr(arr, "chr_y_label", None),
+    )
 
 
 def do_scatter(
@@ -189,9 +203,16 @@ def cnv_on_genome(
     axis.set_ylabel("Copy ratio (log2)")
     if not (y_min and y_max):
         if segments:
-            # Auto-scale y-axis according to segment mean-coverage values
-            # (Avoid spuriously low log2 values in HLA and chrY)
-            low_chroms = segments.chromosome.isin(("6", "chr6", "Y", "chrY"))
+            # Auto-scale y-axis according to segment mean-coverage values,
+            # excluding chrY (low ploidy) and chr6 (HLA region's noisy log2)
+            # to avoid pulling the scale to spuriously low values. For non-human
+            # data without sex chromosomes these exclusions become a no-op.
+            prefix = detect_chr_prefix(segments.chromosome.unique())
+            exclude_for_scaling = {f"{prefix}6"}
+            chr_y_for_scaling = segments.chr_y_label
+            if chr_y_for_scaling is not None:
+                exclude_for_scaling.add(chr_y_for_scaling)
+            low_chroms = segments.chromosome.isin(exclude_for_scaling)
             seg_auto_vals = segments[~low_chroms]["log2"].dropna()
             if not y_min:
                 y_min = (
@@ -228,6 +249,7 @@ def cnv_on_genome(
 
     # Plot points & segments
     x_starts = plots.plot_chromosome_dividers(axis, chrom_sizes)
+    sex_labels = _sex_labels(segments)
     for chrom, x_offset in x_starts.items():
         if probes and chrom in chrom_probes:
             subprobes = chrom_probes[chrom]
@@ -256,7 +278,9 @@ def cnv_on_genome(
 
         if chrom in chrom_segs:
             for seg in chrom_segs[chrom]:
-                color = choose_segment_color(seg, segment_color)
+                color = choose_segment_color(
+                    seg, segment_color, sex_chrom_labels=sex_labels
+                )
                 axis.plot(
                     (seg.start + x_offset, seg.end + x_offset),
                     (seg.log2, seg.log2),
@@ -284,6 +308,7 @@ def snv_on_genome(axis, variants, chrom_sizes, segments, do_trend, segment_color
     else:
         chrom_segs = {}
 
+    sex_labels = _sex_labels(segments)
     for chrom, x_offset in x_starts.items():
         if chrom not in chrom_snvs:
             continue
@@ -306,7 +331,10 @@ def snv_on_genome(axis, variants, chrom_sizes, segments, do_trend, segment_color
                 if seg:
                     posn = [seg.start + x_offset, seg.end + x_offset]
                     color = choose_segment_color(
-                        seg, segment_color, default_bright=False
+                        seg,
+                        segment_color,
+                        default_bright=False,
+                        sex_chrom_labels=sex_labels,
                     )
                 else:
                     posn = [snvs.start.iat[0] + x_offset, snvs.start.iat[-1] + x_offset]
@@ -510,6 +538,14 @@ def select_range_genes(cnarr, segments, variants, show_range, show_gene, window_
         len(gene_ranges),
         (chrom + ":{}-{}".format(*window_coords) if window_coords else chrom),
     )
+    if cnarr and len(sel_probes) == 0:
+        # Help the user diagnose why the selection has no probes
+        # (e.g. yeast Roman-numeral names not present in the .cnr file,
+        # a "chr" prefix mismatch, or a window outside any probe).
+        logging.warning(
+            "%s",
+            diagnose_missing_chromosome(chrom, cnarr.chromosome.unique()),
+        )
 
     return sel_probes, sel_segs, sel_snvs, window_coords, gene_ranges, chrom
 
@@ -593,8 +629,11 @@ def cnv_on_chromosome(
 
     # Draw segments as horizontal lines
     if segments:
+        sex_labels = _sex_labels(segments)
         for row in segments:
-            color = choose_segment_color(row, segment_color)
+            color = choose_segment_color(
+                row, segment_color, sex_chrom_labels=sex_labels
+            )
             axis.plot(
                 (row.start * MB, row.end * MB),
                 (row.log2, row.log2),
@@ -649,10 +688,16 @@ def snv_on_chromosome(axis, variants, segments, genes, do_trend, by_bin, segment
     axis.scatter(x_mb, y, color=POINT_COLOR, alpha=0.3)
     if segments or do_trend:
         # Draw average VAF within each segment
+        sex_labels = _sex_labels(segments) if segments else (None, None)
         for seg, v_freq in get_segment_vafs(variants, segments):
             if seg:
                 posn = [seg.start * MB, seg.end * MB]
-                color = choose_segment_color(seg, segment_color, default_bright=False)
+                color = choose_segment_color(
+                    seg,
+                    segment_color,
+                    default_bright=False,
+                    sex_chrom_labels=sex_labels,
+                )
             else:
                 posn = [variants.start.iat[0] * MB, variants.start.iat[-1] * MB]
                 color = TREND_COLOR
@@ -721,7 +766,12 @@ def setup_chromosome(axis, y_min=None, y_max=None, y_label=None) -> None:
 # === Shared ===
 
 
-def choose_segment_color(segment, highlight_color, default_bright=True):
+def choose_segment_color(
+    segment,
+    highlight_color,
+    default_bright=True,
+    sex_chrom_labels: tuple[str | None, str | None] = (None, None),
+):
     """Choose a display color based on a segment's CNA status.
 
     Uses the fields added by the 'call' command. If these aren't present, use
@@ -729,18 +779,32 @@ def choose_segment_color(segment, highlight_color, default_bright=True):
 
     For sex chromosomes, some single-copy deletions or gains might not be
     highlighted, since sample sex isn't used to infer the neutral ploidies.
+
+    *sex_chrom_labels* is ``(x_label, y_label)`` for the genome being plotted;
+    either may be None when the genome has no detected sex chromosome (e.g.
+    yeast). When both are None, every chromosome is treated as autosomal
+    (ploidy 2 expected). The labels must use the same naming convention as
+    ``segment.chromosome`` (both ``"chrX"`` or both ``"X"``) so the dict
+    lookup matches; in CNVkit's own pipeline this is guaranteed because the
+    labels are derived from the array via ``infer_sex_chrom_labels``.
     """
     neutral_color = TREND_COLOR
     if "cn" not in segment._fields:
         # No 'call' info
         return highlight_color if default_bright else neutral_color
 
+    x_label, y_label = sex_chrom_labels
+    expected_ploidies: dict[str, tuple[int, int]] = {}
+    if x_label is not None:
+        expected_ploidies[x_label] = (1, 2)
+    if y_label is not None:
+        expected_ploidies[y_label] = (0, 1)
+
     # Detect copy number alteration
-    expected_ploidies = {"chrY": (0, 1), "Y": (0, 1), "chrX": (1, 2), "X": (1, 2)}
-    if segment.cn not in expected_ploidies.get(segment.chromosome, [2]):
+    if segment.cn not in expected_ploidies.get(segment.chromosome, (2,)):
         return highlight_color
 
-    # Detect regions of allelic imbalance / LOH
+    # Detect regions of allelic imbalance / LOH on autosomes
     if (
         segment.chromosome not in expected_ploidies
         and "cn1" in segment._fields

--- a/doc/sex.rst
+++ b/doc/sex.rst
@@ -78,6 +78,27 @@ appropriately.
 :ref:`scatter` and :ref:`heatmap` do not adjust the sex chromosomes for sample
 or reference sex.
 
+Non-human and Roman-numeral genomes
+-----------------------------------
+
+CNVkit recognizes chromosomes named with arabic numerals (``1`` / ``chr1``)
+and Roman numerals (``chrI`` / ``XVI``). This means yeast (*S. cerevisiae*)
+and other organisms that use Roman-numeral chromosome names are supported
+out of the box.
+
+For genomes where no recognizable autosome naming convention is detected
+(e.g. an in-progress assembly with scaffold-style names), the
+``autosomes()`` selection falls back permissively to returning the entire
+dataset and logs a warning. This is intentional: it is better to plot
+everything (and trust the user) than to silently discard data.
+
+Sex-chromosome handling is *only* activated when both an ``X``/``chrX`` and
+a ``Y``/``chrY`` (or just an ``X``/``chrX`` in a clearly arabic-numeral
+genome) are detected in the data. In yeast — where ``chrX`` is the 10th
+chromosome by Roman numeral rather than a sex chromosome —
+sex-chromosome inference is automatically disabled and ``cnvkit.py sex``
+will report no result.
+
 FAQ
 ---
 

--- a/doc/skgenome.rst
+++ b/doc/skgenome.rst
@@ -87,10 +87,26 @@ Genomic interval arithmetic
 Helper modules
 --------------
 
+``chromnames``
+~~~~~~~~~~~~~~
+
+.. automodule:: skgenome.chromnames
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ``chromsort``
 ~~~~~~~~~~~~~
 
 .. automodule:: skgenome.chromsort
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+``genomebuild``
+~~~~~~~~~~~~~~~
+
+.. automodule:: skgenome.genomebuild
     :members:
     :undoc-members:
     :show-inheritance:

--- a/skgenome/__init__.py
+++ b/skgenome/__init__.py
@@ -1,2 +1,4 @@
+from . import chromnames as chromnames
+from . import genomebuild as genomebuild
 from . import tabio as tabio
 from .gary import GenomicArray as GenomicArray

--- a/skgenome/chromnames.py
+++ b/skgenome/chromnames.py
@@ -1,0 +1,215 @@
+"""Chromosome name classification and inference.
+
+This module centralizes the heuristics CNVkit uses to interpret chromosome
+names across reference assemblies: detecting autosomes vs. sex chromosomes
+vs. mitochondria vs. alternative contigs, recognizing the "chr" prefix
+convention, and inferring which label a dataset uses for the X and Y
+chromosomes.
+
+Design notes
+------------
+
+These functions split into two groups:
+
+* Pure single-string predicates (``is_arabic_numeral_chrom``,
+  ``is_roman_numeral_chrom``, ``is_mitochondrial``,
+  ``is_alternative_contig``) classify a name in isolation.
+* Context-aware classifiers (``looks_like_roman_numeral_genome``,
+  ``infer_sex_chrom_labels``, ``is_autosome``) consider the full set of
+  chromosome names in a dataset, which is necessary to disambiguate cases
+  like ``chrX`` (a sex chromosome in mammals, but Roman numeral 10 in
+  yeast).
+
+When a dataset's chromosome names look unfamiliar, the public callers
+fall back to a permissive interpretation rather than silently discarding
+data. See ``GenomicArray.autosomes`` for an example of that policy.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+_ARABIC_NUMERAL = re.compile(r"^(?:chr|Chr)?\d{1,3}$")
+
+_ALTERNATIVE_CONTIG = re.compile(
+    "|".join(
+        (
+            r"^chrEBV$",
+            r"^NC[_\-]",
+            r"_random$",
+            r"Un_",
+            r"^HLA[\-_]",
+            r"_alt$",
+            r"hap\d+$",
+            r"_decoy$",
+        )
+    )
+)
+
+_MITOCHONDRIAL = re.compile(r"^(?:chr|Chr)?(?:M|MT|Mito)$", re.IGNORECASE)
+
+
+def _to_roman(n: int) -> str:
+    vals = [
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ]
+    out: list[str] = []
+    for v, sym in vals:
+        while n >= v:
+            out.append(sym)
+            n -= v
+    return "".join(out)
+
+
+# 1..49 covers every known Roman-numeral chromosome assembly (yeast has 16,
+# fission yeast 8, other fungi up to ~30). Using a frozenset built from valid
+# Roman numerals rejects invalid forms like "IIII" or "VV" without a regex.
+_VALID_ROMAN_NUMERALS = frozenset(_to_roman(i) for i in range(1, 50))
+
+
+def _strip_chr_prefix(name: str) -> str:
+    """Return *name* with a leading 'chr' or 'Chr' removed, if present."""
+    return name.removeprefix("chr").removeprefix("Chr")
+
+
+def is_arabic_numeral_chrom(name: str) -> bool:
+    """Match plain integer chromosome names like ``1`` or ``chr22``."""
+    return bool(_ARABIC_NUMERAL.match(name))
+
+
+def is_roman_numeral_chrom(name: str) -> bool:
+    """Match Roman-numeral chromosome names like ``chrI`` or ``XVI``.
+
+    Only valid Roman numerals up to L (50) are accepted; invalid forms
+    such as ``IIII`` or ``VV`` return False.
+    """
+    stripped = _strip_chr_prefix(name)
+    return stripped in _VALID_ROMAN_NUMERALS
+
+
+def is_mitochondrial(name: str) -> bool:
+    """Match mitochondrial chromosome names: ``M``, ``MT``, ``Mito``, etc."""
+    return bool(_MITOCHONDRIAL.match(name))
+
+
+def is_alternative_contig(name: str) -> bool:
+    """Match alternative or unplaced contigs: ``_random``, ``Un_``, ``HLA-``, etc."""
+    return bool(_ALTERNATIVE_CONTIG.search(name))
+
+
+def looks_like_roman_numeral_genome(names: Iterable[str]) -> bool:
+    """Heuristic: does this chromosome set use Roman-numeral autosomes?
+
+    A human dataset with just ``chrX`` and ``chrI`` (a typo or odd subset)
+    is not enough evidence — we require at least three valid Roman-numeral
+    names AND at least one unambiguous name (more than one Roman character)
+    to avoid false positives from single-letter names ``I``/``V``/``X`` that
+    can coincide with normal human chromosomes.
+    """
+    roman_names = [n for n in names if is_roman_numeral_chrom(n)]
+    if len(roman_names) < 3:
+        return False
+    return any(len(_strip_chr_prefix(n)) > 1 for n in roman_names)
+
+
+def infer_sex_chrom_labels(
+    names: Iterable[str],
+) -> tuple[str | None, str | None]:
+    """Detect the X and Y chromosome labels used in a chromosome set.
+
+    Returns a ``(x_label, y_label)`` pair, each of which may be None.
+
+    Returns ``(None, None)`` when the chromosome set looks like a Roman-numeral
+    genome (e.g. yeast), where ``chrX`` is autosome 10 rather than a sex
+    chromosome.
+    """
+    name_set = {str(n) for n in names}
+    if not name_set:
+        return None, None
+    if looks_like_roman_numeral_genome(name_set):
+        return None, None
+    x_label = next((c for c in ("chrX", "X") if c in name_set), None)
+    y_label = next((c for c in ("chrY", "Y") if c in name_set), None)
+    return x_label, y_label
+
+
+def detect_chr_prefix(names: Iterable[str]) -> str:
+    """Return ``"chr"`` if most chromosome names use that prefix, else ``""``.
+
+    Inspects up to the first 32 names to keep this cheap on large sets.
+    """
+    sample = []
+    for i, name in enumerate(names):
+        if i >= 32:
+            break
+        sample.append(name)
+    if not sample:
+        return ""
+    n_prefixed = sum(1 for n in sample if n.startswith("chr"))
+    return "chr" if n_prefixed * 2 > len(sample) else ""
+
+
+def is_autosome(
+    name: str,
+    sex_x_label: str | None = None,
+    sex_y_label: str | None = None,
+) -> bool:
+    """Test whether *name* is a standard autosome.
+
+    Accepts arabic-numeral names (``1``, ``chr1``) and Roman-numeral names
+    (``chrI``, ``XVI``). When *sex_x_label* or *sex_y_label* is supplied,
+    those names are excluded so that e.g. ``chrX`` is recognized as a sex
+    chromosome rather than Roman numeral 10.
+    """
+    if not name:
+        return False
+    if sex_x_label is not None and name == sex_x_label:
+        return False
+    if sex_y_label is not None and name == sex_y_label:
+        return False
+    return is_arabic_numeral_chrom(name) or is_roman_numeral_chrom(name)
+
+
+def diagnose_missing_chromosome(
+    requested: str,
+    available: Iterable[str],
+) -> str:
+    """Build a user-facing message for "0 probes" / "chromosome absent" cases.
+
+    Suggests a ``chr``/no-``chr`` prefix variant if one would match, and
+    summarizes which chromosomes are present.
+    """
+    available_sorted = sorted({str(c) for c in available})
+    if not available_sorted:
+        return f"The data contains no rows; cannot show region {requested!r}."
+    sample = ", ".join(repr(c) for c in available_sorted[:8])
+    if len(available_sorted) > 8:
+        sample += f", ... (+{len(available_sorted) - 8} more)"
+    if requested in available_sorted:
+        return (
+            f"Region {requested!r} matched 0 rows; "
+            f"check whether log2 values were dropped as NaN."
+        )
+    alt = (
+        requested.removeprefix("chr")
+        if requested.startswith("chr")
+        else "chr" + requested
+    )
+    suggestion = f" Did you mean {alt!r}?" if alt in available_sorted else ""
+    return (
+        f"Chromosome {requested!r} is not present in the data. "
+        f"Available chromosomes: {sample}.{suggestion}"
+    )

--- a/skgenome/gary.py
+++ b/skgenome/gary.py
@@ -10,6 +10,12 @@ import bioframe
 import numpy as np
 import pandas as pd
 
+from .chromnames import (
+    infer_sex_chrom_labels,
+    is_alternative_contig,
+    is_autosome,
+    is_mitochondrial,
+)
 from .chromsort import sorter_chrom
 from .cut import cut
 from .intersect import by_ranges, into_ranges, iter_ranges, iter_slices, Numeric
@@ -259,10 +265,32 @@ class GenomicArray:
     # Traversal
 
     def autosomes(self, also: str | list[str] | pd.Series | None = None) -> Self:
-        """Select chromosomes w/ integer names, ignoring any 'chr' prefixes."""
-        is_auto = self.chromosome.str.match(r"(chr)?\d+$", na=False)
+        """Select autosomal rows, excluding sex chromosomes and alternative contigs.
+
+        Accepts both arabic-numeral chromosome names (e.g. ``chr1``) and
+        Roman-numeral names (e.g. ``chrI``, ``chrXVI``). Sex chromosomes are
+        inferred from the chromosome set and excluded, so ``chrX`` is treated
+        as a sex chromosome in human data and as autosome 10 in yeast data.
+
+        Mitochondrial and alternative/unplaced contigs are always excluded.
+
+        If no autosomes can be recognized (e.g. an unfamiliar custom assembly),
+        emits a warning and returns the whole array unchanged.
+        """
+        unique = self.chromosome.unique()
+        sex_x, sex_y = infer_sex_chrom_labels(unique)
+        is_auto = self.chromosome.map(
+            lambda n: is_autosome(n, sex_x, sex_y)
+            and not is_mitochondrial(n)
+            and not is_alternative_contig(n)
+        )
         if not is_auto.any():
-            # The autosomes, if any, are not named with plain integers
+            logging.warning(
+                "GenomicArray.autosomes(): no autosomes recognized in %d "
+                "chromosomes (sample: %s); returning the array unchanged.",
+                len(unique),
+                sorted(map(str, unique))[:8],
+            )
             return self
         if also is not None:
             if isinstance(also, pd.Series):

--- a/skgenome/genomebuild.py
+++ b/skgenome/genomebuild.py
@@ -1,0 +1,87 @@
+"""Reference assembly metadata used for sex-chromosome / PAR handling.
+
+The ``GenomeBuild`` value object collects the build-specific data CNVkit needs
+to interpret a sample's chromosomes correctly: today, that's the
+pseudoautosomal-region (PAR) coordinates on chrX and chrY. Adding a new
+supported assembly is a single ``GenomeBuild(...)`` instance in this module.
+
+For callers that already pass a genome name as a string (e.g.
+``diploid_parx_genome="grch38"``), :func:`get_genome_build` performs the
+lookup and produces a clear ``KeyError`` for unknown names.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+@dataclass(frozen=True)
+class GenomeBuild:
+    """Immutable description of a reference assembly's PAR coordinates.
+
+    ``par_regions`` is keyed by ``"PAR1X"``, ``"PAR2X"``, ``"PAR1Y"``,
+    ``"PAR2Y"`` and gives the half-open coordinate range as a tuple. The
+    backing mapping is wrapped in ``MappingProxyType`` on construction so
+    that the module-level singletons (``GRCH37``, ``GRCH38``) cannot be
+    mutated in place by callers.
+    """
+
+    name: str
+    par_regions: Mapping[str, tuple[int, int]]
+
+    def __post_init__(self) -> None:
+        # Defend the singleton against in-place mutation of the backing dict.
+        object.__setattr__(
+            self, "par_regions", MappingProxyType(dict(self.par_regions))
+        )
+
+
+GRCH37 = GenomeBuild(
+    name="grch37",
+    par_regions={
+        "PAR1X": (60000, 2699520),
+        "PAR2X": (154931043, 155260560),
+        "PAR1Y": (10000, 2649520),
+        "PAR2Y": (59034049, 59363566),
+    },
+)
+
+GRCH38 = GenomeBuild(
+    name="grch38",
+    par_regions={
+        "PAR1X": (10000, 2781479),
+        "PAR2X": (155701382, 156030895),
+        "PAR1Y": (10000, 2781479),
+        "PAR2Y": (56887902, 57217415),
+    },
+)
+
+
+REGISTERED_BUILDS: dict[str, GenomeBuild] = {
+    b.name: b for b in (GRCH37, GRCH38)
+}
+
+
+def get_genome_build(name: str) -> GenomeBuild:
+    """Look up a registered genome build by name (case-insensitive).
+
+    Raises ``KeyError`` with a list of supported names if *name* is unknown.
+    """
+    key = name.lower()
+    try:
+        return REGISTERED_BUILDS[key]
+    except KeyError:
+        raise KeyError(
+            f"Unknown genome build {name!r}; "
+            f"supported: {sorted(REGISTERED_BUILDS)}"
+        ) from None
+
+
+def is_supported_build(name: str) -> bool:
+    """Return True if *name* is a registered genome build."""
+    return name.lower() in REGISTERED_BUILDS

--- a/test/test_chromnames.py
+++ b/test/test_chromnames.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+"""Unit tests for skgenome.chromnames."""
+
+import unittest
+
+from skgenome.chromnames import (
+    detect_chr_prefix,
+    diagnose_missing_chromosome,
+    infer_sex_chrom_labels,
+    is_alternative_contig,
+    is_arabic_numeral_chrom,
+    is_autosome,
+    is_mitochondrial,
+    is_roman_numeral_chrom,
+    looks_like_roman_numeral_genome,
+)
+
+
+class IsArabicNumeralChromTests(unittest.TestCase):
+    def test_plain_integers(self):
+        for name in ("1", "2", "10", "22"):
+            self.assertTrue(is_arabic_numeral_chrom(name), name)
+
+    def test_chr_prefix(self):
+        for name in ("chr1", "chr22", "Chr3"):
+            self.assertTrue(is_arabic_numeral_chrom(name), name)
+
+    def test_sex_and_mito(self):
+        for name in ("X", "chrX", "Y", "chrY", "M", "MT", "chrM"):
+            self.assertFalse(is_arabic_numeral_chrom(name), name)
+
+    def test_alt_contigs(self):
+        for name in ("chr1_random", "Un_gl000220", "HLA-A"):
+            self.assertFalse(is_arabic_numeral_chrom(name), name)
+
+
+class IsRomanNumeralChromTests(unittest.TestCase):
+    def test_valid_low(self):
+        for name in ("I", "II", "III", "IV", "V", "VI", "IX", "X"):
+            self.assertTrue(is_roman_numeral_chrom(name), name)
+
+    def test_valid_yeast(self):
+        for name in ("chrI", "chrII", "chrVIII", "chrIX", "chrXI", "chrXVI"):
+            self.assertTrue(is_roman_numeral_chrom(name), name)
+
+    def test_invalid_forms(self):
+        for name in ("IIII", "VV", "IC", "XM", "VX"):
+            self.assertFalse(is_roman_numeral_chrom(name), name)
+
+    def test_not_roman(self):
+        for name in ("1", "chr1", "Y", "chrY", "MT", "M", ""):
+            self.assertFalse(is_roman_numeral_chrom(name), name)
+
+
+class IsMitochondrialTests(unittest.TestCase):
+    def test_matches(self):
+        for name in ("M", "MT", "Mito", "chrM", "chrMT", "ChrMito"):
+            self.assertTrue(is_mitochondrial(name), name)
+
+    def test_does_not_match(self):
+        for name in ("chrMito_random", "chr1", "X", "MTB", "MTOR"):
+            self.assertFalse(is_mitochondrial(name), name)
+
+
+class IsAlternativeContigTests(unittest.TestCase):
+    def test_matches(self):
+        for name in (
+            "chr1_random",
+            "chrUn_gl000220",
+            "HLA-A",
+            "HLA_DRB1",
+            "chr6_alt",
+            "chr19_hap1",
+            "chr6_hap5",
+            "chrEBV",
+            "NC_007605",
+            "NC-foo",
+            "hs37d5_decoy",
+        ):
+            self.assertTrue(is_alternative_contig(name), name)
+
+    def test_does_not_match(self):
+        for name in ("chr1", "chrX", "chrM", "chrI", "chrXVI", "1", "X", "Y", "MT"):
+            self.assertFalse(is_alternative_contig(name), name)
+
+
+class LooksLikeRomanNumeralGenomeTests(unittest.TestCase):
+    def test_yeast(self):
+        yeast = [f"chr{r}" for r in ("I", "II", "III", "IV", "V", "VIII", "XVI")]
+        self.assertTrue(looks_like_roman_numeral_genome(yeast))
+
+    def test_human(self):
+        human = [f"chr{i}" for i in range(1, 23)] + ["chrX", "chrY", "chrM"]
+        self.assertFalse(looks_like_roman_numeral_genome(human))
+
+    def test_too_few_roman_names(self):
+        # Just chrX in a human dataset is not enough to declare Roman-numeral
+        self.assertFalse(looks_like_roman_numeral_genome(["chr1", "chr2", "chrX"]))
+
+    def test_only_ambiguous_single_chars(self):
+        # I, V, X alone aren't enough to be sure
+        self.assertFalse(looks_like_roman_numeral_genome(["chrI", "chrV", "chrX"]))
+
+
+class InferSexChromLabelsTests(unittest.TestCase):
+    def test_human_chr_prefix(self):
+        x, y = infer_sex_chrom_labels(["chr1", "chr2", "chrX", "chrY"])
+        self.assertEqual((x, y), ("chrX", "chrY"))
+
+    def test_human_no_prefix(self):
+        x, y = infer_sex_chrom_labels(["1", "2", "X", "Y"])
+        self.assertEqual((x, y), ("X", "Y"))
+
+    def test_yeast_returns_none(self):
+        yeast = [f"chr{r}" for r in ("I", "II", "VIII", "X", "XI", "XVI", "M")]
+        self.assertEqual(infer_sex_chrom_labels(yeast), (None, None))
+
+    def test_missing_chromosomes(self):
+        # X present, Y absent
+        x, y = infer_sex_chrom_labels(["chr1", "chrX"])
+        self.assertEqual((x, y), ("chrX", None))
+
+    def test_empty(self):
+        self.assertEqual(infer_sex_chrom_labels([]), (None, None))
+
+
+class DetectChrPrefixTests(unittest.TestCase):
+    def test_chr_prefix(self):
+        self.assertEqual(detect_chr_prefix(["chr1", "chr2", "chrX"]), "chr")
+
+    def test_no_prefix(self):
+        self.assertEqual(detect_chr_prefix(["1", "2", "X"]), "")
+
+    def test_mixed_majority_prefixed(self):
+        self.assertEqual(detect_chr_prefix(["chr1", "chr2", "MT"]), "chr")
+
+    def test_empty(self):
+        self.assertEqual(detect_chr_prefix([]), "")
+
+
+class IsAutosomeTests(unittest.TestCase):
+    def test_arabic_autosome(self):
+        self.assertTrue(is_autosome("chr1", "chrX", "chrY"))
+        self.assertTrue(is_autosome("22"))
+
+    def test_sex_excluded(self):
+        self.assertFalse(is_autosome("chrX", sex_x_label="chrX", sex_y_label="chrY"))
+        self.assertFalse(is_autosome("chrY", sex_x_label="chrX", sex_y_label="chrY"))
+
+    def test_yeast_chr_x_is_autosome(self):
+        # In yeast, chrX is autosome 10 -- and infer_sex_chrom_labels returns None
+        self.assertTrue(is_autosome("chrX", sex_x_label=None, sex_y_label=None))
+        self.assertTrue(is_autosome("chrXVI"))
+
+    def test_mito_is_not_autosome(self):
+        # Mito doesn't match either regex (arabic or roman)
+        self.assertFalse(is_autosome("chrM"))
+
+    def test_empty(self):
+        self.assertFalse(is_autosome(""))
+
+
+class DiagnoseMissingChromosomeTests(unittest.TestCase):
+    def test_suggests_chr_prefix(self):
+        msg = diagnose_missing_chromosome("8", ["chr1", "chr2", "chr8", "chrX"])
+        self.assertIn("'chr8'", msg)
+        self.assertIn("Did you mean", msg)
+
+    def test_suggests_strip_prefix(self):
+        msg = diagnose_missing_chromosome("chr8", ["1", "2", "8", "X"])
+        self.assertIn("Did you mean '8'", msg)
+
+    def test_present_but_empty(self):
+        msg = diagnose_missing_chromosome("chr8", ["chr1", "chr8"])
+        self.assertIn("matched 0 rows", msg)
+        self.assertIn("NaN", msg)
+
+    def test_no_chromosomes(self):
+        msg = diagnose_missing_chromosome("chr1", [])
+        self.assertIn("no rows", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -179,6 +179,32 @@ class CNATests(unittest.TestCase):
             "PAR1/2 is included upon request.",
         )
 
+    def test_yeast_chromosomes(self):
+        """Roman-numeral (yeast) chromosomes are handled correctly.
+
+        Regression test for GitHub issue #889.
+        """
+        log2_value = 0.0
+        rows = [
+            (f"chr{r}", 100, 200, "gene", log2_value)
+            for r in ("I", "II", "VIII", "IX", "X", "XI", "XVI")
+        ] + [("chrM", 100, 200, "gene", log2_value)]
+        yeast = cnary.CopyNumArray.from_rows(rows)
+        # No sex chromosomes detected -- chrX is autosome 10 in yeast.
+        self.assertIsNone(yeast.chr_x_label)
+        self.assertIsNone(yeast.chr_y_label)
+        # Sex-chromosome filters return all-False, not exceptions.
+        self.assertFalse(yeast.chr_x_filter().any())
+        self.assertFalse(yeast.chr_y_filter().any())
+        # autosomes() includes all 7 Roman-numeral chromosomes (incl. chrX)
+        # but excludes chrM.
+        auto = yeast.autosomes()
+        self.assertEqual(len(auto), 7)
+        self.assertNotIn("chrM", set(auto.chromosome))
+        self.assertIn("chrX", set(auto.chromosome))
+        # guess_xx returns None when there's no X/Y to compare.
+        self.assertIsNone(yeast.guess_xx(verbose=False))
+
     def test_basic(self):
         """Test basic container functionality and magic methods."""
         cna = cnvlib.read("formats/reference-tr.cnn")

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -66,6 +66,29 @@ class GaryTests(unittest.TestCase):
             "It's possible to provide a Pandas filter.",
         )
 
+    def test_autosomes_yeast(self):
+        """Roman-numeral chromosomes (yeast) are recognized as autosomes."""
+        rows = [
+            (f"chr{r}", 0, 1000)
+            for r in ("I", "II", "VIII", "IX", "X", "XI", "XVI")
+        ] + [("chrM", 0, 1000)]
+        yeast = GA.from_rows(rows)
+        auto = yeast.autosomes()
+        # All seven Roman-numeral chromosomes are autosomes; chrM is excluded.
+        self.assertEqual(len(auto), 7)
+        self.assertNotIn("chrM", set(auto.chromosome))
+        # chrX is autosome 10 in yeast, not a sex chromosome.
+        self.assertIn("chrX", set(auto.chromosome))
+
+    def test_autosomes_unrecognized_genome(self):
+        """An unfamiliar chromosome set falls back permissively with a warning."""
+        rows = [("custom_a", 0, 100), ("custom_b", 0, 100), ("scaffold_1", 0, 100)]
+        ga = GA.from_rows(rows)
+        with self.assertLogs(level="WARNING") as cm:
+            auto = ga.autosomes()
+        self.assertEqual(len(auto), len(ga))
+        self.assertTrue(any("no autosomes recognized" in m for m in cm.output))
+
     def test_by_chromosome(self):
         for fname in ("formats/amplicon.cnr", "formats/cl_seq.cns"):
             cnarr = read_ga(fname)

--- a/test/test_genomebuild.py
+++ b/test/test_genomebuild.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""Unit tests for skgenome.genomebuild."""
+
+import unittest
+from dataclasses import FrozenInstanceError
+
+from skgenome.genomebuild import (
+    GRCH37,
+    GRCH38,
+    REGISTERED_BUILDS,
+    GenomeBuild,
+    get_genome_build,
+    is_supported_build,
+)
+
+
+class GenomeBuildTests(unittest.TestCase):
+    def test_registered_builds_present(self):
+        self.assertIn("grch37", REGISTERED_BUILDS)
+        self.assertIn("grch38", REGISTERED_BUILDS)
+
+    def test_par_regions_complete(self):
+        for build in (GRCH37, GRCH38):
+            for key in ("PAR1X", "PAR2X", "PAR1Y", "PAR2Y"):
+                self.assertIn(key, build.par_regions, f"{build.name} missing {key}")
+                start, end = build.par_regions[key]
+                self.assertLess(start, end, f"{build.name}/{key} bad coords")
+
+    def test_get_genome_build_case_insensitive(self):
+        self.assertIs(get_genome_build("GRCh38"), GRCH38)
+        self.assertIs(get_genome_build("grch38"), GRCH38)
+        self.assertIs(get_genome_build("GRCH38"), GRCH38)
+
+    def test_get_genome_build_unknown_raises(self):
+        with self.assertRaises(KeyError) as cm:
+            get_genome_build("hg18")
+        # Error message lists supported names so the user can self-correct.
+        self.assertIn("supported", str(cm.exception))
+
+    def test_is_supported_build(self):
+        self.assertTrue(is_supported_build("grch37"))
+        self.assertTrue(is_supported_build("GRCh38"))
+        self.assertFalse(is_supported_build("hg18"))
+
+    def test_frozen(self):
+        with self.assertRaises(FrozenInstanceError):
+            GRCH37.name = "other"  # type: ignore[misc]
+
+    def test_par_regions_singleton_protected_from_mutation(self):
+        """In-place mutation of GenomeBuild.par_regions must be rejected."""
+        with self.assertRaises(TypeError):
+            GRCH38.par_regions["PAR1X"] = (0, 0)  # type: ignore[index]
+
+    def test_back_compat_via_params(self):
+        """cnvlib.params.PSEUDO_AUTSOMAL_REGIONS preserves the historical API."""
+        from cnvlib import params
+
+        # Every registered build appears as a top-level key
+        self.assertEqual(
+            set(params.PSEUDO_AUTSOMAL_REGIONS), set(REGISTERED_BUILDS)
+        )
+        # All four PAR keys round-trip equally for every build
+        for build in (GRCH37, GRCH38):
+            for key in ("PAR1X", "PAR2X", "PAR1Y", "PAR2Y"):
+                self.assertEqual(
+                    list(build.par_regions[key]),
+                    params.PSEUDO_AUTSOMAL_REGIONS[build.name][key],
+                )
+        # Re-exported inner values are mutable lists, not tuples or proxies
+        # (so callers that mutated the legacy list-of-ints keep working).
+        coords = params.PSEUDO_AUTSOMAL_REGIONS["grch38"]["PAR1X"]
+        self.assertIsInstance(coords, list)
+        # And the supported-genomes view stays consistent
+        self.assertEqual(
+            set(params.SUPPORTED_GENOMES_FOR_PAR_HANDLING),
+            set(params.PSEUDO_AUTSOMAL_REGIONS),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #889, where scatter plots of a *S. cerevisiae* (yeast) genome showed "0 probes" for every chromosome. The root cause was bespoke chromosome-name filtering that recognized human-style names but silently dropped the canonical Roman-numeral names (`chrI`..`chrXVI`) used by yeast. Taking the opportunity flagged in the issue, this PR also consolidates the chromosome-name reasoning that was scattered across `cnvlib` and `skgenome` into a single tested module.

### What changed

- **New `skgenome/chromnames.py`** — one home for chromosome-name classification: pure predicates (`is_arabic_numeral_chrom`, `is_roman_numeral_chrom`, `is_mitochondrial`, `is_alternative_contig`, `is_autosome`) and context-aware classifiers (`looks_like_roman_numeral_genome`, `infer_sex_chrom_labels`, `detect_chr_prefix`), plus a `diagnose_missing_chromosome` helper.
- **New `skgenome/genomebuild.py`** — a frozen `GenomeBuild` value object with `GRCH37`/`GRCH38` instances owning the PAR coordinates, accessed via `get_genome_build()`. `cnvlib.params.PSEUDO_AUTSOMAL_REGIONS` is now a back-compat re-export.
- **`GenomicArray.autosomes()`** recognizes arabic *and* Roman numerals, infers sex chromosomes from the whole chromosome set (so `chrX` is a sex chromosome in human data but autosome 10 in yeast), and falls back permissively — warning and returning the array unchanged — on unfamiliar assemblies rather than silently dropping data.
- **`CopyNumArray.chr_x_label` / `chr_y_label`** now scan all chromosome names and return `str | None` (None = no sex chromosome detected); the `chr_*_filter` methods return an all-False mask in that case instead of raising.
- **Removed** the dead `re_canonical` regex and the exclusion-based `is_canonical_contig_name`; callers now compose `is_alternative_contig` + `is_mitochondrial`.
- **`scatter`** logs a helpful diagnostic (listing available chromosomes, suggesting a `chr`-prefix variant) when a selection yields zero probes, and derives its HLA/chrY autoscale and segment-coloring ploidy map from the data's actual sex-chromosome labels instead of hardcoded human literals.
- **Docs**: new "Non-human and Roman-numeral genomes" section in `doc/sex.rst`; `chromnames`/`genomebuild` wired into the API docs; chromosome-handling conventions recorded in `CLAUDE.md`.

### Clinical-impact note

No change to numerical output or file formats (`.cnr`/`.cns`/`.cnn`/SEG/VCF) for human data — verified by the full existing test suite passing. The behavior change is that previously mis-handled organisms (yeast and other Roman-numeral assemblies) now get correct autosome selection and sex-chromosome inference.

## Test plan

- [x] `pytest test/` — 261 passed (the one deselected biweight property-test flake pre-exists on `master`)
- [x] `mypy` — clean across 77 source files
- [x] `make lint` (ruff) — clean
- [x] New unit tests: `test/test_chromnames.py` (34), `test/test_genomebuild.py` (8), plus yeast fixtures in `test_genome.py` and `test_cnvlib.py`
- [x] End-to-end manual check: synthetic yeast `.cnr`/`.cns` — `scatter chrVIII` now plots probes; a wrong chromosome name (`chr8`) emits the diagnostic warning
- [x] Bisectability spot-check: each intermediate commit imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)