### PR TITLE
Guard segment gene aggregation + diagnose wrong-build annotation (#688)

### DIFF
--- a/cnvlib/target.py
+++ b/cnvlib/target.py
@@ -55,6 +55,19 @@ def do_target(
         annotation = tabio.read_auto(annotate)
         antitarget.compare_chrom_names(tgt_arr, annotation)
         tgt_arr["gene"] = annotation.into_ranges(tgt_arr, "gene", "-")
+        # compare_chrom_names only catches *fully* disjoint chromosome names
+        # (e.g. 'chr1' vs '1'). If the names overlap but no coordinates do --
+        # most often an annotation file for a different genome build -- every
+        # region is left unnamed. Flag that rather than failing silently (#688).
+        if len(tgt_arr) and not (tgt_arr["gene"] != "-").any():
+            logging.warning(
+                "No target regions were assigned a gene name from %s, even "
+                "though its chromosome names match the targets. This usually "
+                "means the annotation file is for a different genome build -- "
+                "check that its assembly and chromosome naming match your "
+                "targets.",
+                annotate,
+            )
     if do_short_names:
         logging.info("Shortening target interval labels")
         tgt_arr["gene"] = list(shorten_labels(tgt_arr["gene"]))

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -184,6 +184,30 @@ The targets do not need to be genes, but for convenience CNVkit's documentation
 and source code generally refer to consecutive targeted regions with the same
 label as "genes".
 
+.. note::
+    **The annotation must match your targets' genome build and chromosome
+    naming.** Gene names are assigned by *coordinate overlap*, so a refFlat (or
+    other annotation) from a different assembly -- or one using ``1`` where your
+    targets use ``chr1`` -- will leave regions mislabeled or unlabeled. CNVkit
+    raises an error when the chromosome names don't overlap at all, and warns
+    when an annotation shares chromosome names but matches no coordinates (the
+    usual sign of a wrong-build file).
+
+    **Review the annotated output before relying on it.** The ``target`` command
+    writes a 4-column BED whose fourth column is the gene label; spot-check that
+    most regions are named (not the ``-`` placeholder) and that your genes of
+    interest are present::
+
+        cnvkit.py target my_baits.bed --annotate refFlat_hg38.txt -o my_targets.bed
+        # How many regions are unlabeled ("-") vs. total?
+        cut -f4 my_targets.bed | grep -c -x -- '-'
+        wc -l my_targets.bed
+        # Is a gene of interest present?
+        grep -w EGFR my_targets.bed
+
+    These labels carry through to the ``.cnn``/``.cnr``/``.cns`` files and the
+    final calls, so a region left unlabeled here stays unlabeled downstream.
+
 
 .. _access:
 

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -520,6 +520,49 @@ class OtherTests(unittest.TestCase):
         self.assertIn("GeneA", gene_val)
         self.assertIn("GeneB", gene_val)
 
+    def test_transfer_fields_genes_near_segment_end(self):
+        """Genes from bins near a segment's end are kept in its label (#688).
+
+        Uses the reported EGFR geometry: bins at chr7:55,018,770-55,019,423
+        fall inside the segment chr7:54,246,732-55,031,592 (well before its
+        end), and more EGFR bins fall in the adjacent segment. EGFR must appear
+        in *both* segment labels -- the original report dropped it from the
+        first, where the gene-bearing bins sit near the segment's end.
+        """
+        bins = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr7"] * 6,
+                    "start": [54246732, 54800000, 55018770, 55019096,
+                              55032092, 55088166],
+                    "end": [54300000, 54900000, 55019096, 55019423,
+                            55032193, 55088469],
+                    "gene": ["VSTM2A", "SEC61G", "EGFR", "EGFR",
+                             "EGFR", "EGFR"],
+                    "log2": np.zeros(6),
+                    "depth": np.ones(6) * 100.0,
+                    "weight": np.ones(6),
+                }
+            )
+        )
+        segarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr7", "chr7"],
+                    "start": [54246732, 55032092],
+                    "end": [55031592, 55365525],
+                    "gene": ["-", "-"],
+                    "log2": [0.0, 0.0],
+                    "probes": [4, 2],
+                    "weight": [0.0, 0.0],
+                }
+            )
+        )
+        result = segmentation.transfer_fields(segarr, bins)
+        self.assertIn("EGFR", result["gene"].iat[0])
+        self.assertIn("VSTM2A", result["gene"].iat[0])
+        self.assertIn("EGFR", result["gene"].iat[1])
+
     def test_transfer_fields_nan_weights(self):
         """transfer_fields handles NaN bin weights without NaN in .cns output."""
         n = 10

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -388,6 +388,46 @@ class PreprocessingTests(unittest.TestCase):
         self.assertGreater(cna.log2.nunique(), 1)
 
     @pytest.mark.slow
