### PR TITLE
Fix VCF zygosity: don't count no-call '.' as a distinct allele

### DIFF
--- a/doc/fileformats.rst
+++ b/doc/fileformats.rst
@@ -126,6 +126,16 @@ matched tumor/normal samples with the tumor identified via the PEDIGREE
 header tag or ``-i``/``-n`` command-line options. See :doc:`baf` for full
 guidance on VCF preparation, sample identification, and troubleshooting.
 
+CNVkit reads each sample's zygosity from the ``GT`` genotype field when it is
+present: a call with both a reference and an alternate allele (e.g. ``0/1``) is
+heterozygous, ``0/0`` is homozygous reference, and ``1/1`` is homozygous
+alternate. A no-call allele (``.``) is treated as missing rather than as a
+distinct allele, so a complete no-call (``./.``) and a genotype with no ``GT``
+field at all (e.g. Strelka somatic output) fall back to inferring zygosity from
+the alternate-allele frequency. A partial call keeps its called allele: ``0/.``
+(no alternate observed) is homozygous reference, while ``1/.`` retains the
+alternate allele and is treated as heterozygous.
+
 
 .. _cnxformat:
 

--- a/skgenome/tabio/vcfio.py
+++ b/skgenome/tabio/vcfio.py
@@ -351,16 +351,26 @@ def _get_zygosity(
     alternate-allele frequency.
     """
     if "GT" in sample:
-        gts = set(sample["GT"])
-        # A complete no-call ('./.', i.e. {None}) carries no genotype, so fall
-        # through to frequency inference rather than misreading it as hom-alt.
-        # Partial calls (e.g. '1/.', {1, None}) keep their existing handling.
-        if gts != {None}:
-            if len(gts) > 1:
+        gt = tuple(sample["GT"])
+        # pysam reports a no-call allele as None; it is a missing-allele
+        # placeholder, not a distinct allele, so don't count it as one
+        # (gh-9vv). Classify by the alleles that were actually called.
+        called = set(gt) - {None}
+        has_nocall = None in gt
+        # A complete no-call ('./.', i.e. nothing called) carries no genotype,
+        # so fall through to frequency inference rather than guessing.
+        if called:
+            if 0 in called:
+                # A REF allele was called -- het only if an ALT was too
+                # ('0/1'); '0/0' and the partial '0/.' (no ALT evidence)
+                # are hom-ref.
+                return 0.5 if len(called) > 1 else 0.0
+            # Only ALT allele(s) called. '1/1' (and '1/2') are unambiguous,
+            # but a partial '1/.' leaves the other allele unknown; real
+            # ensemble VCFs show these lean heterozygous, so keep them het.
+            if has_nocall:
                 return 0.5
-            if gts.pop() == 0:
-                return 0.0
-            return 1.0
+            return 0.5 if len(called) > 1 else 1.0
     # No (complete) genotype call -- guess from allele frequency, if we have it
     if (
         depth

--- a/test/formats/gt-partial.vcf
+++ b/test/formats/gt-partial.vcf
@@ -1,0 +1,13 @@
+##fileformat=VCFv4.2
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total read depth">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+##contig=<ID=chr1,length=249250621>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1
+chr1	100	.	G	A	50	PASS	DP=20	GT:AD:DP	0/.:10,10:20
+chr1	200	.	C	T	50	PASS	DP=20	GT:AD:DP	1/.:18,2:20
+chr1	300	.	A	G	50	PASS	DP=20	GT:AD:DP	./.:10,10:20
+chr1	400	.	T	C	50	PASS	DP=20	GT:AD:DP	0/0:20,0:20
+chr1	500	.	G	T	50	PASS	DP=20	GT:AD:DP	1/1:0,20:20
+chr1	600	.	C	A	50	PASS	DP=20	GT:AD:DP	0/1:2,18:20

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -184,6 +184,23 @@ class IOTests(unittest.TestCase):
         # ./. with balanced reads -> het; explicit 0/1 -> het; ./. ref-heavy -> hom-ref
         self.assertEqual(list(v["zygosity"]), [0.5, 0.5, 0.0])
 
+    def test_read_vcf_partial_gt(self):
+        """A partial genotype ('1/.', '0/.') is read from the called allele.
+
+        pysam reports a no-call allele as None, so '1/.' is (1, None) and '0/.'
+        is (0, None). The missing-allele placeholder must not be counted as a
+        distinct allele (gh-9vv): '0/.' has no ALT evidence and is hom-ref,
+        while '1/.' carries an ALT allele and is kept heterozygous (consistent
+        with the read evidence in real ensemble VCFs). Read depths here diverge
+        from the GT classification (e.g. '1/.' with AF=0.1) to prove the result
+        comes from the genotype, not from frequency inference.
+        """
+        v = tabio.read("formats/gt-partial.vcf", "vcf")
+        self.assertEqual(len(v), 6)
+        # 0/. -> hom-ref; 1/. -> het; ./. -> freq (balanced=het);
+        # 0/0 -> hom-ref; 1/1 -> hom-alt; 0/1 -> het
+        self.assertEqual(list(v["zygosity"]), [0.0, 0.5, 0.5, 0.0, 1.0, 0.5])
+
     def test_read_vcf_malformed(self):
         """A VCF declaring a FORMAT column but no samples gives a clear error.
 


### PR DESCRIPTION
## Problem

`_get_zygosity` in `skgenome/tabio/vcfio.py` built a `set()` over the `GT` genotype, where pysam represents a no-call allele as `None`. A partial call like `1/.` became `{1, None}` (length 2) and tripped the "more than one allele → heterozygous" rule, because the missing-allele placeholder `None` was silently **counted as a second, distinct allele**. The same bug classified `0/.` — one reference allele and *no* ALT evidence — as heterozygous, which is plainly wrong.

This was deliberately deferred during PR #1059 review (which narrowed the `./.` no-call fix to `gts == {None}` to avoid shifting BAF output) and tracked as bead `cnvkit-9vv`.

## Fix

Strip `None` before classifying and decide by the alleles actually called:

| Genotype | Before | After |
|---|---|---|
| `0/.` | het `0.5` | **hom-ref `0.0`** (fix — no ALT evidence) |
| `1/.` | het `0.5` | het `0.5` (preserved) |
| `./.` | freq inference | freq inference (unchanged) |
| `0/0`, `0/1`, `1/1`, `1/2`, haploid | — | unchanged |

The `1/.` → het choice matches the read evidence in real ensemble VCFs (median alt-freq ~0.5 on calls with a trustworthy `AD` field) and is the informative choice for BAF/het-SNP analysis. Frequency inference was rejected for partial calls: on ensemble VCFs the per-caller `AO` is small relative to the merged `DP`, so `AO/DP` collapses most `1/.` to spurious hom-ref, overriding an explicit ALT call.

## Clinical impact: none on existing data

The bundled test VCF `na12878_na12882_mix.vcf` has 847/854 partial calls per sample, **all `1/.`**, which stay het. BAF output and the `load_het_snps` median test are unchanged. Only the genuinely-wrong `0/.` → het case changes behavior.

## Tests

- New fixture `test/formats/gt-partial.vcf` and `test_read_vcf_partial_gt`, with read depths that **diverge** from the GT classification (e.g. `1/.` at AF=0.1) to prove the result comes from the genotype rather than frequency inference. Confirmed it fails on the pre-fix code and passes after.
- mypy clean, ruff clean, 131 tests pass across `test_io`/`test_cnvlib`/`test_genome`/`test_commands`.
- Genotype interpretation documented in `doc/fileformats.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)