### PR TITLE
Route bedGraph chrom-name matching through chromnames.detect_chr_prefix

### DIFF
--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 from skgenome import tabio
 from skgenome._pysam import PYSAM_INSTALL_MSG
+from skgenome.chromnames import detect_chr_prefix
 
 from . import core, samutil
 from .cnary import CopyNumArray as CNA
@@ -102,6 +103,11 @@ def bedgraph_to_basecount(
     try:
         rows = []
         chromosomes_in_bedgraph = set(tbx.contigs)
+        # Detect each file's 'chr'-prefix convention so a name absent from the
+        # bedGraph can be retried under the bedGraph's convention, regardless of
+        # which side carries the prefix (chr1<->1, chrM<->M, etc.).
+        bedgraph_prefix = detect_chr_prefix(chromosomes_in_bedgraph)
+        bed_prefix = detect_chr_prefix(bed_data.chromosome.unique())
 
         for region in bed_data:
             chrom = region.chromosome
@@ -110,12 +116,8 @@ def bedgraph_to_basecount(
 
             # Handle chromosome naming mismatches or missing chromosomes
             if chrom not in chromosomes_in_bedgraph:
-                # Try adding/removing 'chr' prefix
-                alt_chrom = (
-                    f"chr{chrom}"
-                    if not chrom.startswith("chr")
-                    else chrom.removeprefix("chr")
-                )
+                # Retry under the bedGraph's prefix convention (e.g. chr1<->1)
+                alt_chrom = bedgraph_prefix + chrom.removeprefix(bed_prefix)
                 if alt_chrom in chromosomes_in_bedgraph:
                     chrom = alt_chrom
                 else:


### PR DESCRIPTION
## Summary

`bedgraph_to_basecount` in `cnvlib/coverage.py` used an inline `chrom.startswith("chr")` heuristic to toggle the `chr` prefix when a BED region's chromosome name was absent from the bedGraph contigs. This violates the project convention that **all** chromosome-name handling route through `skgenome.chromnames`, and it hardcoded both the literal `"chr"` prefix and the assumption that the BED side is the prefixed one.

This change detects each file's prefix convention once via `detect_chr_prefix`, then maps a missing name into the bedGraph's convention:

```python
alt_chrom = bedgraph_prefix + chrom.removeprefix(bed_prefix)
```

`removeprefix("")` is a no-op, so a single code path covers all prefix combinations.

## Why it's correct

- `chr1`→`1`: `"" + "chr1".removeprefix("chr")` = `"1"`
- `1`→`chr1`: `"chr" + "1".removeprefix("")` = `"chr1"`
- Same convention on both sides → `alt_chrom == chrom`, already known absent → falls through to 0-coverage (unchanged)
- Mixed-convention BED → `removeprefix(bed_prefix)` is a safe no-op for rows lacking the detected prefix

The old code hardcoded `"chr"` and assumed the BED side carried the prefix; the new code is driven by *detected* conventions, so it also handles non-`chr` prefixes the old version couldn't.

## Clinical-impact note

No change to numerical output or file formats for standard inputs — behavior is identical for the common `chr`↔no-`chr` cases the old code handled, and strictly more correct for non-`chr` prefix conventions.

## Testing

- `test_coverage_bedgraph_chr_naming` (covering test) + all 9 `coverage` tests pass
- `mypy cnvlib/coverage.py` clean
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)