### PR TITLE
CI: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,16 +28,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for version info
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -45,7 +45,7 @@ jobs:
       # Uncomment to enable GitHub Container Registry as backup
       # - name: Log in to GitHub Container Registry
       #   if: github.event_name != 'pull_request'
-      #   uses: docker/login-action@v3
+      #   uses: docker/login-action@v4
       #   with:
       #     registry: ghcr.io
       #     username: ${{ github.actor }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
@@ -83,7 +83,7 @@ jobs:
             org.opencontainers.image.vendor=Eric Talevich
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,25 +18,25 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
-          
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y liblzma-dev python3-dev r-bioc-dnacopy zlib1g-dev poppler-utils
-          
+
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip setuptools wheel
           pip install -r requirements/tests.txt
           pip install -e .
-          
+
       - name: Run integration tests
         run: |
           cd test/

--- a/.github/workflows/tests-tox.yaml
+++ b/.github/workflows/tests-tox.yaml
@@ -31,14 +31,14 @@ jobs:
           - {name: Security, python: '3.12', os: ubuntu-latest, tox: security}
           - {name: Coverage, python: '3.12', os: ubuntu-latest, tox: coverage}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
       - name: Cache tox environments
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .tox
           key: tox-${{ matrix.tox }}-${{ matrix.python }}-${{ hashFiles('requirements/*.txt', 'pyproject.toml') }}
@@ -62,7 +62,7 @@ jobs:
         run: tox -e ${{ matrix.tox }}
       - name: Upload coverage to Codecov
         if: matrix.tox == 'coverage'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage.xml
           flags: unittests


### PR DESCRIPTION
## Why
GitHub is [deprecating the Node 20 action runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (Node 20 EOL April 2026; hosted runners default to Node 24 on **2026-06-16**, full removal Fall 2026). Nothing is breaking yet, but CI currently surfaces a *"Node.js 20 actions are deprecated"* warning. I verified that **every** action pinned in our workflows resolved to `runs.using: node20`, so all of them contribute to the warning.

## What
Bump each third-party action to its latest stable major, all of which run on **node24** (codecov v5+ is now a *composite* action rather than node-based):

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-python` | v5 | **v6** |
| `actions/cache` | v4 | **v5** |
| `codecov/codecov-action` | v4 | **v6** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/login-action` | v3 | **v4** |
| `docker/metadata-action` | v5 | **v6** |
| `docker/build-push-action` | v6 | **v7** |

`anthropics/claude-code-action@beta` is upstream-managed (no version pin), so it's left unchanged.

## Breaking-change review
I checked release notes for every bump. All breaking changes are either the node24 runtime itself (the point of this PR) or removal of inputs/envs this repo doesn't use:
- **codecov v4→v6**: input renames (`file`→`files`, `plugin`→`plugins`) landed in v5; we already use `files` and no `plugin`. All our inputs (`files`/`flags`/`name`/`fail_ci_if_error`/`token`/`disable_search`) remain valid. `fail_ci_if_error: false` also caps blast radius.
- **docker/build-push v6→v7**: removes deprecated `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs — we set neither.
- **checkout v5→v6**: moves credential persistence to a separate file; no effect on our usage. Requires runner ≥ v2.327.1, which GitHub-hosted runners already exceed.

Also trims some pre-existing trailing whitespace on blank lines in `integration-tests.yaml`.

## Clinical-impact note
Pure CI-config change. **No impact on cnvkit numerical output or file formats** (`.cnr`/`.cns`/`.cnn`/SEG/VCF).

## Validation
- All four workflow files parse as YAML; repo pre-commit hooks pass.
- Real validation is this PR's own CI run: confirm the Node 20 deprecation warning is gone and all matrix jobs (incl. Codecov upload + Docker build) pass.

Tracked as `cnvkit-e0e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)