### PR TITLE
Explicitly exclude duplicate reads in bedcov coverage path (#689)

### DIFF
--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -27,6 +27,16 @@ if TYPE_CHECKING:
     from skgenome import GenomicArray
 
 
+# SAM flags for reads excluded from coverage: unmapped (0x4), secondary (0x100),
+# QC-fail (0x200), and duplicate (0x400), i.e. 0x704. This mirrors the
+# `filter_read` predicate used by the by-count path (`region_depth_count`) and
+# happens to equal `samtools bedcov`'s own default exclude set -- but we pass it
+# to bedcov explicitly so the depth path keeps ignoring marked duplicates even
+# if a samtools version changes that default (#689). Picard MarkDuplicates sets
+# the duplicate flag, so marking duplicates is equivalent to removing them.
+COVERAGE_EXCLUDE_FLAGS = 0x704
+
+
 def is_bedgraph_format(fname: str) -> bool:
     """Check if input file is bedGraph format (.bed.gz)."""
     return fname.endswith(".bed.gz")
@@ -472,7 +482,11 @@ def region_depth_count(
     """
 
     def filter_read(read) -> bool:
-        """True if the given read should be counted towards coverage."""
+        """True if the given read should be counted towards coverage.
+
+        Excludes the same reads as ``COVERAGE_EXCLUDE_FLAGS`` (0x704) in the
+        depth/bedcov path, plus low-MAPQ reads (#689).
+        """
         return not (
             read.is_duplicate
             or read.is_secondary
@@ -635,8 +649,11 @@ def bedcov(
                 f"BAM file {bam_fname!r}"
             )
     try:
-        # Count bases in each region; exclude low-MAPQ reads
-        cmd = []
+        # Count bases in each region; exclude low-MAPQ and flagged reads.
+        # `-G` *adds* to bedcov's default exclude set, so this guarantees
+        # unmapped/secondary/QC-fail/duplicate reads are skipped regardless of
+        # the samtools default (#689).
+        cmd = ["-G", hex(COVERAGE_EXCLUDE_FLAGS)]
         if max_depth is not None:
             cmd.extend(["-d", str(max_depth)])
         if min_mapq and min_mapq > 0:

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -335,6 +335,15 @@ duplicates with a program such as `SAMBLASTER
 `Picard tools <http://picard.sourceforge.net/>`_, so that CNVkit will skip
 these reads when calculating read depth.
 
+.. note::
+    **Marking duplicates is enough -- you don't need to remove them.** CNVkit
+    excludes reads flagged as duplicates (along with unmapped, secondary, and
+    QC-failed reads) from both the depth and ``--count`` coverage calculations.
+    A BAM with duplicates *marked* by Picard MarkDuplicates (or SAMBLASTER,
+    SAMBAMBA) therefore yields the same coverage as one with the duplicates
+    physically removed. (Exception: for amplicon sequencing, do *not* mark
+    duplicates at all -- see :doc:`nonhybrid`.)
+
 You will probably want to index the finished BAM file using `samtools
 <http://samtools.sourceforge.net/>`_ or SAMBAMBA.  But if you haven't done this
 beforehand, CNVkit will automatically do it for you.

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -18,6 +18,7 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 import matplotlib
 import numpy as np
 import pandas as pd
+import pysam
 from skgenome import tabio, GenomicArray as GA
 
 matplotlib.use("Agg")
@@ -164,6 +165,49 @@ class PreprocessingTests(unittest.TestCase):
             self.assertEqual(len(empty), 0)
         finally:
             os.unlink(bed)
+
+    def test_coverage_skips_marked_duplicates(self):
+        """Coverage ignores reads flagged as duplicates in both the depth
+        (bedcov) and by-count paths, so marking duplicates (e.g. Picard
+        MarkDuplicates) is equivalent to physically removing them (#689)."""
+        seqlen = 50
+        n_total, n_dup = 10, 6  # 4 reads survive the duplicate filter
+        header = {
+            "HD": {"VN": "1.6", "SO": "coordinate"},
+            "SQ": [{"SN": "chr1", "LN": 1000}],
+        }
+        tmpdir = tempfile.mkdtemp()
+        bam = os.path.join(tmpdir, "dup.bam")
+        with pysam.AlignmentFile(bam, "wb", header=header) as out:
+            for i in range(n_total):
+                a = pysam.AlignedSegment()
+                a.query_name = f"r{i}"
+                a.query_sequence = "A" * seqlen
+                a.flag = 0
+                a.reference_id = 0
+                a.reference_start = 100
+                a.mapping_quality = 60
+                a.cigarstring = f"{seqlen}M"
+                a.query_qualities = pysam.qualitystring_to_array("I" * seqlen)
+                a.is_duplicate = i >= (n_total - n_dup)
+                out.write(a)
+        pysam.index(bam)
+        bed = os.path.join(tmpdir, "region.bed")
+        with open(bed, "w") as fh:
+            fh.write("chr1\t90\t160\tregionA\n")
+        n_kept = n_total - n_dup
+        try:
+            # Depth path (default): basecount counts only non-duplicate reads
+            table = coverage.bedcov(bed, bam, 0)
+            self.assertEqual(float(table["basecount"].iloc[0]), n_kept * seqlen)
+            # By-count path: same surviving read count
+            bamfile = pysam.AlignmentFile(bam, "rb")
+            count, _row = coverage.region_depth_count(
+                bamfile, "chr1", 90, 160, "regionA", 0
+            )
+            self.assertEqual(count, n_kept)
+        finally:
+            shutil.rmtree(tmpdir)
 
     def test_coverage_partial_chrom_mismatch(self):
         """coverage tolerates a BED mixing present and absent contigs,


### PR DESCRIPTION
## Summary

Fixes the root cause behind #689, where a BAM with **marked** duplicates (Picard MarkDuplicates) produced different — noisier — CNV calls than the same BAM with duplicates **removed**, masking a small exon-level deletion in a high-duplicate sample.

CNVkit has two coverage code paths with inconsistent duplicate handling:

- **by-count** (`region_depth_count`): always excluded duplicate/secondary/unmapped/QC-fail reads via `filter_read`.
- **default depth path** (`bedcov` → `pysam.bedcov`): passed **no** read-filter flag, relying entirely on samtools' *implicit default* exclude set.

Modern `samtools bedcov` (1.23.1) defaults to `UNMAP,SECONDARY,QCFAIL,DUP` (0x704), so it skips marked duplicates today — but older samtools defaults did not, which is exactly what the reporter hit on cnvkit 0.9.3 in 2022.

## Change

Pass `-G 0x704` to `pysam.bedcov` explicitly (`COVERAGE_EXCLUDE_FLAGS`) so the depth path always excludes those reads regardless of the samtools version's default, matching the by-count path by intent rather than coincidence.

## Clinical-impact note

`-G` *adds* to bedcov's default exclude set, so on modern samtools this is a **verified no-op** — identical `basecount` with and without the flag. **No numerical change** to `.cnr`/`.cns`/`.cnn` output for current users; it *stabilizes* coverage output across samtools versions.

## Test plan

- New `test_coverage_skips_marked_duplicates` exercises both coverage paths on a synthetic duplicate-flagged BAM (10 reads, 6 marked dup → 4 counted).
- 63 non-slow command tests + 11 coverage/bedcov tests pass; `mypy` clean; `ruff` clean; docs build with 0 warnings.

## Docs

Adds a note to the `coverage` section: marking duplicates is equivalent to removing them (with the amplicon-sequencing exception, per `nonhybrid.rst`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)