### PR TITLE
Add regression test for variant re-segmentation crash (gh#1004)

### DIFF
--- a/test/test_hmm.py
+++ b/test/test_hmm.py
@@ -10,6 +10,8 @@ from numpy.testing import assert_allclose, assert_array_equal
 from scipy.special import betaln, gammaln
 from scipy.stats import betabinom as sp_betabinom
 
+from cnvlib import segmentation
+from cnvlib.cnary import CopyNumArray as CNA
 from cnvlib.segmentation.hmm import (
     BETABINOM_RHO,
     _batched_emission_baf,
@@ -406,6 +408,57 @@ class VariantsInSegmentTests(unittest.TestCase):
         result = variants_in_segment(varr, segment)
         self.assertEqual(result.iloc[0]["gene"], "TP53")
         self.assertAlmostEqual(result.iloc[0]["log2"], -0.5)
+
+
+class VariantReSegmentationIntegrationTests(unittest.TestCase):
+    """Integration tests for the BAF re-segmentation glue in _do_segmentation.
+
+    The reporter of gh#1004 ran ``segment --method cbs --vcf ... --smooth-cbs``
+    and crashed inside ``variants_in_segment`` with ``'Series' object has no
+    attribute 'reshape'`` -- the pre-rewrite code called ``observations.reshape``
+    on a pandas Series. That call is reached for *any* non-HMM method via
+    ``variants.by_ranges(segarr)`` in ``_do_segmentation``, so we drive the same
+    path R-free with ``method="none"``. The unit tests above exercise
+    ``variants_in_segment`` in isolation; this covers the ``by_ranges`` ->
+    ``pd.concat`` -> ``baf_by_ranges`` integration the pool actually hits.
+    """
+
+    def test_variant_resegmentation_no_crash(self):
+        nbins = 60
+        starts = np.arange(0, nbins * 1000, 1000)
+        cnr = CNA(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * nbins,
+                    "start": starts,
+                    "end": starts + 1000,
+                    "gene": ["-"] * nbins,
+                    "log2": np.zeros(nbins),
+                    "depth": np.full(nbins, 100.0),
+                    "weight": np.ones(nbins),
+                }
+            )
+        )
+        # 120 SNVs whose BAF shifts 0.5 -> 0.67 midway, so re-segmentation runs
+        # the Viterbi path (>50 variants) that used to crash on Series.reshape.
+        rng = np.random.default_rng(0)
+        n = 120
+        alt_freqs = np.concatenate(
+            [rng.normal(0.5, 0.02, n // 2), rng.normal(0.67, 0.02, n // 2)]
+        ).clip(0.01, 0.99)
+        vstart = np.linspace(0, nbins * 1000 - 2, n).astype(int)
+        varr = _make_variant_array(
+            ["chr1"] * n, vstart.tolist(), (vstart + 1).tolist(), alt_freqs.tolist()
+        )
+
+        segarr = segmentation._do_segmentation(
+            cnr, "none", None, None, variants=varr, skip_outliers=0
+        )
+        # The BAF shift splits the single 'none' segment into >= 2 pieces ...
+        self.assertGreaterEqual(len(segarr), 2)
+        # ... with valid coordinates and a populated BAF column (gh#1004).
+        self.assertTrue((segarr["start"] < segarr["end"]).all())
+        self.assertIn("baf", segarr.data.columns)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1004

## Summary

Resolves **gh#1004** ("segment command errors out with `'Series' object has no attribute 'reshape'`").

The reporter ran `cnvkit.py segment --method cbs --vcf ... --smooth-cbs --processes 8` and hit, inside the process pool:

```
File ".../cnvlib/segmentation/hmm.py", line 401, in variants_in_segment
    X_3d = observations.reshape(1, -1, 1).astype(np.float32)
AttributeError: 'Series' object has no attribute 'reshape'
```

The pre-rewrite code called `.reshape(1, -1, 1)` (pomegranate/hmmlearn's 3D input shape) directly on the pandas Series returned by `mirrored_baf()`. The **pomegranate→numpy rewrite (`1ff3dc8`)** replaced that with `observations.to_numpy(...)` and a hand-rolled Viterbi HMM, so the crash is already fixed on `master`. This PR adds the missing regression coverage.

## Why a new test (the gap)

`VariantsInSegmentTests` already exercises `variants_in_segment` in isolation, but nothing covers the **`_do_segmentation` integration glue** the reporter actually hit:

```python
newsegs = [variants_in_segment(subvarr, segment)
           for segment, subvarr in variants.by_ranges(segarr)]
segarr = segarr.as_dataframe(pd.concat(newsegs))
segarr["baf"] = variants.baf_by_ranges(segarr)
```

That re-segmentation runs for **any** non-HMM method, so the new test drives the identical path R-free via `method="none"` — a `.cnr` plus a `VariantArray` whose BAF shifts 0.5→0.67 midway (>50 variants → the Viterbi path that contained the crashing line). It asserts the segment splits, coordinates stay valid, and the `baf` column is populated. **This test would have failed with the original `AttributeError`.**

## Testing
- `pytest test/test_hmm.py -k "VariantsInSegment or VariantReSegmentation"` → 6 passed (~2s, no R needed)
- `ruff check` / `ruff format --check` clean
- Manually reproduced the full path end-to-end (2 segments, breakpoint at the BAF shift, `baf` populated)

## Clinical-output impact
None — test-only addition. No changes to `.cnr`/`.cns`/`.cnn`/SEG/VCF output or numerical behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)