### PR TITLE
Add regression test guarding R invocation against --vanilla (gh#491)

### DIFF
--- a/test/test_r.py
+++ b/test/test_r.py
@@ -4,6 +4,7 @@
 import tempfile
 import unittest
 import logging
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -81,6 +82,38 @@ class RTests(unittest.TestCase):
         cns = segmentation.do_segmentation(cnr, "cbs", processes=1)
         self.assertGreater(len(cns), 0)
         self.assertFalse(np.isnan(cns["log2"].to_numpy()).any())
+
+    def test_cbs_invocation_omits_vanilla(self):
+        """Regression test for issue #491.
+
+        ``--vanilla`` bundles ``--no-init-file``/``--no-site-file``, so R skips
+        the user's ``.Rprofile``/``Rprofile.site`` -- breaking custom installs
+        that set ``.libPaths()`` there. The segmentation R call must pass only
+        ``--no-restore --no-environ``. We mock ``call_quiet`` to capture the
+        argv before R runs, so this test needs no R installation (hence it is
+        not marked ``slow``).
+        """
+        captured = []
+
+        class _StopBeforeR(Exception):
+            pass
+
+        def fake_call_quiet(*args):
+            captured.append(args)
+            raise _StopBeforeR
+
+        with mock.patch.object(core, "call_quiet", fake_call_quiet):
+            with self.assertRaises(_StopBeforeR):
+                segmentation._do_segmentation(
+                    self.tas_cnr, "cbs", None, 0.0001, skip_outliers=0
+                )
+
+        argv = captured[0]
+        self.assertNotIn("--vanilla", argv)
+        self.assertNotIn("--no-init-file", argv)
+        self.assertNotIn("--no-site-file", argv)
+        self.assertIn("--no-restore", argv)
+        self.assertIn("--no-environ", argv)
 
     @pytest.mark.slow
     def test_cbs_all_bins_unsegmentable(self):


### PR DESCRIPTION
Fixes #491

## Summary

Closes the long-standing **gh#491** ("Use of `--vanilla` to call R breaks custom R installs"). The underlying defect is **already fixed** in the current code — `cnvlib/segmentation/__init__.py` invokes R as:

```python
core.call_quiet(rscript_path, "--no-restore", "--no-environ", script_fname)
```

No `--vanilla` anywhere. The distinction matters: `--vanilla` bundles `--no-init-file`/`--no-site-file`, which make R skip `Rprofile.site`/`.Rprofile` — exactly where admins set `.libPaths()` for custom R installs. The current flags keep reproducibility (no stale workspace via `--no-restore`, no stray env via `--no-environ`) while still loading site/init profiles.

## What this PR adds

A **regression guard** so `--vanilla` (or `--no-init-file`/`--no-site-file`) can't silently creep back in: `test_r.py::RTests::test_cbs_invocation_omits_vanilla`. It mocks `core.call_quiet` to capture the real argv and raise *before* R runs, then asserts the flag set.

Because it never touches R, it runs in the normal suite (~2s) rather than the R-gated `@pytest.mark.slow` group — unlike every other test in that file.

## Testing
- `pytest test/test_r.py::RTests::test_cbs_invocation_omits_vanilla` passes (2.2s, no R needed)
- `ruff check` / `ruff format --check` clean

## Clinical-output impact
None — test-only addition. No changes to `.cnr`/`.cns`/`.cnn`/SEG/VCF output or any numerical behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)