### PR TITLE
Fix variant re-segmentation crash/mis-slice on unsorted VCF (#893)

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -97,6 +97,16 @@ def do_segmentation(
             return cnarr, ""
         return cnarr
 
+    if variants is not None and len(variants):
+        # Process variants in genomic order. by_ranges/baf_by_ranges slice via
+        # binary search and the HMM expects an ordered observation sequence, so
+        # an unsorted input VCF -- which nothing upstream sorts -- mis-assigns
+        # variants to segments (silently wrong BAF) and crashes downstream in
+        # variants_in_segment with "Improper post-processing of segment"
+        # (#893). Copy first so we don't mutate the caller's array.
+        variants = variants.copy()
+        variants.sort()
+
     if not threshold:
         threshold = {
             "cbs": 0.0001,

--- a/cnvlib/segmentation/hmm.py
+++ b/cnvlib/segmentation/hmm.py
@@ -871,6 +871,15 @@ def variants_in_segment(varr, segment, min_variants=MIN_VARIANTS_THRESHOLD):
     results = None
 
     if len(varr) > min_variants:
+        # Process variants in genomic order. The 2-state HMM's transition model
+        # assumes a position-sorted observation sequence, and squash_by_groups
+        # merges by row adjacency -- so out-of-order rows (e.g. from an unsorted
+        # input VCF, which nothing upstream sorts) produce genomically
+        # overlapping segments whose midpoint breakpoints come out non-monotonic,
+        # yielding start >= end downstream (#893). Copy first so we don't
+        # mutate the caller's array.
+        varr = varr.copy()
+        varr.sort()
         observations = varr.mirrored_baf(above_half=True)
 
         if len(observations) > 0:

--- a/test/test_hmm.py
+++ b/test/test_hmm.py
@@ -10,6 +10,8 @@ from numpy.testing import assert_allclose, assert_array_equal
 from scipy.special import betaln, gammaln
 from scipy.stats import betabinom as sp_betabinom
 
+from cnvlib import segmentation
+from cnvlib.cnary import CopyNumArray as CNA
 from cnvlib.segmentation.hmm import (
     BETABINOM_RHO,
     _batched_emission_baf,
@@ -406,6 +408,103 @@ class VariantsInSegmentTests(unittest.TestCase):
         result = variants_in_segment(varr, segment)
         self.assertEqual(result.iloc[0]["gene"], "TP53")
         self.assertAlmostEqual(result.iloc[0]["log2"], -0.5)
+
+    def test_unsorted_variants_no_crash(self):
+        """Regression test for #893.
+
+        An input VCF that isn't position-sorted reaches variants_in_segment
+        with rows out of genomic order -- nothing in the pipeline sorts
+        variants. The 2-state HMM must process observations in genomic order;
+        otherwise squash_by_groups (which groups by row adjacency) emits
+        genomically overlapping segments, the midpoint breakpoints come out
+        non-monotonic, and post-processing produces a segment with
+        ``start >= end`` -- the "Improper post-processing of segment"
+        RuntimeError the reporter hit.
+        """
+        rng = np.random.default_rng(1)
+        n = 120
+        alt_freqs = np.concatenate(
+            [rng.normal(0.5, 0.02, n // 2), rng.normal(0.67, 0.02, n // 2)]
+        ).clip(0.01, 0.99)
+        pos = np.linspace(1000, 190000, n).astype(int)
+        perm = np.arange(n)
+        rng.shuffle(perm)  # scramble row order: rows no longer position-sorted
+        varr = _make_variant_array(
+            ["chr1"] * n,
+            pos[perm].tolist(),
+            (pos[perm] + 1).tolist(),
+            alt_freqs[perm].tolist(),
+        )
+        segment = _make_segment("chr1", 0, 200000, log2=-0.03, probes=n)
+        result = variants_in_segment(varr, segment, min_variants=50)
+        # No RuntimeError, and every output segment has valid coordinates ...
+        self.assertTrue((result["start"] < result["end"]).all())
+        # ... and the BAF shift is still recovered as a breakpoint despite the
+        # scrambled input, spanning the full parent segment.
+        self.assertGreaterEqual(len(result), 2)
+        self.assertEqual(result.iloc[0]["start"], 0)
+        self.assertEqual(result.iloc[-1]["end"], 200000)
+
+
+class VariantReSegmentationOrderTests(unittest.TestCase):
+    """#893: variant re-segmentation must not depend on input VCF row order.
+
+    by_ranges/baf_by_ranges slice variants by binary search, so an unsorted
+    input VCF mis-assigns variants to segments (silently wrong BAF) and crashes
+    variants_in_segment. do_segmentation must sort variants up front, making its
+    output invariant to the order in which variants are supplied. This drives
+    the full do_segmentation pipeline R-free via method="none".
+    """
+
+    def test_segmentation_invariant_to_variant_order(self):
+        nbins = 60
+        starts = np.arange(0, nbins * 1000, 1000)
+        cnr = CNA(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * nbins,
+                    "start": starts,
+                    "end": starts + 1000,
+                    "gene": ["-"] * nbins,
+                    "log2": np.zeros(nbins),
+                    "depth": np.full(nbins, 100.0),
+                    "weight": np.ones(nbins),
+                }
+            )
+        )
+        rng = np.random.default_rng(0)
+        n = 200
+        alt_freqs = np.concatenate(
+            [rng.normal(0.5, 0.02, n // 2), rng.normal(0.67, 0.02, n // 2)]
+        ).clip(0.01, 0.99)
+        pos = np.linspace(0, nbins * 1000 - 2, n).astype(int)
+        sorted_varr = _make_variant_array(
+            ["chr1"] * n, pos.tolist(), (pos + 1).tolist(), alt_freqs.tolist()
+        )
+        perm = rng.permutation(n)
+        shuffled_varr = _make_variant_array(
+            ["chr1"] * n,
+            pos[perm].tolist(),
+            (pos[perm] + 1).tolist(),
+            alt_freqs[perm].tolist(),
+        )
+
+        seg_sorted = segmentation.do_segmentation(
+            cnr, "none", variants=sorted_varr, processes=1
+        )
+        seg_shuffled = segmentation.do_segmentation(
+            cnr, "none", variants=shuffled_varr, processes=1
+        )
+
+        # Same breakpoints and BAF regardless of input variant order (#893) ...
+        assert_array_equal(
+            seg_sorted["start"].to_numpy(), seg_shuffled["start"].to_numpy()
+        )
+        assert_array_equal(seg_sorted["end"].to_numpy(), seg_shuffled["end"].to_numpy())
+        assert_allclose(seg_sorted["baf"].to_numpy(), seg_shuffled["baf"].to_numpy())
+        # ... and the BAF shift actually split the single 'none' segment.
+        self.assertGreaterEqual(len(seg_sorted), 2)
+        self.assertTrue((seg_sorted["start"] < seg_sorted["end"]).all())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #893 — `segment --vcf` crashing with `RuntimeError: Improper post-processing of segment ... start >= end` in `hmm.variants_in_segment`.

**Root cause:** the input VCF was not position-sorted, and nothing upstream sorts variants. Unsorted rows break the variant re-segmentation in two ways:

1. **Mis-slicing (silently wrong output).** `do_segmentation` slices variants per segment with `variants.by_ranges()` / `variants.baf_by_ranges()`, which use binary search (`searchsorted`) — only correct on sorted input. Unsorted variants are assigned to the wrong segments, producing **wrong per-segment BAF**, not just a crash. Demonstrated: for the same data, sorted vs. shuffled gave per-segment counts `[63, 57]` vs `[36, 57]` and BAF `0.4605` vs `0.5664`.
2. **The crash.** `variants_in_segment`'s 2-state HMM assumes a position-ordered observation sequence, and `squash_by_groups` merges by *row adjacency*. Out-of-order rows yield genomically overlapping groups, so the midpoint breakpoints come out non-monotonic → `start >= end` → the `RuntimeError`.

## Fix

- Sort the variants (on a **copy**, so the caller's array isn't mutated) once at `do_segmentation` entry — fixes the slicing *and* the HMM-path ordering.
- Defensively sort inside `variants_in_segment` so the function is correct in isolation (it's exported and unit-tested directly).

The HMM/Viterbi processing variants in genomic order is also simply *correct* — out-of-order observations make the transition model meaningless.

## Clinical-output impact

For an already position-sorted VCF (the normal case), `sort()` is a stable no-op (mergesort preserves order), so `.cns`/BAF output is **byte-identical**. Output changes only for previously-broken inputs: unsorted VCFs went from crash (non-HMM methods) or silently-wrong BAF → correct, order-invariant results.

## Testing
- `VariantsInSegmentTests::test_unsorted_variants_no_crash` — the unit-level crash (fails on master with the exact `RuntimeError`).
- `VariantReSegmentationOrderTests::test_segmentation_invariant_to_variant_order` — full `do_segmentation` output is invariant to variant input order (guards the mis-slicing). R-free via `method="none"`.
- Full `test_hmm.py` (23) pass; `mypy` clean; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)