### PR TITLE
Harden VCF reader: missing GT (Strelka), ./. no-calls, unparseable headers

### DIFF
--- a/doc/baf.rst
+++ b/doc/baf.rst
@@ -58,9 +58,14 @@ SNP sites to extract likely germline SNVs from a tumor-only VCF and use just
 those sites. Note that without a paired normal, sample-level somatic filtering
 is weaker (see below).
 
-If you already have somatic calls produced by GATK Mutect2, you can re-run with
-``--genotype-germline-sites true --genotype-pon-sites true`` to retain the
-germline SNP sites in the same VCF -- this gives CNVkit something to work with.
+If you are calling somatic variants, configure the caller to also emit germline
+genotypes -- a somatic-only VCF gives CNVkit no heterozygous SNPs to use:
+
+- **GATK Mutect2:** re-run with ``--genotype-germline-sites true
+  --genotype-pon-sites true`` to keep the germline SNP sites in the same VCF.
+- **Strelka:** run its *germline* workflow, not the somatic one. Strelka's
+  somatic VCF contains only somatic variants and omits the ``GT`` field, so it
+  has no usable germline SNPs.
 
 An `example VCF
 <https://github.com/etal/cnvkit/blob/master/test/formats/na12878_na12882_mix.vcf?raw=true>`_

--- a/skgenome/tabio/vcfio.py
+++ b/skgenome/tabio/vcfio.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import collections
 import logging
+import os
 
 from itertools import chain
 
@@ -23,6 +24,10 @@ if TYPE_CHECKING:
     )
 
 
