### PR TITLE
Restore bare #NNN issue references (drop gh# prefix)

### DIFF
--- a/cnvlib/autobin.py
+++ b/cnvlib/autobin.py
@@ -144,7 +144,7 @@ def do_autobin(
 
     # A non-finite or non-positive target depth means no reads were found in
     # the sampled/accessible regions -- give an actionable error rather than a
-    # cryptic "cannot convert float NaN to integer" downstream (gh#421).
+    # cryptic "cannot convert float NaN to integer" downstream (#421).
     if tgt_depth is None or not np.isfinite(tgt_depth) or tgt_depth <= 0:
         raise ValueError(
             f"Could not estimate read depth in the target regions of "

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -406,7 +406,7 @@ def interval_coverages_count(
         ) from None
     regions = tabio.read_auto(bed_fname)
     # Skip regions on contigs absent from the BAM: pysam.fetch raises
-    # "invalid contig" on them, same chrom-name-mismatch class as gh#620.
+    # "invalid contig" on them, same chrom-name-mismatch class as #620.
     bam_chroms = samutil.get_bam_chroms(bam_fname, fasta)
     present = [
         (chrom, subr) for chrom, subr in regions.by_chromosome() if chrom in bam_chroms
@@ -512,7 +512,7 @@ def interval_coverages_pileup(
     # Regions on contigs absent from the BAM header make samtools bedcov fail;
     # filter them out per call so a chrom-name mismatch on some (but not all)
     # regions doesn't abort the run -- and so the result is independent of how
-    # the BED is split across processes (gh#620).
+    # the BED is split across processes (#620).
     bam_chroms = samutil.get_bam_chroms(bam_fname, fasta)
     if procs == 1:
         table = bedcov(bed_fname, bam_fname, min_mapq, fasta, bam_chroms=bam_chroms)
@@ -614,7 +614,7 @@ def bedcov(
     bam_chroms : set of str, optional
         Reference names present in the BAM header. When given, BED regions on
         any other contig are dropped before calling samtools, which otherwise
-        aborts on regions whose contig is absent from the BAM (gh#620).
+        aborts on regions whose contig is absent from the BAM (#620).
     """
     try:
         import pysam

--- a/cnvlib/segfilters.py
+++ b/cnvlib/segfilters.py
@@ -62,7 +62,7 @@ def squash_by_groups(
     is not sorted by genomic position -- e.g. .cns files from several segmenters
     concatenated together -- which previously collided under integer run-id
     arithmetic and merged non-contiguous bins into segments with start > end
-    (gh#677).  For sorted input the grouping is identical to the legacy
+    (#677).  For sorted input the grouping is identical to the legacy
     behavior, including its NaN handling.
     """
     assert cnarr.data.index.is_unique
@@ -147,7 +147,7 @@ def squash_region(cnarr: DataFrame) -> DataFrame:
     out: dict = {
         "chromosome": [cnarr["chromosome"].iat[0]],
         # Span the full run via min/max (not first/last) so a run whose bins are
-        # not in ascending order can't yield start > end (gh#677).
+        # not in ascending order can't yield start > end (#677).
         "start": cnarr["start"].min(),
         "end": cnarr["end"].max(),
     }

--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -204,7 +204,7 @@ def _do_segmentation(
         return cnarr
 
     filtered_cn = cnarr.copy()
-    # Drop bins with no log2 value before any analysis (gh#881). They carry no
+    # Drop bins with no log2 value before any analysis (#881). They carry no
     # signal and cannot be segmented, but a bare comparison treats NaN as False,
     # so without this they survive the gates below and reach either the
     # Savitzky-Golay outlier filter (scipy's lstsq rejects non-finite input) or

--- a/skgenome/tabio/vcfio.py
+++ b/skgenome/tabio/vcfio.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     )
 
 
-# Strelka reports per-base counts (tier1, tier2) instead of GT/AD (gh#943)
+# Strelka reports per-base counts (tier1, tier2) instead of GT/AD (#943)
 _STRELKA_TIER1_FIELD = {"A": "AU", "C": "CU", "G": "GU", "T": "TU"}
 
 
@@ -60,7 +60,7 @@ def read_vcf(
     try:
         vcf_reader = pysam.VariantFile(infile)
     except (OSError, ValueError) as exc:
-        # e.g. a malformed header (FORMAT column declared but no samples, gh#680)
+        # e.g. a malformed header (FORMAT column declared but no samples, #680)
         raise ValueError(f"Could not read VCF file {infile!r}: {exc}") from exc
     if vcf_reader.header.samples:
         sid, nid = _choose_samples(vcf_reader, sample_id, normal_id)
@@ -347,7 +347,7 @@ def _get_zygosity(
     """Get the zygosity (0=hom-ref, 0.5=het, 1=hom-alt) of a sample's genotype.
 
     Use the explicit GT call when present and complete; otherwise -- when GT is
-    absent (e.g. Strelka, gh#943) or a no-call (``./.``) -- infer it from the
+    absent (e.g. Strelka, #943) or a no-call (``./.``) -- infer it from the
     alternate-allele frequency.
     """
     if "GT" in sample:

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -415,7 +415,7 @@ class OtherTests(unittest.TestCase):
         )
 
     def test_drop_low_coverage_drops_nan(self):
-        """drop_low_coverage removes NaN-log2 bins, not just the sentinel (gh#521).
+        """drop_low_coverage removes NaN-log2 bins, not just the sentinel (#521).
 
         A bare ``log2 < min_cvg`` comparison is False for NaN, so without
         explicit NaN handling, NaN bins survive into segmentation and trigger
@@ -430,7 +430,7 @@ class OtherTests(unittest.TestCase):
         self.assertEqual(len(kept), 3)
 
     def test_mask_bad_bins_flags_nan(self):
-        """mask_bad_bins treats NaN log2/spread reference bins as bad (gh#521)."""
+        """mask_bad_bins treats NaN log2/spread reference bins as bad (#521)."""
         n = 5
         ref = cnary.CopyNumArray(
             pd.DataFrame(
@@ -537,7 +537,7 @@ class OtherTests(unittest.TestCase):
         self.assertEqual(result2["depth"].iat[0], 0.0)
 
     def test_do_segmentation_drops_nan_log2(self):
-        """do_segmentation tolerates NaN-log2 bins on the default path (gh#881).
+        """do_segmentation tolerates NaN-log2 bins on the default path (#881).
 
         Without --drop-low-coverage (skip_low=False), NaN-log2 bins are never
         filtered before drop_outliers' Savitzky-Golay smoother, whose scipy
@@ -668,7 +668,7 @@ class OtherTests(unittest.TestCase):
         self.assertEqual(result2["gene"].iat[0], "-")
 
     def test_squash_by_groups_no_cross_region_merge(self):
-        """squash_by_groups merges only contiguous runs (gh#677).
+        """squash_by_groups merges only contiguous runs (#677).
 
         The old code combined a run-id cumsum with an integer chromosome
         index by *addition*, which collided on position-unsorted input and
@@ -702,7 +702,7 @@ class OtherTests(unittest.TestCase):
         self.assertEqual(out["probes"].sum(), 3)
 
     def test_squash_region_unsorted_span(self):
-        """squash_region spans [min start, max end] (gh#677).
+        """squash_region spans [min start, max end] (#677).
 
         A run whose bins are not in ascending order must not yield start > end.
         """
@@ -723,7 +723,7 @@ class OtherTests(unittest.TestCase):
 
     def test_squash_by_groups_cn1_cn2_nan(self):
         """Allele-specific squash splits on known cn1/cn2 changes but treats
-        NaN (missing BAF) as 'no change', matching legacy grouping (gh#677).
+        NaN (missing BAF) as 'no change', matching legacy grouping (#677).
 
         Without this, the adjacency check would split every NaN row off on its
         own (NaN != NaN), changing .cns output for `call`/`ampdel` on segments
@@ -754,7 +754,7 @@ class OtherTests(unittest.TestCase):
         self.assertTrue((out_nan.start < out_nan.end).all())
 
     def test_squash_by_groups_empty_and_single(self):
-        """squash_by_groups handles empty and single-row input (gh#677)."""
+        """squash_by_groups handles empty and single-row input (#677)."""
         cols = ["chromosome", "start", "end", "gene", "log2", "probes", "weight"]
         empty = cnary.CopyNumArray(pd.DataFrame({c: [] for c in cols}))
         self.assertEqual(len(segfilters.squash_by_groups(empty, empty["log2"])), 0)

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -117,7 +117,7 @@ class PreprocessingTests(unittest.TestCase):
     def test_autobin_chrom_name_mismatch(self):
         """WGS autobin gives a clear, actionable error -- not the cryptic
         'cannot convert float NaN to integer' -- when the BAM and access
-        regions share no chromosome names (gh#421)."""
+        regions share no chromosome names (#421)."""
         bam_fname = "formats/na12878-chrM-Y-trunc.bam"
         # Access regions on a contig absent from the BAM => no shared chroms,
         # so the estimated read depth is NaN.
@@ -132,7 +132,7 @@ class PreprocessingTests(unittest.TestCase):
 
     def test_bedcov_filters_absent_contigs(self):
         """bedcov keeps regions on BAM contigs and drops those on absent
-        contigs instead of erroring out entirely (gh#620)."""
+        contigs instead of erroring out entirely (#620)."""
         bam = "formats/na12878-chrM-Y-trunc.bam"
         bam_chroms = samutil.get_bam_chroms(bam)
         with tempfile.NamedTemporaryFile("w+t", suffix=".bed", delete=False) as f:
@@ -168,7 +168,7 @@ class PreprocessingTests(unittest.TestCase):
     def test_coverage_partial_chrom_mismatch(self):
         """coverage tolerates a BED mixing present and absent contigs,
         returning only the present-contig regions, for any process count and
-        either depth/count method (gh#620: failure was process-count- and
+        either depth/count method (#620: failure was process-count- and
         method-dependent)."""
         bam = "formats/na12878-chrM-Y-trunc.bam"
         with tempfile.NamedTemporaryFile("w+t", suffix=".bed", delete=False) as f:
@@ -192,7 +192,7 @@ class PreprocessingTests(unittest.TestCase):
 
     def test_coverage_all_chrom_mismatch(self):
         """coverage raises a clear error when no BED chromosome matches the
-        BAM, for any process count or method (gh#620)."""
+        BAM, for any process count or method (#620)."""
         bam = "formats/na12878-chrM-Y-trunc.bam"
         with tempfile.NamedTemporaryFile("w+t", suffix=".bed", delete=False) as f:
             f.write("absent_contig\t100\t200\tbaz\n")
@@ -585,7 +585,7 @@ class ReferenceTests(unittest.TestCase):
         self.assertTrue(0 < len(cnr) <= len(tgt_bins))
 
     def test_fix_degenerate_no_nan(self):
-        """do_fix never emits NaN log2/weight from degenerate input (gh#521/#524).
+        """do_fix never emits NaN log2/weight from degenerate input (#521/#524).
 
         Zero-coverage sentinel and NaN bins (from malformed inputs or dead
         regions in WGS) must not survive into the .cnr, where they would crash
@@ -1309,7 +1309,7 @@ class CallTests(unittest.TestCase):
     def test_call_clonal_no_negative_cn(self):
         """Clonal calling with impure samples never emits negative copy number.
 
-        Regression for gh#503/#516: with purity < 1, the purity-rescale formula
+        Regression for #503/#516: with purity < 1, the purity-rescale formula
         n = (r*2^log2 - x*(1-p)) / p extrapolates to negative absolute copies
         for deeply deleted (or zero-coverage sentinel) segments. Absolute copy
         number is physically >= 0, so it must be floored at 0.
@@ -1334,7 +1334,7 @@ class CallTests(unittest.TestCase):
                 self.assertEqual(called["cn"].iloc[2], 0)
 
     def test_log2_ratio_to_absolute_floored_at_zero(self):
-        """_log2_ratio_to_absolute never returns a negative absolute (gh#503)."""
+        """_log2_ratio_to_absolute never returns a negative absolute (#503)."""
         # Impure path: deep deletion below the (1-p) contamination floor
         self.assertEqual(
             call._log2_ratio_to_absolute(-20.0, 2, 2, purity=0.5), 0.0

--- a/test/test_hmm.py
+++ b/test/test_hmm.py
@@ -413,7 +413,7 @@ class VariantsInSegmentTests(unittest.TestCase):
 class VariantReSegmentationIntegrationTests(unittest.TestCase):
     """Integration tests for the BAF re-segmentation glue in _do_segmentation.
 
-    The reporter of gh#1004 ran ``segment --method cbs --vcf ... --smooth-cbs``
+    The reporter of #1004 ran ``segment --method cbs --vcf ... --smooth-cbs``
     and crashed inside ``variants_in_segment`` with ``'Series' object has no
     attribute 'reshape'`` -- the pre-rewrite code called ``observations.reshape``
     on a pandas Series. That call is reached for *any* non-HMM method via
@@ -456,7 +456,7 @@ class VariantReSegmentationIntegrationTests(unittest.TestCase):
         )
         # The BAF shift splits the single 'none' segment into >= 2 pieces ...
         self.assertGreaterEqual(len(segarr), 2)
-        # ... with valid coordinates and a populated BAF column (gh#1004).
+        # ... with valid coordinates and a populated BAF column (#1004).
         self.assertTrue((segarr["start"] < segarr["end"]).all())
         self.assertIn("baf", segarr.data.columns)
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -146,7 +146,7 @@ class IOTests(unittest.TestCase):
         """Read a Strelka somatic-SNV VCF, which has no GT FORMAT field.
 
         Strelka reports per-base allele counts via AU/CU/GU/TU instead of an
-        explicit genotype. The reader must tolerate the missing GT (gh#943).
+        explicit genotype. The reader must tolerate the missing GT (#943).
         """
         fname = "formats/strelka.vcf"
         # Tumor/normal pair
@@ -205,7 +205,7 @@ class IOTests(unittest.TestCase):
         """A VCF declaring a FORMAT column but no samples gives a clear error.
 
         pysam rejects such files; the reader must not mislabel the failure as
-        an open-file-handle mistake (gh#680).
+        an open-file-handle mistake (#680).
         """
         with self.assertRaises(ValueError) as ctx:
             tabio.read("formats/format-no-sample.vcf", "vcf")

--- a/test/test_r.py
+++ b/test/test_r.py
@@ -66,7 +66,7 @@ class RTests(unittest.TestCase):
 
     @pytest.mark.slow
     def test_cbs_nan_log2_in_memory(self):
-        """CBS segments an in-memory .cnr with NaN log2 values (gh#881).
+        """CBS segments an in-memory .cnr with NaN log2 values (#881).
 
         The reporter ran ``segment`` (no --drop-low-coverage) on a .cnr with NaN
         values and hit ``subprocess.CalledProcessError``. The file-read path is


### PR DESCRIPTION
## Summary

Issue references in comments and docstrings had drifted to a `gh#NNN` style (carried over from beads issue notes over the last two days). The repo's original convention is a bare `#NNN`. This converts all **29 occurrences across 10 files** back to bare `#NNN`.

Comments and docstrings only — **no code or behavior change** (the diff is exactly 29 lines changed, 1:1).

## Files
`cnvlib/autobin.py`, `cnvlib/coverage.py`, `cnvlib/segfilters.py`, `cnvlib/segmentation/__init__.py`, `skgenome/tabio/vcfio.py`, and tests `test_cnvlib.py`, `test_commands.py`, `test_hmm.py`, `test_io.py`, `test_r.py`.

## Testing
- `ruff check` clean on all changed files
- `mypy` clean on the changed source files
- `pytest test/test_hmm.py test/test_io.py` pass

## Note
I deliberately did **not** run `ruff format`: my local ruff wants to reformat several unrelated lines (e.g. line-wrapping in `_wavg`/`_get_alt_count`) that were already "would reformat" on master before this change — i.e. a ruff-version skew, not something this change introduced. Keeping that out so this PR stays a pure issue-ref rename. (Flagging separately — see PR description discussion.)

## Clinical-output impact
None — comments/docstrings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)