+    def test_target_annotate_refflat_assigns_genes(self):
+        """'target --annotate refFlat' actually populates gene names (#688).
+
+        The refFlat reader parses the gene column, tabio sorts the annotation,
+        and into_ranges overlaps it onto the baits. Guards against silent
+        annotation failures: a real bait set should come back almost entirely
+        gene-named, with names drawn from the refFlat's first column.
+        """
+        annot_fname = "formats/refflat-mini.txt"
+        baits = tabio.read_auto("formats/baits-funky.bed")
+        out = commands.do_target(baits, do_split=True, avg_size=200, annotate=annot_fname)
+        named = [g for g in out["gene"] if g != "-"]
+        # Nearly all bins on these gene-dense baits should be annotated
+        self.assertGreater(len(named), 0.9 * len(out))
+        # Names come from the refFlat first column (gene symbols)
+        all_names = {n for g in named for n in g.split(",")}
+        self.assertIn("DDX11L1", all_names)
+        self.assertIn("WASH7P", all_names)
+
+    def test_target_annotate_wrong_build_warns(self):
+        """Warn when annotation shares chrom names but assigns no genes (#688).
+
+        Mimics a wrong-genome-build refFlat: chromosome names match (so
+        compare_chrom_names passes), but no coordinates overlap, leaving every
+        region unnamed. Without the warning this failure is silent.
+        """
+        annot_fname = "formats/refflat-mini.txt"  # chr1 genes end well before 210 Mb
+        baits = GA.from_columns(
+            {
+                "chromosome": ["chr1", "chr1"],
+                "start": [210_000_000, 210_010_000],
+                "end": [210_001_000, 210_011_000],
+                "gene": ["-", "-"],
+            }
+        )
+        with self.assertLogs(level="WARNING") as cm:
+            out = commands.do_target(baits, annotate=annot_fname)
+        self.assertTrue(all(g == "-" for g in out["gene"]))
+        self.assertTrue(any("different genome build" in m for m in cm.output))
+
     def test_target(self):
         """The 'target' command."""
         annot_fname = "formats/refflat-mini.txt"


### PR DESCRIPTION
## Summary

Addresses both halves of #688.

**1. Original report — a gene (EGFR) dropped from a segment's label** despite EGFR bins falling inside the segment. This is already handled correctly on current code: I reproduced the exact reported geometry and `transfer_fields`/`iter_slices` keeps EGFR in both the simple and nested bin-assignment paths. The 2022 report predates the fix (its repeated `VSTM2A` shows a pre-dedup version). Added a regression guard using the reported two-segment EGFR layout so the end-boundary aggregation can't regress.

**2. Comment sub-issue — `--annotate refFlat.txt` "assigns no genes."** refFlat annotation itself works (parse → sort → coordinate overlap; verified 164/164 on real baits). The real gap: `compare_chrom_names` only errors on *fully disjoint* chromosome names (`chr1` vs `1`), so an annotation for the **wrong genome build** (same names, non-overlapping coordinates) silently leaves every region unlabeled.

## Changes

- `do_target`: warn when an annotation shares chromosome names with the targets but assigns **zero** gene names — the typical wrong-build signature. Conservative zero-named threshold so it won't false-positive on legitimately sparse annotations (e.g. genome-wide WGS `access` targets).
- Docs (`target` section): the annotation must match the targets' genome build / chromosome naming, plus how to review the annotated 4-column BED before relying on it.
- Tests: segment gene aggregation near a segment end (#688 geometry); refFlat annotation populates gene names; the wrong-build warning fires.

## Clinical-impact note

No change to numerical output or file formats. The new warning is log-only; the rest is tests and docs.

## Test plan

- 93 command/cnvlib tests pass (3 new); `mypy` clean; `ruff` clean; docs build with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)