### PR TITLE
Normalize singleton NaN gene names in merge/flatten/squash (Fixes #850)

### DIFF
--- a/skgenome/merge.py
+++ b/skgenome/merge.py
@@ -17,12 +17,37 @@ import numpy as np
 import pandas as pd
 
 from .chromsort import sorter_chrom
-from .combiners import first_of, get_combiners
+from .combiners import first_of, get_combiners, join_strings
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
 _BF_COLS = ("chromosome", "start", "end")
+
+
+def _fill_unnamed(table: pd.DataFrame, cmb: dict[str, Callable]) -> pd.DataFrame:
+    """Fill non-string values in string-join columns with the "-" placeholder.
+
+    ``merge``/``flatten``/``squash`` emit singleton (non-overlapping) rows
+    verbatim, so a NaN-float gene/accession from a ragged input survives
+    unjoined. Bring those into line with the multi-row output of
+    :func:`join_strings`, which renders missing names as ``"-"``. Only columns
+    that actually use ``join_strings`` are touched, so caller-supplied combiners
+    are respected. A no-op returning the input unchanged when every value is
+    already a string, so well-formed data is neither copied nor altered.
+    """
+    fix = {}
+    for col, fn in cmb.items():
+        if fn is join_strings and col in table.columns:
+            nonstr = ~table[col].map(lambda v: isinstance(v, str)).to_numpy()
+            if nonstr.any():
+                fix[col] = nonstr
+    if not fix:
+        return table
+    table = table.copy()
+    for col, nonstr in fix.items():
+        table.loc[nonstr, col] = "-"
+    return table
 
 
 def flatten(
@@ -33,11 +58,11 @@ def flatten(
     """Combine overlapping regions into single rows, similar to bedtools merge."""
     if table.empty:
         return table
+    cmb = get_combiners(table, False, combine)
     if (table.start.to_numpy()[1:] >= table.end.cummax().to_numpy()[:-1]).all():
-        return table
+        return _fill_unnamed(table, cmb)
     # NB: Input rows and columns should already be sorted like this
     table = table.sort_values(["chromosome", "start", "end"])
-    cmb = get_combiners(table, False, combine)
     clustered = bioframe.cluster(
         table, min_dist=0, cols=_BF_COLS, return_cluster_ids=True
     )
@@ -48,9 +73,10 @@ def flatten(
         )
         all_rows.extend(_flatten_tuples(group_rows, cmb))
     out = pd.DataFrame.from_records(all_rows, columns=table.columns)
-    return out.reindex(
+    out = out.reindex(
         out.chromosome.apply(sorter_chrom).sort_values(kind="mergesort").index
     )
+    return _fill_unnamed(out, cmb)
 
 
 def _flatten_tuples(
@@ -88,15 +114,15 @@ def merge(
     """Merge overlapping rows in a DataFrame."""
     if table.empty:
         return table
+    cmb = get_combiners(table, stranded, combine)
     gap_sizes = table.start.to_numpy()[1:] - table.end.cummax().to_numpy()[:-1]
     if (gap_sizes > -bp).all():
-        return table
+        return _fill_unnamed(table, cmb)
     if stranded:
         groupkey = ["chromosome", "strand"]
     else:
         groupkey = ["chromosome"]
     table = table.sort_values([*groupkey, "start", "end"])
-    cmb = get_combiners(table, stranded, combine)
     min_dist = max(0, -bp)
     on = ["strand"] if stranded else None
     clustered = bioframe.cluster(
@@ -130,9 +156,10 @@ def merge(
             result_rows.append(pd.Series(vals))
     out = pd.DataFrame(result_rows, columns=data_cols).reset_index(drop=True)
     # Re-sort chromosomes cleverly instead of lexicographically
-    return out.reindex(
+    out = out.reindex(
         out.chromosome.apply(sorter_chrom).sort_values(kind="mergesort").index
     )
+    return _fill_unnamed(out, cmb)
 
 
 def squash(
@@ -160,7 +187,7 @@ def squash(
     DataFrame
         A new DataFrame with consecutive adjacent rows combined.
     """
-    if table.empty or len(table) == 1:
+    if table.empty:
         return table
 
     cmb = get_combiners(table, stranded=False, combine=combine)
@@ -179,7 +206,7 @@ def squash(
 
     # Nothing to squash -- short-circuit
     if not is_adjacent.any():
-        return table
+        return _fill_unnamed(table, cmb)
 
     # Assign group IDs: increment when rows are *not* adjacent
     group_ids = np.concatenate([[0], np.cumsum(~is_adjacent)])
@@ -200,4 +227,5 @@ def squash(
                 else:
                     vals[col] = group[col].iloc[0]
             result_rows.append(pd.Series(vals))
-    return pd.DataFrame(result_rows, columns=table.columns).reset_index(drop=True)
+    out = pd.DataFrame(result_rows, columns=table.columns).reset_index(drop=True)
+    return _fill_unnamed(out, cmb)

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -365,6 +365,54 @@ class IntervalTests(unittest.TestCase):
             expect = self._from_intervals(merged_coords)
             self._compare_regions(result, expect)
 
+    def test_nan_gene_names(self):
+        """merge/flatten/subdivide tolerate NaN-float gene names (issue #850).
+
+        A bait BED whose 'gene' column holds NaN floats (e.g. a ragged name
+        column) once crashed ``target --annotate --split`` two ways:
+        ``TypeError: expected str instance, numpy.float64 found`` inside
+        ``join_strings`` (``",".join`` over NaN), and an ``AttributeError`` in
+        the old ``groupby.apply`` merge path on newer pandas.  Both are fixed
+        upstream -- by the bioframe rewrite (#982) and the ``join_strings`` NaN
+        filter (#900) -- but the skgenome merge/subdivide path that the 'target'
+        command exercises had no regression guard.  Use the default combiner
+        (``join_strings``), not the ``"".join`` test combiner, so the real
+        production code path is tested.
+
+        Regions 0+1 overlap (NaN skipped -> "BRCA1"); regions 2+3 overlap and
+        are all-NaN (-> "-"); region 4 is isolated and all-NaN.  The isolated
+        region exercises the singleton/early-return paths, where merge & co.
+        emit rows verbatim -- those NaN floats are normalized to "-" so no
+        unjoined NaN survives in a gene/accession column.
+        """
+        regions = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": "chr0",
+                    "start": [100, 150, 700, 800, 5000],
+                    "end": [400, 600, 900, 1000, 8000],
+                    "gene": [np.nan, "BRCA1", np.nan, np.nan, np.nan],
+                }
+            )
+        )
+        merged = regions.merge()
+        self.assertEqual(list(merged["gene"]), ["BRCA1", "-", "-"])
+
+        # Single-row fast paths (merge/flatten/squash all short-circuit on a
+        # lone region) must normalize too, not pass the NaN float through.
+        isolated = GA(regions.data.iloc[[4]])
+        self.assertEqual(list(isolated.merge()["gene"]), ["-"])
+        self.assertEqual(list(isolated.flatten()["gene"]), ["-"])
+        self.assertEqual(list(isolated.squash()["gene"]), ["-"])
+
+        # flatten() splits at breakpoints and re-joins per sub-interval.
+        # subdivide() (the 'target --split' path) merges then splits big bins.
+        for result in (regions.flatten(), regions.subdivide(100, 0)):
+            self.assertGreater(len(result), 0)
+            for gene in result["gene"]:
+                self.assertIsInstance(gene, str)
+                self.assertNotIn("nan", gene.lower())
+
     def test_intersect(self):
         selections1 = self._from_intervals(
             [


### PR DESCRIPTION
## Summary

`cnvkit.py target --annotate --split` (#850) crashed on a `gene` column holding NaN floats — two ways:
- `TypeError: expected str instance, numpy.float64 found` in `join_strings` (`",".join` over NaN)
- on newer pandas, `AttributeError: 'Pandas' object has no attribute 'chromosome'` in the old `groupby.apply` merge path

Both **root causes were already resolved** by unrelated upstream work — the bioframe `merge()` rewrite (#982) and the `join_strings` NaN filter (#900/#1043) — verified here by reproducing the original `TypeError`. What remained:

1. **No regression guard** on the skgenome `merge`/`subdivide` path that the `target` command exercises.
2. A residual leak: **singleton / non-overlapping rows bypass the combiner**, so a NaN-float gene/accession survived unjoined (e.g. an isolated bait with a missing name).

## Changes

- Add `_fill_unnamed()` in `skgenome/merge.py`, called on every return path of `merge()`, `flatten()`, and `squash()`. It normalizes non-string values to the `"-"` placeholder **only** in columns whose combiner `is join_strings` (`gene`, `accession`), matching the multi-row output. It is a **no-op (no copy)** when all values are already strings.
- Drop `squash()`'s `len(table) == 1` fast-return so a lone NaN-gene row is normalized too (the empty `is_adjacent` array already routes it correctly).
- Add `IntervalTests.test_nan_gene_names` covering `merge`/`flatten`/`subdivide` and the single-row fast paths with mixed-, all-, and isolated-NaN genes.

## Clinical-output impact

**None for well-formed data.** The `gene`/`accession` columns are always strings in normal CNVkit data, so `_fill_unnamed` short-circuits and returns the input unchanged (no copy, no mutation). Only previously-broken inputs that leaked a raw `NaN` now get the conventional `"-"` placeholder. No numeric columns are touched.

## Testing

- New regression test + existing `test_target` (split+annotate) pass
- `mypy` clean (77 files), `ruff` clean
- 132 core tests pass (`test_genome`, `test_commands`, `test_cnvlib`, `test_io`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)