### PR TITLE
Harden coverage->log2 boundary: floor copy number at 0, drop NaN bins

### DIFF
--- a/cnvlib/call.py
+++ b/cnvlib/call.py
@@ -526,6 +526,16 @@ def _log2_ratio_to_absolute(
     """
     if purity and purity < 1.0:
         ncopies = (ref_copies * 2**log2_ratio - expect_copies * (1 - purity)) / purity
+        # Absolute copy number is physically >= 0. For a segment deleted below
+        # the (1 - purity) normal-contamination floor (e.g. a homozygous
+        # deletion, or the NULL_LOG2_COVERAGE sentinel from zero-coverage bins),
+        # this formula extrapolates to a negative count; clamp it to 0 so the
+        # 'call' command never emits a nonsensical negative copy number (#503).
+        # A NaN log2 (malformed input) is left to propagate rather than silently
+        # floored to 0 -- a false homozygous-deletion call would be worse than a
+        # surfaced error (cf. the np.isnan guard in absolute_threshold).
+        if not np.isnan(ncopies):
+            ncopies = max(0.0, ncopies)
     else:
         ncopies = _log2_ratio_to_absolute_pure(log2_ratio, ref_copies)
     return ncopies

--- a/cnvlib/cnary.py
+++ b/cnvlib/cnary.py
@@ -304,11 +304,18 @@ class CopyNumArray(GenomicArray):
         These are generally bins that had no reads mapped due to sample-specific
         issues. A very small log2 ratio or coverage value may have been
         substituted to avoid domain or divide-by-zero errors.
+
+        NaN log2/depth values (from degenerate or malformed inputs) are also
+        dropped here: a bare ``log2 < min_cvg`` comparison is False for NaN, so
+        without this NaN bins would slip past into segmentation and trigger an
+        'invalid value encountered in greater' warning or a CBS crash (#521).
         """
         min_cvg = params.NULL_LOG2_COVERAGE - params.MIN_REF_COVERAGE
-        drop_idx = self.data["log2"] < min_cvg
+        log2 = self.data["log2"]
+        drop_idx = (log2 < min_cvg) | log2.isna()
         if "depth" in self:
-            drop_idx |= self.data["depth"] == 0
+            depth = self.data["depth"]
+            drop_idx |= (depth == 0) | depth.isna()
         if verbose and drop_idx.any():
             logging.info("Dropped %d low-coverage bins", drop_idx.sum())
         return self[~drop_idx]

--- a/cnvlib/fix.py
+++ b/cnvlib/fix.py
@@ -231,8 +231,11 @@ def load_adjust_coverages(
 
     ref_matched = match_ref_to_sample(ref_cnarr, cnarr)
 
-    # Drop bins that had poor coverage in the pooled reference
-    ok_cvg_indices = ~mask_bad_bins(ref_matched)
+    # Drop bins that had poor coverage in the pooled reference, or whose own
+    # sample coverage is degenerate (NaN log2 from a malformed input file).
+    # mask_bad_bins only inspects the reference, so a NaN in the sample itself
+    # would otherwise survive and propagate into segmentation/smoothing (#521).
+    ok_cvg_indices = ~(mask_bad_bins(ref_matched) | cnarr["log2"].isna())
     logging.info("Keeping %d of %d bins", sum(ok_cvg_indices), len(ref_matched))
     cnarr = cnarr[ok_cvg_indices]
     ref_matched = ref_matched[ok_cvg_indices]
@@ -289,9 +292,14 @@ def mask_bad_bins(cnarr: CopyNumArray) -> Series:
         (cnarr["log2"] < params.MIN_REF_COVERAGE)
         | (cnarr["log2"] > -params.MIN_REF_COVERAGE)
         | (cnarr["spread"] > params.MAX_REF_SPREAD)
+        # NaN log2/spread (degenerate reference bins) compare False above, so
+        # flag them explicitly -- otherwise NaN propagates into the sample after
+        # reference subtraction and crashes segmentation (#521).
+        | cnarr["log2"].isna()
+        | cnarr["spread"].isna()
     )
     if "depth" in cnarr:
-        mask |= cnarr["depth"] == 0
+        mask |= (cnarr["depth"] == 0) | cnarr["depth"].isna()
     if "gc" in cnarr:
         assert params.GC_MIN_FRACTION >= 0 and params.GC_MIN_FRACTION <= 1
         assert params.GC_MAX_FRACTION >= 0 and params.GC_MAX_FRACTION <= 1

--- a/doc/heterogeneity.rst
+++ b/doc/heterogeneity.rst
@@ -131,6 +131,11 @@ numbers are emitted unless the ``-m none`` option is used to skip it.
     # Or, using a custom set of cutoffs
     cnvkit.py call -t=-1.1,-0.4,0.3,0.7 Sample.cns -y -o Sample.call.cns
 
+Absolute copy number is floored at 0: for a deeply deleted segment in a
+low-purity sample, the purity-rescaling formula can extrapolate to a negative
+value, which is reported as a homozygous deletion (copy number 0) rather than a
+nonsensical negative count.
+
 
 Export integer copy numbers as BED or VCF
 -----------------------------------------

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -395,6 +395,65 @@ class OtherTests(unittest.TestCase):
         result = fix.apply_weights(cnarr, ref_nan, "log2", "spread")
         self.assertFalse(np.isnan(result["weight"]).any())
 
+    @staticmethod
+    def _cna_with_nan_log2():
+        """A CopyNumArray whose middle bins carry NaN / sentinel log2 values."""
+        log2 = [0.1, np.nan, params.NULL_LOG2_COVERAGE, 0.2, np.nan, -0.1]
+        n = len(log2)
+        return cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * n,
+                    "start": np.arange(0, n * 1000, 1000),
+                    "end": np.arange(1000, n * 1000 + 1000, 1000),
+                    "gene": ["G"] * n,
+                    "log2": log2,
+                    "depth": [100.0, 100.0, 0.0, 100.0, np.nan, 100.0],
+                    "weight": [1.0] * n,
+                }
+            )
+        )
+
+    def test_drop_low_coverage_drops_nan(self):
+        """drop_low_coverage removes NaN-log2 bins, not just the sentinel (gh#521).
+
+        A bare ``log2 < min_cvg`` comparison is False for NaN, so without
+        explicit NaN handling, NaN bins survive into segmentation and trigger
+        the 'invalid value encountered in greater' RuntimeWarning / CBS crash.
+        """
+        cnarr = self._cna_with_nan_log2()
+        kept = cnarr.drop_low_coverage()
+        # No NaN and no sentinel survives
+        self.assertFalse(np.isnan(kept["log2"]).any())
+        self.assertTrue((kept["log2"] > params.NULL_LOG2_COVERAGE).all())
+        # The three good bins remain (0.1, 0.2, -0.1)
+        self.assertEqual(len(kept), 3)
+
+    def test_mask_bad_bins_flags_nan(self):
+        """mask_bad_bins treats NaN log2/spread reference bins as bad (gh#521)."""
+        n = 5
+        ref = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * n,
+                    "start": np.arange(0, n * 1000, 1000),
+                    "end": np.arange(1000, n * 1000 + 1000, 1000),
+                    "gene": ["G"] * n,
+                    "log2": [0.0, np.nan, 0.0, 0.0, 0.0],
+                    "spread": [0.1, 0.1, np.nan, 0.1, 0.1],
+                    "depth": [100.0, 100.0, 100.0, 100.0, 100.0],
+                }
+            )
+        )
+        mask = fix.mask_bad_bins(ref)
+        # NaN-log2 (idx 1) and NaN-spread (idx 2) bins must be flagged bad
+        self.assertTrue(mask.iloc[1])
+        self.assertTrue(mask.iloc[2])
+        # The clean bins are kept
+        self.assertFalse(mask.iloc[0])
+        self.assertFalse(mask.iloc[3])
+        self.assertFalse(mask.iloc[4])
+
     def test_transfer_fields_nan_gene(self):
         """transfer_fields handles NaN gene names without crashing (issue #900)."""
         n = 10

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -488,6 +488,30 @@ class ReferenceTests(unittest.TestCase):
         cnr = commands.do_fix(tgt_bins, blank_bins, ref[~is_bg])
         self.assertTrue(0 < len(cnr) <= len(tgt_bins))
 