+# Strelka reports per-base counts (tier1, tier2) instead of GT/AD (gh#943)
+_STRELKA_TIER1_FIELD = {"A": "AU", "C": "CU", "G": "GU", "T": "TU"}
+
+
 def read_vcf(
     infile: str,
     sample_id: str | None = None,
@@ -37,6 +42,9 @@ def read_vcf(
     file.  If `sample_id` is a string identifier, return the (paired or single)
     sample  matching that ID.  If `sample_id` is a positive integer, return the
     sample or pair at that index position, counting from 0.
+
+    Samples without a ``GT`` genotype field (e.g. Strelka somatic calls) are
+    tolerated: zygosity is then inferred from the alternate-allele frequency.
     """
     try:
         import pysam
@@ -44,12 +52,16 @@ def read_vcf(
         raise ImportError(
             f"pysam is required for reading VCF files. {PYSAM_INSTALL_MSG}"
         ) from None
+    if not isinstance(infile, (str, os.PathLike)):
+        # pysam requires a path on disk; an open file handle can't be parsed
+        raise ValueError(
+            f"Must give a VCF filename, not an open file handle: {infile!r}"
+        )
     try:
         vcf_reader = pysam.VariantFile(infile)
-    except Exception as exc:
-        raise ValueError(
-            f"Must give a VCF filename, not open file handle: {exc}"
-        ) from exc
+    except (OSError, ValueError) as exc:
+        # e.g. a malformed header (FORMAT column declared but no samples, gh#680)
+        raise ValueError(f"Could not read VCF file {infile!r}: {exc}") from exc
     if vcf_reader.header.samples:
         sid, nid = _choose_samples(vcf_reader, sample_id, normal_id)
         logging.info(
@@ -269,17 +281,12 @@ def _parse_records(
                 raise
         else:
             # Assume unpaired tumor; take DP, AF from INFO (e.g. LoFreq)
-            depth = record.info.get("DP", 0.0) if "DP" in record.info else 0.0  # type: ignore[assignment,arg-type]
+            depth = record.info.get("DP", 0.0)  # type: ignore[assignment,arg-type]
             if "AF" in record.info:
                 alt_freq = record.info["AF"]
                 alt_count = round(alt_freq * depth)
                 # NB: No genotype, so crudely guess from allele frequency
-                if alt_freq < 0.25:
-                    zygosity = 0.0
-                elif alt_freq < 0.75:
-                    zygosity = 0.5
-                else:
-                    zygosity = 1.0
+                zygosity = _zygosity_from_freq(alt_freq)
             else:
                 alt_count = 0
                 zygosity = 0.0
@@ -315,33 +322,68 @@ def _parse_records(
 
 def _extract_genotype(
     sample: VariantRecordSample, record: VariantRecord
-) -> (
-    tuple[None, float, int]
-    | tuple[int, float, int]
-    | tuple[None, float, float]
-    | tuple[int, float, float]
-):
-    if "DP" in sample:
-        depth = sample["DP"]
-    elif "AD" in sample and isinstance(sample["AD"], tuple):
-        depth = _safesum(sample["AD"])
-    elif "DP" in record.info:
-        depth = record.info["DP"]
-    else:
-        # SV or not called, probably
-        depth = np.nan  # 0.0
-    gts = set(sample["GT"])
-    if len(gts) > 1:
-        zygosity = 0.5
-    elif gts.pop() == 0:
-        zygosity = 0.0
-    else:
-        zygosity = 1.0
-    alt_count = _get_alt_count(sample)
+) -> tuple[int | float, float, int | float]:
+    depth = _get_depth(sample, record)
+    alt_count = _get_alt_count(sample, record)
+    zygosity = _get_zygosity(sample, depth, alt_count)
     return depth, zygosity, alt_count
 
 
-def _get_alt_count(sample: VariantRecordSample) -> int | float:
+def _get_depth(sample: VariantRecordSample, record: VariantRecord) -> int | float:
+    """Get the total read depth at a sample's locus."""
+    if "DP" in sample:
+        return sample["DP"]  # type: ignore[no-any-return]
+    if "AD" in sample and isinstance(sample["AD"], tuple):
+        return _safesum(sample["AD"])
+    if "DP" in record.info:
+        return record.info["DP"]  # type: ignore[no-any-return]
+    # SV or not called, probably
+    return np.nan
+
+
+def _get_zygosity(
+    sample: VariantRecordSample, depth: int | float, alt_count: int | float
+) -> float:
+    """Get the zygosity (0=hom-ref, 0.5=het, 1=hom-alt) of a sample's genotype.
+
+    Use the explicit GT call when present and complete; otherwise -- when GT is
+    absent (e.g. Strelka, gh#943) or a no-call (``./.``) -- infer it from the
+    alternate-allele frequency.
+    """
+    if "GT" in sample:
+        gts = set(sample["GT"])
+        # A complete no-call ('./.', i.e. {None}) carries no genotype, so fall
+        # through to frequency inference rather than misreading it as hom-alt.
+        # Partial calls (e.g. '1/.', {1, None}) keep their existing handling.
+        if gts != {None}:
+            if len(gts) > 1:
+                return 0.5
+            if gts.pop() == 0:
+                return 0.0
+            return 1.0
+    # No (complete) genotype call -- guess from allele frequency, if we have it
+    if (
+        depth
+        and not np.isnan(depth)
+        and alt_count is not None
+        and not np.isnan(alt_count)
+    ):
+        return _zygosity_from_freq(alt_count / depth)
+    return 0.0
+
+
+def _zygosity_from_freq(alt_freq: float) -> float:
+    """Crudely guess zygosity from an alternate-allele frequency."""
+    if alt_freq < 0.25:
+        return 0.0
+    if alt_freq < 0.75:
+        return 0.5
+    return 1.0
+
+
+def _get_alt_count(
+    sample: VariantRecordSample, record: VariantRecord
+) -> int | float:
     """Get the alternative allele count from a sample in a VCF record."""
     if sample.get("AD") not in (None, (None,)):
         # GATK and other callers: (ref depth, alt depth)
@@ -364,8 +406,27 @@ def _get_alt_count(sample: VariantRecordSample) -> int | float:
         else:
             alt_count = 0.0
     else:
-        alt_count = np.nan
+        alt_count = _strelka_alt_count(sample, record)
     return alt_count
+
+
+def _strelka_alt_count(
+    sample: VariantRecordSample, record: VariantRecord
+) -> int | float:
+    """Get the alt-allele count from Strelka's per-base tier-1 counts.
+
+    Strelka SNV VCFs report AU/CU/GU/TU (counts of A/C/G/T alleles in tiers
+    1,2) rather than AD. Return the tier-1 count for the (first) ALT base, or
+    NaN if unavailable (e.g. indels, which use a different layout).
+    """
+    if not record.alts:
+        return np.nan
+    field = _STRELKA_TIER1_FIELD.get(record.alts[0].upper())
+    if field is not None and field in sample:
+        value = sample[field]
+        # tier-1 count is the first of the (tier1, tier2) pair
+        return value[0] if isinstance(value, tuple) else value  # type: ignore[no-any-return]
+    return np.nan
 
 
 def _safesum(tup: tuple[None] | tuple[int, int] | tuple[int]) -> int:

--- a/test/formats/format-no-sample.vcf
+++ b/test/formats/format-no-sample.vcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.2
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total read depth">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1,length=249250621>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
+chr1	49515	.	G	A	50.8	PASS	DP=34

--- a/test/formats/gt-nocall.vcf
+++ b/test/formats/gt-nocall.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.2
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total read depth">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+##contig=<ID=chr1,length=249250621>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1
+chr1	100	.	G	A	50	PASS	DP=20	GT:AD:DP	./.:10,10:20
+chr1	200	.	C	T	50	PASS	DP=20	GT:AD:DP	0/1:8,12:20
+chr1	300	.	A	G	50	PASS	DP=20	GT:AD:DP	./.:19,1:20

--- a/test/formats/strelka.vcf
+++ b/test/formats/strelka.vcf
@@ -1,0 +1,20 @@
+##fileformat=VCFv4.1
+##source=strelka
+##content=strelka somatic snv calls
+##FILTER=<ID=LowEVS,Description="Somatic Empirical Variant Score (SomaticEVS) is below threshold">
+##FORMAT=<ID=AU,Number=2,Type=Integer,Description="Number of 'A' alleles used in tiers 1,2">
+##FORMAT=<ID=CU,Number=2,Type=Integer,Description="Number of 'C' alleles used in tiers 1,2">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth for tier1 (used+filtered)">
+##FORMAT=<ID=FDP,Number=1,Type=Integer,Description="Number of basecalls filtered from original read depth for tier1">
+##FORMAT=<ID=GU,Number=2,Type=Integer,Description="Number of 'G' alleles used in tiers 1,2">
+##FORMAT=<ID=SDP,Number=1,Type=Integer,Description="Number of reads with deletions spanning this site at tier1">
+##FORMAT=<ID=SUBDP,Number=1,Type=Integer,Description="Number of reads below tier1 mapping quality threshold aligned across this site">
+##FORMAT=<ID=TU,Number=2,Type=Integer,Description="Number of 'T' alleles used in tiers 1,2">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Combined depth across samples">
+##INFO=<ID=NT,Number=1,Type=String,Description="Genotype of the normal in all data tiers.">
+##INFO=<ID=SOMATIC,Number=0,Type=Flag,Description="Somatic mutation">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NORMAL	TUMOR
+chr1	221367	.	G	C	.	PASS	DP=53;NT=het;SOMATIC	DP:FDP:SDP:SUBDP:AU:CU:GU:TU	20:0:0:0:0,0:10,12:10,11:0,0	33:0:0:0:0,0:16,18:17,20:0,0
+chr1	300000	.	G	C	.	PASS	DP=55;NT=ref;SOMATIC	DP:FDP:SDP:SUBDP:AU:CU:GU:TU	25:0:0:0:0,0:1,1:24,26:0,0	30:0:0:0:0,0:28,30:1,2:0,0
+chr1	400000	.	A	T	.	PASS	DP=40;NT=ref;SOMATIC	DP:FDP:SDP:SUBDP:AU:CU:GU:TU	20:0:0:0:20,22:0,0:0,0:0,0	20:0:0:0:15,17:0,0:0,0:5,6

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -142,6 +142,61 @@ class IOTests(unittest.TestCase):
         v6 = tabio.read("formats/gatk-emptyalt.vcf", "vcf", sample_id="sample1")
         self.assertEqual(len(v6), 0)
 
+    def test_read_vcf_strelka(self):
+        """Read a Strelka somatic-SNV VCF, which has no GT FORMAT field.
+
+        Strelka reports per-base allele counts via AU/CU/GU/TU instead of an
+        explicit genotype. The reader must tolerate the missing GT (gh#943).
+        """
+        fname = "formats/strelka.vcf"
+        # Tumor/normal pair
+        pair = tabio.read(fname, "vcf", sample_id="TUMOR", normal_id="NORMAL")
+        self.assertEqual(len(pair), 3)
+        self.assertEqual(pair.sample_id, "TUMOR")
+        # Alt counts come from the tier-1 count of the ALT base
+        self.assertEqual(list(pair["alt_count"]), [16, 28, 5])
+        self.assertEqual(list(pair["depth"]), [33, 30, 20])
+        # Zygosity inferred from allele frequency (no GT available)
+        self.assertEqual(list(pair["zygosity"]), [0.5, 1.0, 0.5])
+        # Normal-sample columns are present and populated
+        self.assertEqual(list(pair["n_alt_count"]), [10, 1, 0])
+        self.assertEqual(list(pair["n_depth"]), [20, 25, 20])
+        self.assertEqual(list(pair["n_zygosity"]), [0.5, 0.0, 0.0])
+        # Single unpaired sample also works
+        solo = tabio.read(fname, "vcf", sample_id="TUMOR")
+        self.assertEqual(len(solo), 3)
+        self.assertNotIn("n_depth", solo.data.columns)
+        # Default selection (first sample) does not crash
+        default = tabio.read(fname, "vcf")
+        self.assertEqual(len(default), 3)
+
+    def test_read_vcf_nocall(self):
+        """A GT no-call ('./.') is inferred from frequency, not called hom-alt.
+
+        pysam reports './.' as (None, None); the reader must treat it as a
+        missing genotype and fall back to the allele frequency rather than
+        misreading it as homozygous-alt.
+        """
+        v = tabio.read("formats/gt-nocall.vcf", "vcf")
+        self.assertEqual(len(v), 3)
+        self.assertEqual(list(v["alt_count"]), [10, 12, 1])
+        self.assertEqual(list(v["depth"]), [20, 20, 20])
+        # ./. with balanced reads -> het; explicit 0/1 -> het; ./. ref-heavy -> hom-ref
+        self.assertEqual(list(v["zygosity"]), [0.5, 0.5, 0.0])
+
+    def test_read_vcf_malformed(self):
+        """A VCF declaring a FORMAT column but no samples gives a clear error.
+
+        pysam rejects such files; the reader must not mislabel the failure as
+        an open-file-handle mistake (gh#680).
+        """
+        with self.assertRaises(ValueError) as ctx:
+            tabio.read("formats/format-no-sample.vcf", "vcf")
+        msg = str(ctx.exception)
+        self.assertIn("format-no-sample.vcf", msg)
+        # Should not be mislabeled as a "passed an open file handle" mistake
+        self.assertNotIn("file handle", msg)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

The VCF reader (`skgenome/tabio/vcfio.py`) assumed every sample carries a usable `GT` genotype, and that any pysam open failure meant the caller passed an open file handle. Both broke on real-world inputs. This hardens the reader and clarifies the BAF docs.

### Fixes #943 — Strelka somatic VCFs (no `GT`)
Strelka somatic SNV VCFs omit `GT` entirely, reporting per-base allele counts as `AU`/`CU`/`GU`/`TU`. The old code did `set(sample["GT"])` and crashed with `KeyError: 'invalid FORMAT: GT'`.

`_extract_genotype` is split into `_get_depth` / `_get_alt_count` / `_get_zygosity`: depth and alt-count are derived from whatever fields exist (adding Strelka's tier-1 count keyed by the ALT base), then zygosity comes from `GT` when present **and complete**, else is inferred from the alternate-allele frequency — the same fallback already used for sample-less LoFreq VCFs, sharing one `_zygosity_from_freq` helper (thresholds match the canonical `VariantArray.zygosity_from_freq`, `<0.25`/`≥0.75`).

### Fixes #680 — clearer error for unparseable / sample-less VCFs
A malformed VCF (a `FORMAT` column declared but no sample columns) makes pysam fail; the reader used to mislabel it `"Must give a VCF filename, not open file handle"`. It now type-checks for an open handle first, then surfaces a clear `"Could not read VCF file <name>: ..."` error.

### Also: `./.` no-call handling
A complete no-call (`./.`) previously fell through to a **homozygous-alt** classification. It's now treated as a missing genotype and inferred from frequency. Partial calls (`1/.`) keep their existing handling (narrowed deliberately — see below).

## Clinical-impact note
Numerical output is **unchanged** for VCFs with explicit, complete `GT` calls. Only previously-**crashing** (Strelka) or balanced-`./.` inputs differ. In practice the `./.` change rarely affects BAF: `heterozygous()` excludes both hom-ref and hom-alt, so only a *balanced* `./.` (now het) is newly retained. Verified on `na12878_na12882_mix.vcf`: the narrowed fix changes **0** of its records (it has 847 `1/.` partial calls that are intentionally left as-is).

## Tests
New cases in `test/test_io.py` with fixtures `strelka.vcf`, `gt-nocall.vcf`, `format-no-sample.vcf`:
- `test_read_vcf_strelka` — paired & unpaired Strelka read; verifies tier-1 alt-counts, depths, and frequency-inferred zygosity.
- `test_read_vcf_nocall` — `./.` inferred from frequency, not hom-alt.
- `test_read_vcf_malformed` — clear error (not the "file handle" message).

Full suite: 280 passed; mypy and ruff clean.

## Known pre-existing issue (not addressed here)
Partial genotypes like `1/.` are classified het because the missing allele counts as a distinct allele. This is debatable but pre-existing; changing it shifts BAF results, so it's left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)