### PR TITLE
Keep allele frequency NaN when VCF lacks allele counts (#407)

### DIFF
--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -53,7 +53,13 @@ class VariantArray(GenomicArray):
             return pd.Series(np.repeat(np.nan, len(ranges)), index=self.data.index)
 
         def summarize(vals):
-            return summary_func(_mirrored_baf(vals, above_half))
+            mirrored = _mirrored_baf(vals, above_half)
+            # A bin whose het SNPs all lack allele frequencies (NaN) has no
+            # usable BAF; return NaN directly rather than letting np.nanmedian
+            # warn on an all-NaN slice (#407).
+            if mirrored.isna().all():
+                return np.nan
+            return summary_func(mirrored)
 
         cnarr = self.heterozygous()
         if tumor_boost and "n_alt_freq" in self:

--- a/doc/baf.rst
+++ b/doc/baf.rst
@@ -200,3 +200,29 @@ or::
 Both indicate the loaded variants don't look like germline heterozygous
 SNPs. Re-check the VCF preparation (see :ref:`baf-vcf-prep`) and sample
 identification.
+
+``baf`` is 0 across (nearly) every segment
+``````````````````````````````````````````
+
+Symptom: the ``.cns`` output has ``baf`` of exactly 0 in most or all
+segments, even though the VCF clearly contains heterozygous SNPs (the load
+log reports many records "kept heterozygous").
+
+Cause: CNVkit derives each SNP's allele frequency from per-sample
+allele-*count* FORMAT fields, not from the genotype alone. It reads, in order
+of preference, ``AD`` (GATK, VarScan2), ``CLCAD2`` (Qiagen CLC), ``AO`` with
+``RO`` (FreeBayes), Strelka's per-base tier counts (``AU``/``CU``/``GU``/``TU``),
+or -- for an unpaired VCF with no per-sample genotypes -- the INFO ``AF``
+field. If a record has a genotype (``GT``) but *none* of these count fields,
+its allele frequency is unknown.
+
+Such sites are now treated as missing (NaN) rather than as a 0% alt-allele
+frequency, so they are excluded from the per-segment BAF instead of pinning it
+to 0. (Previously the unknown frequency was coerced to 0, which kept the het
+site and forced its mirrored BAF to 0; see issue #407.) If *all* het SNPs in a
+segment lack counts, that segment's ``baf`` is written as missing (NaN).
+
+The fix is to call variants with a tool that emits allele depths, or re-run the
+caller so that one of the fields above is present. For example, VarScan2 emits
+``AD``/``RD`` and VarDict/FreeBayes emit ``AD``/``AF``; a ``GT``-only VCF does
+not carry enough information for BAF.

--- a/skgenome/tabio/vcfio.py
+++ b/skgenome/tabio/vcfio.py
@@ -95,7 +95,13 @@ def read_vcf(
     table["alt_freq"] = table["alt_count"] / table["depth"]
     if nid:
         table["n_alt_freq"] = table["n_alt_count"] / table["n_depth"]
-    table = table.fillna({col: 0.0 for col in table.columns[6:]})
+    # Fill missing genotype/depth/count fields with 0, but leave allele
+    # *frequencies* as NaN: a het call with no allele counts has an unknown
+    # (not zero) frequency, and coercing it to 0 pins mirrored BAF to 0 over
+    # the whole region (#407). NaN is excluded by the np.nanmedian aggregation.
+    freq_cols = {"alt_freq", "n_alt_freq"}
+    fill_cols = [c for c in table.columns[6:] if c not in freq_cols]
+    table = table.fillna({col: 0.0 for col in fill_cols})
     # Filter out records as requested
     cnt_depth = cnt_som = 0
     if min_depth:

--- a/test/formats/vcf-het-no-altcount.vcf
+++ b/test/formats/vcf-het-no-altcount.vcf
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.2
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total read depth">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+##contig=<ID=chr1,length=249250621>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TUMOR	NORMAL
+chr1	100	.	G	A	50	PASS	DP=40	GT:DP	0/1:42	0/1:38
+chr1	200	.	C	T	50	PASS	DP=36	GT:DP	0/1:36	0/1:34
+chr1	300	.	A	G	50	PASS	DP=30	GT:DP	0/1:30	0/1:30

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -201,6 +201,45 @@ class IOTests(unittest.TestCase):
         # 0/0 -> hom-ref; 1/1 -> hom-alt; 0/1 -> het
         self.assertEqual(list(v["zygosity"]), [0.0, 0.5, 0.5, 0.0, 1.0, 0.5])
 
+    def test_read_vcf_het_no_alt_count(self):
+        """A het call with no allele-count field gets NaN alt_freq, not 0 (#407).
+
+        When a VCF has genotypes (GT=0/1 -> het) but no AD/AO/DP4/AF to derive
+        an alternate-allele count, the frequency is unknown. It must stay NaN so
+        BAF aggregation (np.nanmedian) excludes it, rather than being coerced to
+        0.0 -- which would keep the het site yet pin its mirrored BAF to exactly
+        0 over the whole region.
+        """
+        import math
+
+        from cnvlib.cnary import CopyNumArray as CNA
+
+        varr = tabio.read(
+            "formats/vcf-het-no-altcount.vcf",
+            "vcf",
+            sample_id="TUMOR",
+            normal_id="NORMAL",
+        )
+        self.assertEqual(len(varr), 3)
+        # Genotype is read as heterozygous, so these sites are kept...
+        self.assertEqual(list(varr["zygosity"]), [0.5, 0.5, 0.5])
+        # ...but with no allele counts the frequency is unknown, not zero
+        self.assertTrue(all(math.isnan(f) for f in varr["alt_freq"]))
+        self.assertTrue(all(math.isnan(f) for f in varr["n_alt_freq"]))
+        # A bin spanning all three het SNPs gets NaN BAF, not a spurious 0.0
+        seg = CNA.from_columns(
+            {
+                "chromosome": ["chr1"],
+                "start": [0],
+                "end": [1000],
+                "gene": ["-"],
+                "log2": [0.0],
+            }
+        )
+        baf = varr.baf_by_ranges(seg)
+        self.assertEqual(len(baf), 1)
+        self.assertTrue(math.isnan(baf.iloc[0]))
+
     def test_read_vcf_malformed(self):
         """A VCF declaring a FORMAT column but no samples gives a clear error.
 


### PR DESCRIPTION
Fixes #407.

## Symptom

`.cns` output has `baf` of exactly **0 across (nearly) every segment**, even though the load log reports many records "kept heterozygous". Reported with VarScan2 and GATK HaplotypeCaller VCFs that carry genotypes but no per-sample allele counts.

## Root cause

CNVkit derives a SNP's allele frequency from per-sample allele-*count* FORMAT fields (`AD`, `AO`/`RO`, `DP4`, `CLCAD2`, Strelka tier counts), or INFO `AF` for unpaired VCFs — not from `GT` alone. When a record has `GT=0/1` (→ heterozygous) but **none** of those count fields, `read_vcf` correctly computes `alt_freq` as `NaN`… but then this line coerced it to `0.0`:

```python
table = table.fillna({col: 0.0 for col in table.columns[6:]})  # includes alt_freq!
```

The site is still kept as heterozygous (zygosity from `GT`), so `_mirrored_baf` turns its fake `0.0` frequency into a mirrored BAF of exactly `0`, pinning the whole segment's BAF to 0.

This is a "missing vs. zero" conflation: `alt_freq=0.0` means "0% alt reads" (a real hom-ref observation), while `NaN` means "no read-count evidence". Because BAF aggregation uses `np.nanmedian`, a true `NaN` is excluded but a fake `0.0` is averaged in.

## Fix

- **`skgenome/tabio/vcfio.py`**: exclude `alt_freq`/`n_alt_freq` from the `fillna(0.0)` so unknown frequencies stay `NaN` and are skipped by the `np.nanmedian` BAF aggregation. (Genotype/depth/count columns are still filled with 0 as before.)
- **`cnvlib/vary.py`**: guard `baf_by_ranges`' per-bin summary so a bin whose het SNPs are all `NaN` returns `NaN` directly, instead of emitting numpy's "All-NaN slice" `RuntimeWarning`.

## Clinical-impact note

VCFs that carry allele counts are **unaffected** — `alt_freq` is never `NaN` from missing counts there, so the `fillna` never touched it, and numerical output is identical. Only the previously-buggy `baf=0` sites now correctly become `NaN`/excluded. Affected segments' `baf` (and downstream `cn1`/`cn2` in `call`) change from a spurious `0` to either a real value (from sites that do have counts) or `NaN` (if none do).

## Testing

- New `test_read_vcf_het_no_alt_count` (TDD: fails before, passes after) with a `GT`-only paired fixture `test/formats/vcf-het-no-altcount.vcf`, asserting `alt_freq` is `NaN` and the per-segment BAF is `NaN` rather than `0`.
- Full unit suite: **313 passed**.
- `mypy` (vcfio + vary) and `ruff` clean.

## Docs

Adds a "`baf` is 0 across (nearly) every segment" troubleshooting subsection to `doc/baf.rst` listing the allele-count fields CNVkit reads and the new graceful-degradation behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)