+    def test_fix_degenerate_no_nan(self):
+        """do_fix never emits NaN log2/weight from degenerate input (gh#521/#524).
+
+        Zero-coverage sentinel and NaN bins (from malformed inputs or dead
+        regions in WGS) must not survive into the .cnr, where they would crash
+        smoothing/CBS downstream.
+        """
+        ref = cnvlib.read("formats/reference-tr.cnn")
+        is_bg = ref["gene"] == "Background"
+        tgt_bins = ref[~is_bg].copy()
+        anti_bins = ref[is_bg].copy()
+        # Inject degenerate values into a few sample bins
+        tgt_log2 = tgt_bins["log2"].copy()
+        tgt_log2.iloc[0] = np.nan
+        tgt_log2.iloc[1] = params.NULL_LOG2_COVERAGE
+        tgt_bins["log2"] = tgt_log2
+        # Inject a degenerate value into the reference, too
+        ref_log2 = ref["log2"].copy()
+        ref_log2.iloc[2] = np.nan
+        ref["log2"] = ref_log2
+        cnr = commands.do_fix(tgt_bins, anti_bins, ref)
+        self.assertFalse(np.isnan(cnr["log2"]).any())
+        self.assertFalse(np.isnan(cnr["weight"]).any())
+
 
 class SegmentationTests(unittest.TestCase):
     """Tests for segmentation commands."""
