### PR TITLE
Fix silent crash producing no .cnr when <2 bins survive coverage filters (#891)

### DIFF
--- a/cnvlib/smoothing.py
+++ b/cnvlib/smoothing.py
@@ -74,6 +74,10 @@ def _pad_array(x: ndarray, wing: int) -> ndarray:
 
 def rolling_median(x: pd.Series, width: float) -> ndarray:
     """Rolling median with mirrored edges."""
+    if len(x) < 2:
+        # Nothing to smooth; a single bin has no neighbors (#891).
+        # Guard before check_inputs, which can't form a valid window here.
+        return np.asarray(x, dtype=float)
     x, wing, signal = check_inputs(x, width)  # type: ignore[misc]
     rolled = signal.rolling(2 * wing + 1, 1, center=True).median()  # type: ignore[union-attr]
     # if rolled.hasnans:
@@ -83,6 +87,8 @@ def rolling_median(x: pd.Series, width: float) -> ndarray:
 
 def rolling_quantile(x: pd.Series, width: int, quantile: float) -> ndarray:
     """Rolling quantile (0--1) with mirrored edges."""
+    if len(x) < 2:
+        return np.asarray(x, dtype=float)
     x, wing, signal = check_inputs(x, width)  # type: ignore[misc]
     rolled = signal.rolling(2 * wing + 1, 2, center=True).quantile(quantile)  # type: ignore[union-attr]
     return np.asarray(rolled[wing:-wing], dtype=float)
@@ -90,6 +96,8 @@ def rolling_quantile(x: pd.Series, width: int, quantile: float) -> ndarray:
 
 def rolling_std(x, width):
     """Rolling quantile (0--1) with mirrored edges."""
+    if len(x) < 2:
+        return np.asarray(x, dtype=float)
     x, wing, signal = check_inputs(x, width)  # type: ignore[misc]
     rolled = signal.rolling(2 * wing + 1, 2, center=True).std()  # type: ignore[union-attr]
     return np.asarray(rolled[wing:-wing], dtype=float)

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -334,6 +334,35 @@ class OtherTests(unittest.TestCase):
             2 * fix.edge_gains(target_size, gap_size, insert_size),
         )
 
+    def test_center_by_window_single_bin(self):
+        """center_by_window survives one surviving bin (#891).
+
+        Near-zero antitarget coverage can leave a single bin after the
+        bad-bin/NaN filters in load_adjust_coverages. The bias-correction
+        smoothing (rolling_median) then received len-1 input, where the
+        fraction ``max(0.01, len ** -0.5) == 1.0`` is an invalid width that
+        crashed ``_width2wing`` (and len-0 tripped its ``wing >= 1`` assert),
+        terminating ``batch`` silently without ever writing a .cnr.
+        """
+        one_bin = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"],
+                    "start": [1000],
+                    "end": [2000],
+                    "gene": ["G"],
+                    "log2": [0.42],
+                    "depth": [50.0],
+                }
+            )
+        )
+        # frac as computed in load_adjust_coverages for one surviving bin
+        frac = max(0.01, len(one_bin) ** -0.5)
+        self.assertEqual(frac, 1.0)
+        result = fix.center_by_window(one_bin, frac, np.array([0.5]))
+        self.assertEqual(len(result), 1)
+        self.assertFalse(np.isnan(result["log2"]).any())
+
     # call
     # Test: convert_clonal(x, 1, 2) == convert_diploid(x)
 

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -36,6 +36,8 @@ from cnvlib.smoothing import (
     _width2wing,
     kaiser,
     rolling_median,
+    rolling_quantile,
+    rolling_std,
     savgol,
 )
 
@@ -371,6 +373,33 @@ class TestRollingMedian:
         x, width = args
         result = rolling_median(x, width)
         assert not np.any(np.isnan(result))
+
+
+class TestRollingShortInput:
+    """Degenerate short-signal inputs must not crash (#891).
+
+    Near-zero coverage can leave 0 or 1 surviving bins. With 1 bin the
+    caller's fraction is ``1 ** -0.5 == 1.0`` (an invalid width); with 0 bins
+    ``_width2wing`` would compute a negative wing. Both previously raised
+    out of ``rolling_*``, unlike the guarded ``savgol``/``kaiser``.
+    """
+
+    @pytest.mark.parametrize("func", [rolling_median, rolling_std])
+    @pytest.mark.parametrize("n", [0, 1])
+    @pytest.mark.parametrize("width", [1.0, 0.5, 7])
+    def test_short_input_returns_input_unchanged(self, func, n, width):
+        x = np.arange(n, dtype=float)
+        result = func(x, width)
+        assert len(result) == n
+        assert np.array_equal(result, x)
+
+    @pytest.mark.parametrize("n", [0, 1])
+    @pytest.mark.parametrize("width", [1.0, 0.5, 7])
+    def test_rolling_quantile_short_input(self, n, width):
+        x = np.arange(n, dtype=float)
+        result = rolling_quantile(x, width, 0.5)
+        assert len(result) == n
+        assert np.array_equal(result, x)
 
 
 class TestKaiser:


### PR DESCRIPTION
## Problem

`cnvkit batch` silently terminated after writing the `.cnn` files and never produced a `.cnr` when a sample's antitarget coverage was near-zero (reported as `Keeping 1 of 19087 bins`). No error was printed — the exception was swallowed under the worker pool. Fixes #891.

## Root cause

When the bad-bin/NaN filters in `load_adjust_coverages` drop nearly everything, bias correction routes the surviving bins through `center_by_window` → `smoothing.rolling_median`. That function — unlike its siblings `savgol` and `kaiser`, which both guard `if len(x) < 2: return x` — passed degenerate input straight into `_width2wing`, where no valid window exists:

| surviving bins | `frac = max(0.01, len**-0.5)` | crash |
|---|---|---|
| 1 | `1.0` | `ValueError: width must be a fraction… or integer > 1 (got 1.0)` |
| 0 | `0.01` | `AssertionError: Wing must be at least 1 (got -1)` |

The second matches the assert the reporter observed. This is the "too-few-bins-survive" tail of the same near-zero-coverage cluster whose NaN→drop boundary was hardened earlier.

## Fix

Add the same `if len(x) < 2: return np.asarray(x, dtype=float)` short-circuit to `rolling_median`, `rolling_quantile`, and `rolling_std`, so all five smoothing primitives are consistently no-ops on trivially short input. The only *live* caller affected is `rolling_median` via `center_by_window`; the outlier-detection callers of the other two already guard `len(x) <= width` upstream, so the additions there are defensive consistency.

## Output stability

For any run with ≥2 surviving bins (every normal run) the guard never fires — output is **byte-identical**, no change to `.cnr`/`.cns` numerics or file formats. Only previously-*crashing* runs change behavior, now emitting a valid `.cnr`.

## Tests

- `test_center_by_window_single_bin` (`test_cnvlib.py`) — reproduces the real `frac == 1.0` crash path with a single surviving bin.
- `TestRollingShortInput` (`test_properties.py`) — parametrized n∈{0,1} across all three `rolling_*` functions.

Both written failing-first. 93 tests pass in the two suites; `mypy` and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)