### PR TITLE
Fix segment crash on NaN log2 bins via in-memory path (gh#881)

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -204,6 +204,17 @@ def _do_segmentation(
         return cnarr
 
     filtered_cn = cnarr.copy()
+    # Drop bins with no log2 value before any analysis (gh#881). They carry no
+    # signal and cannot be segmented, but a bare comparison treats NaN as False,
+    # so without this they survive the gates below and reach either the
+    # Savitzky-Golay outlier filter (scipy's lstsq rejects non-finite input) or
+    # DNAcopy's CBS -- both of which then crash. read_tab drops them on the file
+    # path; do it here too for the in-memory/API path (e.g. batch).
+    log2_missing = filtered_cn["log2"].isna()
+    n_log2_missing = int(log2_missing.sum())
+    if n_log2_missing:
+        filtered_cn = filtered_cn[~log2_missing]
+        logging.info("Dropped %d bins with missing log2 values", n_log2_missing)
     # Filter out bins with no or near-zero sequencing coverage
     if skip_low:
         filtered_cn = filtered_cn.drop_low_coverage(verbose=False)

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -536,6 +536,39 @@ class OtherTests(unittest.TestCase):
         self.assertEqual(result2["weight"].iat[0], 0.0)
         self.assertEqual(result2["depth"].iat[0], 0.0)
 
+    def test_do_segmentation_drops_nan_log2(self):
+        """do_segmentation tolerates NaN-log2 bins on the default path (gh#881).
+
+        Without --drop-low-coverage (skip_low=False), NaN-log2 bins are never
+        filtered before drop_outliers' Savitzky-Golay smoother, whose scipy
+        lstsq rejects non-finite input ("array must not contain infs or NaNs"),
+        crashing segmentation long before reaching DNAcopy. The NaN bins must be
+        dropped first. Uses the pure-Python 'haar' method so no R is required;
+        the savgol outlier path that crashed is shared by every method.
+        """
+        n = 120  # > drop_outliers' width (50) so savgol actually runs
+        rng = np.random.default_rng(0)
+        log2 = rng.normal(0, 0.2, n)
+        log2[5] = np.nan  # inside the leading savgol edge window
+        log2[60] = np.nan
+        cnarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * n,
+                    "start": np.arange(0, n * 1000, 1000),
+                    "end": np.arange(1000, n * 1000 + 1000, 1000),
+                    "gene": ["G"] * n,
+                    "log2": log2,
+                    "depth": np.ones(n) * 100.0,
+                    "weight": np.ones(n),
+                }
+            )
+        )
+        # Must not raise, and no NaN should leak into the segment log2 values
+        cns = segmentation.do_segmentation(cnarr, "haar", processes=1)
+        self.assertGreater(len(cns), 0)
+        self.assertFalse(np.isnan(cns["log2"].to_numpy()).any())
+
     def test_squash_region_nan_weights(self):
         """squash_region handles NaN weights without NaN in output."""
         df = pd.DataFrame(

--- a/test/test_r.py
+++ b/test/test_r.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 import logging
 
+import numpy as np
 import pytest
 
 logging.basicConfig(level=logging.ERROR, format="%(message)s")
@@ -61,6 +62,25 @@ class RTests(unittest.TestCase):
                 )
         # No exception means the weights stayed aligned with the kept probes.
         self.assertIn("test868", seg_out.decode())
+
+    @pytest.mark.slow
+    def test_cbs_nan_log2_in_memory(self):
+        """CBS segments an in-memory .cnr with NaN log2 values (gh#881).
+
+        The reporter ran ``segment`` (no --drop-low-coverage) on a .cnr with NaN
+        values and hit ``subprocess.CalledProcessError``. The file-read path is
+        guarded by read_tab, but an in-memory CopyNumArray (e.g. from batch)
+        reaches segmentation with the NaN bins intact. They must be dropped
+        before the Savitzky-Golay outlier filter and DNAcopy, not crash.
+        """
+        cnr = self.tas_cnr.copy()
+        log2 = cnr["log2"].to_numpy().copy()
+        # Scatter a few NaN values across the bins, as a degenerate .cnr would
+        log2[[3, 50, 120, len(log2) - 2]] = np.nan
+        cnr["log2"] = log2
+        cns = segmentation.do_segmentation(cnr, "cbs", processes=1)
+        self.assertGreater(len(cns), 0)
+        self.assertFalse(np.isnan(cns["log2"].to_numpy()).any())
 
     @pytest.mark.slow
     def test_cbs_all_bins_unsegmentable(self):


### PR DESCRIPTION
## Summary

Fixes #881 — `cnvkit.py segment` raised `subprocess.CalledProcessError` / a scipy `ValueError` on `.cnr` files containing NaN values.

Rechecking the cause (after #868 and the coverage→log2 boundary hardening): the reporter's R-level error — *"length of weights should be the same as the number of probes"* — is the **#868 mechanism** (R's `read.delim` turns an empty/`NA` chromosome or maploc into `NA`, DNAcopy's `CNA()` silently drops those markers, and the `weights` vector is then too long). That is already fixed on master.

This PR closes a **remaining gap on the default `segment` path** (`skip_low=False`): a `CopyNumArray` carrying NaN `log2` reaches `drop_outliers` → `rolling_outlier_quantile` → `savgol` → scipy `lstsq` (`check_finite=True`), which raises **"array must not contain infs or NaNs"** — crashing *before* R is ever invoked. The file-read path is shielded by `skgenome.tabio.tab.read_tab` (drops NaN-`log2` at read time), but the in-memory / API path (e.g. `batch`) is not.

## Fix

`_do_segmentation` now drops NaN-`log2` bins up front, before any analysis. Such bins carry no signal and cannot be segmented; this mirrors what `read_tab` and the CBS R script already do independently.

## Clinical impact

**None for valid inputs.** The new branch only executes when NaN `log2` is present (`n_log2_missing > 0`); normal `.cnr` segmentation output is unchanged. The change only converts a crash into correct output for degenerate inputs. No change to `.cnr`/`.cns`/SEG output format.

## Tests

- `test_do_segmentation_drops_nan_log2` — fast, no R required (uses `haar`, which shares the savgol outlier crash site).
- `test_cbs_nan_log2_in_memory` — slow, exercises the full CBS/R path end-to-end on an in-memory NaN-`log2` `.cnr`.

Both fail before the fix and pass after. `mypy` + `ruff` clean; `test_cnvlib` (27), `test_r` (5), and segment/batch command tests (9) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)