@@ -1164,6 +1188,73 @@ class CallTests(unittest.TestCase):
         _assert_chrx_non_par(abs_df, abs_ref, abs_clonal, abs_exp, 2, 1, 3.43002)
         _assert_chry_par(abs_df, abs_ref, abs_exp, abs_clonal, 0, 0, 0.0)
         _assert_chry_non_par(abs_df, abs_ref, abs_exp, abs_clonal, 1, 1, 0.45083)
+
+    @staticmethod
+    def _deep_deletion_cns():
+        """Segments including deep deletions: a true homozygous deletion
+        (log2=-3) and a zero-coverage sentinel segment (log2=NULL_LOG2_COVERAGE).
+        """
+        log2 = [0.0, -3.0, params.NULL_LOG2_COVERAGE, 0.585]
+        n = len(log2)
+        return cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * n,
+                    "start": np.arange(0, n * 1000, 1000),
+                    "end": np.arange(1000, n * 1000 + 1000, 1000),
+                    "gene": ["-"] * n,
+                    "log2": log2,
+                    "probes": [10] * n,
+                    "weight": [1.0] * n,
+                }
+            )
+        )
+
+    def test_call_clonal_no_negative_cn(self):
+        """Clonal calling with impure samples never emits negative copy number.
+
+        Regression for gh#503/#516: with purity < 1, the purity-rescale formula
+        n = (r*2^log2 - x*(1-p)) / p extrapolates to negative absolute copies
+        for deeply deleted (or zero-coverage sentinel) segments. Absolute copy
+        number is physically >= 0, so it must be floored at 0.
+        """
+        cns = self._deep_deletion_cns()
+        for tumor_purity in (0.3, 0.5, 0.65, 0.9):
+            with self.subTest(purity=tumor_purity):
+                called = commands.do_call(
+                    cns,
+                    None,
+                    "clonal",
+                    purity=tumor_purity,
+                    is_haploid_x_reference=True,
+                    is_sample_female=True,
+                )
+                self.assertTrue(
+                    (called["cn"] >= 0).all(),
+                    f"negative cn at purity={tumor_purity}: {called['cn'].tolist()}",
+                )
+                # Deep-deletion and sentinel segments should call CN 0
+                self.assertEqual(called["cn"].iloc[1], 0)
+                self.assertEqual(called["cn"].iloc[2], 0)
+
+    def test_log2_ratio_to_absolute_floored_at_zero(self):
+        """_log2_ratio_to_absolute never returns a negative absolute (gh#503)."""
+        # Impure path: deep deletion below the (1-p) contamination floor
+        self.assertEqual(
+            call._log2_ratio_to_absolute(-20.0, 2, 2, purity=0.5), 0.0
+        )
+        self.assertEqual(
+            call._log2_ratio_to_absolute(-3.0, 2, 2, purity=0.5), 0.0
+        )
+        # A real single-copy gain is unaffected
+        self.assertAlmostEqual(
+            call._log2_ratio_to_absolute(0.585, 2, 2, purity=1.0), 3.0, places=2
+        )
+        # A NaN log2 (malformed input) propagates rather than being silently
+        # floored to 0 -- a false homozygous-deletion call would be worse.
+        self.assertTrue(
+            np.isnan(call._log2_ratio_to_absolute(np.nan, 2, 2, purity=0.5))
+        )
 
 
 class LoadHetSnpsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes two physical-impossibility leaks downstream of zero/near-zero-coverage bins, both at the root cause.

