### PR TITLE
Fix the failing Hypothesis test

### DIFF
--- a/cnvlib/descriptives.py
+++ b/cnvlib/descriptives.py
@@ -104,21 +104,32 @@ def biweight_location(
         # Weight the observations by distance from initial estimate
         d = a - initial
         mad = np.median(np.abs(d))
-        w = d / max(c * mad, epsilon)
-        w = (1 - w**2) ** 2
+        if mad == 0:
+            # More than half the values equal the median: no robust spread to
+            # weight by, so the location is that dominant value. (An absolute
+            # scale floor here would not be scale-equivariant.)
+            return initial, 0.0
+        scale = c * mad
+        # Standardized residuals of far outliers overflow when squared; the
+        # mask below rejects them anyway, so silence that benign warning.
+        with np.errstate(over="ignore"):
+            w = (1 - (d / scale) ** 2) ** 2
         # Omit the outlier points
         mask = w < 1
         weightsum = w[mask].sum()
         if weightsum == 0:
             # Insufficient variation to improve the initial estimate
-            return initial
-        return initial + (d[mask] * w[mask]).sum() / weightsum
+            return initial, scale
+        return initial + (d[mask] * w[mask]).sum() / weightsum, scale
 
     if initial is None:
         initial = np.median(a)
     for _i in range(max_iter):
-        result = biloc_iter(a, initial)
-        if abs(result - initial) <= epsilon:
+        result, scale = biloc_iter(a, initial)
+        # Stop on the *standardized* step so convergence is scale-equivariant:
+        # an absolute threshold would stop scaled and unscaled inputs after
+        # different iteration counts, breaking biweight_location(k*a) == k*...
+        if abs(result - initial) <= epsilon * scale:
             break
         initial = result
     return result  # type: ignore[no-any-return]

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -528,8 +528,8 @@ class TestRescaleBaf:
     def test_output_clamped_to_unit_interval(self, purity, observed_baf):
         """rescale_baf output is always in [0, 1] for any in-range inputs."""
         result = rescale_baf(purity, observed_baf)
-        assert (result.values >= 0.0).all()
-        assert (result.values <= 1.0).all()
+        assert (result.to_numpy() >= 0.0).all()
+        assert (result.to_numpy() <= 1.0).all()
 
     def test_low_purity_extreme_baf_clamped_to_zero(self):
         """Regression for issue #601: low purity + observed BAF ~ 0 must

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -156,20 +156,25 @@ class TestBiweightLocation:
         assert abs(shifted - (base + c)) < tol
 
     @given(
-        # min_size=20: biweight outlier-rejection weights are unstable for
-        # small samples, breaking scale equivariance even for well-conditioned
-        # data.  20+ points give enough mass for stable convergence.
+        # min_size=20: for very small samples the windowed biweight iteration
+        # can fall into a 2-cycle (different single points enter the window each
+        # step) and never converge, so the max_iter cutoff -- and thus
+        # equivariance -- becomes sensitive to floating-point noise.  20+ points
+        # give enough mass for the iteration to converge.
         _non_constant_array(min_size=20),
         st.floats(min_value=0.5, max_value=10.0, allow_nan=False, allow_infinity=False),
     )
     def test_scale_equivariance(self, a, k):
-        """biweight_location(a * k) == biweight_location(a) * k."""
+        """biweight_location(a * k) == biweight_location(a) * k.
+
+        The convergence rule stops on the standardized step, so scaled and
+        unscaled inputs take the same iterations and equivariance holds up to
+        floating-point rounding only.
+        """
         assume(np.all(np.isfinite(a * k)))
         base = biweight_location(a)
         scaled = biweight_location(a * k)
-        # Iterative convergence (epsilon=1e-3 per run) + floating-point
-        # arithmetic across scales can compound to ~3 * epsilon.
-        tol = max(0.02 * abs(base * k), 0.004)
+        tol = 1e-9 * (abs(base * k) + 1)
         assert abs(scaled - base * k) < tol
 
 


### PR DESCRIPTION
Root cause: numerical instability in the biweight location calculation.