### PR TITLE
Document --smooth-cbs and the "Smoothing overshot" message (#935)

### DIFF
--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -608,6 +608,19 @@ is provided (``-v``), BAF information is jointly modeled with log2 ratios.
 The methods ``haar`` and ``none`` do not have any additional dependencies beyond
 the basic CNVkit installation.
 
+.. note::
+   **Smoothing.** By default, ``cbs`` segments the log2 ratios directly, without
+   any pre-smoothing. The ``--smooth-cbs`` option enables an additional smoothing
+   pass before CBS (via DNAcopy's ``smooth.CNA``), which can increase sensitivity
+   on noisy data; it is opt-in and applies only to the ``cbs`` method.
+
+   A separate Savitzky-Golay smoother draws the grey trend line in :ref:`scatter`
+   plots and is used internally by the ``haar`` and ``hmm`` methods. When that
+   smoother produces a value slightly outside the input range it logs a
+   ``Smoothing overshot ...`` message. This is informational only and does not
+   affect ``cbs`` segmentation, so seeing it after a ``scatter`` plot or an
+   ``haar``/``hmm`` run is expected.
+
 
 Bin filtering
 `````````````


### PR DESCRIPTION
## Summary

Closes the documentation gap surfaced by #935, where a user believed `cnvkit.py segment` auto-smooths CBS results because they saw `Smoothing overshot ...` warnings.

The segment docs never mentioned the `--smooth-cbs` option or explained that log message. This adds a `Smoothing` note to the segment section of `doc/pipeline.rst` clarifying:

- CBS segments log2 ratios directly; `--smooth-cbs` is **opt-in** and applies only to the `cbs` method (R-level `smooth.CNA`).
- The Savitzky-Golay `Smoothing overshot ...` message comes from the trend-line smoother used by `scatter` plots and the `haar`/`hmm` methods — **not** from CBS — and is informational.

## Context

#935 reported `batch` vs. stepwise divergence. Root-causing it (see the issue comment) found all three reported differences already resolved on master:

1. **Binning** (the dominant cause) was fixed in 04b3373 (#302) — `batch -m hybrid` now runs `autobin` instead of hard-coded default bin sizes.
2. **"Auto-smoothing"** was never real (this PR documents why).
3. **Post-processing steps** are already documented in the batch-equivalent pipeline block.

This PR addresses the one genuine remaining gap (2).

## Clinical-impact note

Docs-only. No change to numerical output or file formats (`.cnr`/`.cns`/`.cnn`/SEG/VCF).

## Test plan

- `sphinx-build` of `doc/` completes with **0 warnings**; the new note renders in `pipeline.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)