### 1. Negative copy numbers — Fixes #503, Fixes #516
`call._log2_ratio_to_absolute`'s purity-rescale formula `n = (r·2^v − x·(1−p)) / p` extrapolates to a **negative** absolute count when the log2 ratio `v` is below the `(1−p)` normal-contamination floor — e.g. a homozygous deletion or the `NULL_LOG2_COVERAGE` (−20) sentinel. `do_call` then emitted negative integer `cn` (reproduced: `cn = [2, -4, …]` at purity 0.3). Fix: clamp finite `ncopies` at 0. A NaN log2 is left to **propagate** rather than silently floored to 0 (a false homozygous-deletion call would be worse), matching the existing `np.isnan` guard in `absolute_threshold`.

> The `-9.96578` in old reports is `log2_ratios()`'s `1e-3` floor (`log2(1e-3) = -9.9658`) reacting to that negative absolute — not a coverage artifact. Once `cn` is floored it is a legitimate deep-deletion floor.

### 2. NaN cascade into smoothing/CBS — Fixes #521, Fixes #524
Bare `<`/`>`/`==` comparisons return `False` for NaN, so NaN `log2`/`depth`/`spread` bins survived the gates and reached smoothing (`invalid value encountered in greater`) and CBS. Now dropped explicitly in:
- `cnary.drop_low_coverage` (the gate before CBS)
- `fix.mask_bad_bins` (reference side)
- `fix.load_adjust_coverages` (sample side — `mask_bad_bins` only inspects the reference, so a sample-only NaN otherwise slipped through)

## ⚠️ Clinical / numerical-output impact
- **`call` with `purity < 1`**: segments that previously got a *negative* `cn` now get `0`. Rescaled output `log2` is **unchanged** (both floor to `log2(1e-3)`). Valid calls are bit-identical — confirmed by the unchanged hardcoded expectations in `test_call_various_abs_ref_exp_methods` / `test_call_sex`.
- **`fix`/`.cnr`**: NaN bins from degenerate inputs are dropped (fewer rows) instead of emitting NaN. Normal inputs unchanged.
- Documented the floor in `doc/heterogeneity.rst`.

## Tests
5 regression tests added: `test_call_clonal_no_negative_cn`, `test_log2_ratio_to_absolute_floored_at_zero` (incl. NaN propagation), `test_drop_low_coverage_drops_nan`, `test_mask_bad_bins_flags_nan`, `test_fix_degenerate_no_nan`. mypy clean; ruff clean (new lines); 87 unit tests pass.

## Reviewed
Ran a 3-agent review (simplicity/DRY; bugs/correctness; conventions). Acted on findings: added the NaN-propagation guard, simplified the `load_adjust_coverages` mask (dropped redundant `.to_numpy()`), and added the doc note.

## Not included (deliberately)
`#881` (R/CBS `CalledProcessError`) and `#891` (empty `.cnr` from a near-empty/wrong reference) are **not** caused by this boundary and remain open for separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)