### PR TITLE
Fix start>end segments from squashing unsorted .cns (Fixes #677)

### DIFF
--- a/cnvlib/segfilters.py
+++ b/cnvlib/segfilters.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
     from cnvlib.cnary import CopyNumArray
+    from numpy.typing import NDArray
     from pandas.core.frame import DataFrame
     from pandas.core.series import Series
 
@@ -52,35 +53,38 @@ def require_column(*colnames) -> Callable:
 def squash_by_groups(
     cnarr: CopyNumArray, levels: Series, by_arm: bool = False
 ) -> CopyNumArray:
-    """Reduce CopyNumArray rows to a single row within each given level."""
-    # Enumerate runs of identical values
-    change_levels = enumerate_changes(levels)
-    assert (change_levels.index == levels.index).all()
+    """Reduce CopyNumArray rows to a single row within each run of equal values.
+
+    A new segment begins wherever the level changes, the chromosome (or arm, if
+    `by_arm`) changes, or -- for allele-specific data -- cn1/cn2 changes.  Each
+    boundary is detected by *adjacency* (comparing a row with its predecessor),
+    so only consecutive like rows are merged.  This stays correct when the input
+    is not sorted by genomic position -- e.g. .cns files from several segmenters
+    concatenated together -- which previously collided under integer run-id
+    arithmetic and merged non-contiguous bins into segments with start > end
+    (gh#677).  For sorted input the grouping is identical to the legacy
+    behavior, including its NaN handling.
+    """
     assert cnarr.data.index.is_unique
     assert levels.index.is_unique
-    assert change_levels.index.is_unique
+    assert len(levels) == len(cnarr)
     if by_arm:
-        # Enumerate chromosome arms
-        arm_levels = []
+        # Per-row arm id, kept in this array's row order so unsorted input is
+        # handled correctly (not just chromosome-contiguous input).
+        arm_id = pd.Series(0, index=cnarr.data.index)
         for i, (_chrom, cnarm) in enumerate(cnarr.by_arm()):
-            arm_levels.append(np.repeat(i, len(cnarm)))
-        change_levels += np.concatenate(arm_levels)
+            arm_id.loc[cnarm.data.index] = i
+        boundary = _starts_new_run(arm_id.to_numpy())
     else:
-        # Enumerate chromosomes
-        chrom_names = cnarr["chromosome"].unique()
-        chrom_col = cnarr["chromosome"].map(
-            pd.Series(np.arange(len(chrom_names)), index=chrom_names)
-        )
-        change_levels += chrom_col
-    data = cnarr.data.assign(_group=change_levels)
-    groupkey = ["_group"]
+        boundary = _starts_new_run(cnarr["chromosome"].to_numpy())
+    boundary |= _changed_between_known(levels.to_numpy())
     if "cn1" in cnarr:
         # Keep allele-specific CNAs separate
-        data["_g1"] = enumerate_changes(cnarr["cn1"])
-        data["_g2"] = enumerate_changes(cnarr["cn2"])
-        groupkey.extend(["_g1", "_g2"])
+        boundary |= _changed_between_known(cnarr["cn1"].to_numpy())
+        boundary |= _changed_between_known(cnarr["cn2"].to_numpy())
+    data = cnarr.data.assign(_group=np.cumsum(boundary))
     data = (
-        data.groupby(groupkey, as_index=False, group_keys=False, sort=False)[
+        data.groupby("_group", as_index=False, group_keys=False, sort=False)[
             data.columns
         ]
         .apply(squash_region)
@@ -89,12 +93,31 @@ def squash_by_groups(
     return cnarr.as_dataframe(data)
 
 
-def enumerate_changes(levels: Series) -> Series:
-    """Assign a unique integer to each run of identical values.
+def _starts_new_run(values: np.ndarray) -> NDArray[np.bool_]:
+    """Boolean mask, True where ``values[i]`` differs from ``values[i - 1]``.
 
-    Repeated but non-consecutive values will be assigned different integers.
+    Index 0 is always True (it starts the first run).  For never-missing keys
+    like chromosome name or arm index.
     """
-    return levels.diff().fillna(0).abs().cumsum().astype(int)
+    mask = np.ones(len(values), dtype=bool)
+    mask[1:] = values[1:] != values[:-1]
+    return mask
+
+
+def _changed_between_known(values: np.ndarray) -> NDArray[np.bool_]:
+    """Boolean mask, True where ``values[i]`` and ``values[i - 1]`` are both
+    non-NaN and differ.  Index 0 is always False.
+
+    NaN is treated as "no change" (matching the legacy run-length grouping), so
+    a row with an unknown value -- e.g. cn1/cn2 = NaN where BAF data is missing
+    -- is merged by the remaining keys instead of being split off on its own.
+    """
+    mask = np.zeros(len(values), dtype=bool)
+    if len(values) > 1:
+        v = values.astype(float)
+        known = ~np.isnan(v)
+        mask[1:] = (v[1:] != v[:-1]) & known[1:] & known[:-1]
+    return mask
 
 
 def squash_region(cnarr: DataFrame) -> DataFrame:
@@ -123,8 +146,10 @@ def squash_region(cnarr: DataFrame) -> DataFrame:
 
     out: dict = {
         "chromosome": [cnarr["chromosome"].iat[0]],
-        "start": cnarr["start"].iat[0],
-        "end": cnarr["end"].iat[-1],
+        # Span the full run via min/max (not first/last) so a run whose bins are
+        # not in ascending order can't yield start > end (gh#677).
+        "start": cnarr["start"].min(),
+        "end": cnarr["end"].max(),
     }
     out["log2"] = _wavg("log2")
     out["gene"] = join_strings(cnarr["gene"])
@@ -151,7 +176,7 @@ def squash_region(cnarr: DataFrame) -> DataFrame:
         out["p_bintest"] = cnarr["p_bintest"].max()
 
     # Preserve any remaining columns (e.g. segmetrics: sem, ci_lo, ci_hi, stdev)
-    handled = set(out.keys()) | {"_group", "_g1", "_g2"}
+    handled = set(out.keys()) | {"_group"}
     for col in cnarr.columns:
         if col in handled:
             continue

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -634,6 +634,114 @@ class OtherTests(unittest.TestCase):
         result2 = segfilters.squash_region(df_allnan)
         self.assertEqual(result2["gene"].iat[0], "-")
 
+    def test_squash_by_groups_no_cross_region_merge(self):
+        """squash_by_groups merges only contiguous runs (gh#677).
+
+        The old code combined a run-id cumsum with an integer chromosome
+        index by *addition*, which collided on position-unsorted input and
+        merged non-consecutive bins -- yielding segments with start > end and
+        a bogus end coordinate (the constant "10488" in the ticket).  This is
+        the shared segment-construction path used by HMM, CBS, and all segment
+        filters, so it is not specific to HMM or to the segmetrics command that
+        first surfaced it.  Boundaries are now detected by adjacency.
+        """
+        # chr1 appears in two runs (300-400, then 100-200) with a chr2 bin
+        # between them; all three share the same state/level.
+        df = pd.DataFrame(
+            {
+                "chromosome": ["chr1", "chr2", "chr1"],
+                "start": [300, 50, 100],
+                "end": [400, 90, 200],
+                "gene": ["-", "-", "-"],
+                "log2": [0.0, 0.0, 0.0],
+                "probes": [1, 1, 1],
+                "weight": [1.0, 1.0, 1.0],
+            }
+        )
+        cn = cnary.CopyNumArray(df)
+        levels = pd.Series([2, 2, 2], index=cn.data.index)
+        out = segfilters.squash_by_groups(cn, levels)
+        # No segment may have start >= end ...
+        self.assertTrue((out.start < out.end).all(), out.data)
+        # ... and the two chr1 runs stay separate (3 segments, not 2) with all
+        # probes conserved and no cross-chromosome absorption.
+        self.assertEqual(len(out), 3)
+        self.assertEqual(out["probes"].sum(), 3)
+
+    def test_squash_region_unsorted_span(self):
+        """squash_region spans [min start, max end] (gh#677).
+
+        A run whose bins are not in ascending order must not yield start > end.
+        """
+        df = pd.DataFrame(
+            {
+                "chromosome": ["chr1", "chr1"],
+                "start": [300, 100],
+                "end": [400, 200],
+                "gene": ["A", "A"],
+                "log2": [0.0, 0.0],
+                "probes": [1, 1],
+                "weight": [1.0, 1.0],
+            }
+        )
+        result = segfilters.squash_region(df)
+        self.assertEqual(result["start"].iat[0], 100)
+        self.assertEqual(result["end"].iat[0], 400)
+
+    def test_squash_by_groups_cn1_cn2_nan(self):
+        """Allele-specific squash splits on known cn1/cn2 changes but treats
+        NaN (missing BAF) as 'no change', matching legacy grouping (gh#677).
+
+        Without this, the adjacency check would split every NaN row off on its
+        own (NaN != NaN), changing .cns output for `call`/`ampdel` on segments
+        that lack BAF data (call sets cn1/cn2 = NaN there).
+        """
+        base = {
+            "chromosome": ["chr1"] * 4,
+            "start": [0, 100, 200, 300],
+            "end": [100, 200, 300, 400],
+            "gene": ["-"] * 4,
+            "log2": [0.0] * 4,
+            "probes": [1, 1, 1, 1],
+            "weight": [1.0] * 4,
+            "cn": [2, 2, 2, 2],
+        }
+        # A known cn1/cn2 change in the middle splits into 2 segments.
+        known = cnary.CopyNumArray(
+            pd.DataFrame({**base, "cn1": [1, 1, 2, 2], "cn2": [1, 1, 0, 0]})
+        )
+        out = segfilters.squash_by_groups(known, known["cn"])
+        self.assertEqual(len(out), 2)
+        # All-NaN cn1/cn2 (no BAF) stays merged into 1 segment, not 4.
+        allnan = cnary.CopyNumArray(
+            pd.DataFrame({**base, "cn1": [np.nan] * 4, "cn2": [np.nan] * 4})
+        )
+        out_nan = segfilters.squash_by_groups(allnan, allnan["cn"])
+        self.assertEqual(len(out_nan), 1)
+        self.assertTrue((out_nan.start < out_nan.end).all())
+
+    def test_squash_by_groups_empty_and_single(self):
+        """squash_by_groups handles empty and single-row input (gh#677)."""
+        cols = ["chromosome", "start", "end", "gene", "log2", "probes", "weight"]
+        empty = cnary.CopyNumArray(pd.DataFrame({c: [] for c in cols}))
+        self.assertEqual(len(segfilters.squash_by_groups(empty, empty["log2"])), 0)
+        one = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"],
+                    "start": [10],
+                    "end": [20],
+                    "gene": ["G"],
+                    "log2": [0.1],
+                    "probes": [1],
+                    "weight": [1.0],
+                }
+            )
+        )
+        out = segfilters.squash_by_groups(one, one["log2"])
+        self.assertEqual(len(out), 1)
+        self.assertEqual((out["start"].iat[0], out["end"].iat[0]), (10, 20))
+
 
 class VATests(unittest.TestCase):
     """Tests for the VariantArray class."""


### PR DESCRIPTION
## Summary

`segmetrics`/`segment` could emit segments with **`start > end`** and a bogus constant `end` coordinate (the `10488` in the ticket). Root cause is in the **shared** segment-construction helper `segfilters.squash_by_groups`, used by HMM, CBS, and every segment filter (`ci`/`cn`/`sem`/`ampdel`/`bic`/`cn_neutral`) — so it is **not** HMM-specific, and `segmetrics` merely *propagated* bad input rows (it never touches `start`/`end`).

`squash_by_groups` combined a run-id cumsum with an integer chromosome/arm index by **addition**. That only stays collision-free for position-sorted input. On **unsorted/interleaved chromosomes** — exactly what you get from running several segmenters independently and concatenating their `.cns` files — the sums collided and merged *non-contiguous* bins into a single segment, taking `start` from one location and `end` from another.

## Changes

- **Adjacency-based grouping.** A new run begins wherever the chromosome/arm, level, or (allele-specific) `cn1`/`cn2` changes vs the previous row — detected by comparing each row to its predecessor (`_starts_new_run` / `_changed_between_known`), then `np.cumsum`. Order-independent, no integer collisions.
- **`_changed_between_known` treats NaN as "no change"**, so missing-BAF `cn1`/`cn2 = NaN` (set by `call`) groups identically to the legacy `enumerate_changes` — verified across all NaN patterns.
- **Per-row arm ids** so the `by_arm` path is order-independent too.
- **`squash_region` spans `[start.min(), end.max()]`** instead of first/last, so a run whose bins aren't in ascending order can't yield `start > end`.
- Removed the now-unused `enumerate_changes` helper.

## Clinical-output impact

**None for well-formed (sorted, non-overlapping) data.** Empirically verified that the new grouping reproduces the legacy grouping exactly for sorted input (including every NaN pattern), and `min/max == first/last` for sorted non-overlapping segments. Only previously-broken unsorted inputs change — from garbage (`start > end`) to correct contiguous segments.

## Testing

- New regression tests: non-contiguous cross-region merge, unsorted span, `cn1`/`cn2` NaN merging, empty/single-row inputs.
- 140 tests pass (`test_cnvlib`, `test_commands`, `test_genome`, `test_io`, `test_r` — the last exercises real CBS/flasso segmentation through this path); `mypy` clean; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)