### PR TITLE
Add regression test for NCBI-style dotted chromosome names in region specs (#602)

### DIFF
--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -836,6 +836,27 @@ class OtherTests(unittest.TestCase):
             result = rangelabel.unpack_range(region)
             self.assertEqual(result, expect)
 
+    def test_rangelabel_ncbi_chrom(self):
+        # NCBI-style chromosome names contain a '.' version suffix (gh#602)
+        row = rangelabel.from_label("NC_039902.1:10000000-15000000", keep_gene=False)
+        self.assertEqual(tuple(row), ("NC_039902.1", 9999999, 15000000))
+        self.assertEqual(rangelabel.to_label(row), "NC_039902.1:10000000-15000000")
+        # Open-ended start/end are still parsed with a dotted chromosome name
+        self.assertEqual(
+            tuple(rangelabel.from_label("NC_039902.1:10000000-", keep_gene=False)),
+            ("NC_039902.1", 9999999, None),
+        )
+        self.assertEqual(
+            tuple(rangelabel.from_label("NC_039902.1:-15000000", keep_gene=False)),
+            ("NC_039902.1", None, 15000000),
+        )
+        # unpack_range: whole dotted chromosome (no colon) and a region of it
+        for region, expect in (
+            ["NC_039902.1", ("NC_039902.1", None, None)],
+            ["NC_039902.1:10000000-15000000", ("NC_039902.1", 9999999, 15000000)],
+        ):
+            self.assertEqual(rangelabel.unpack_range(region), expect)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Issue #602 reported that `cnvkit.py scatter -c NC_039902.1:10000000-15000000` failed with `Invalid range spec: ...`. The root cause — the region-spec regex in `skgenome/rangelabel.py` rejecting `.` in chromosome names — was **already fixed** in commit `15df21c` (PR #603), which widened the chromosome group from `(\w+)?` to `(\w[\w.]*)?`.

That fix had **no test guarding it**: `test_rangelabel` only exercised `chr1`-style names, so a future refactor of the regex could silently re-break NCBI-style names. This PR closes that gap.

## What changed

- `test/test_genome.py`: add `test_rangelabel_ncbi_chrom`, covering `from_label` / `to_label` / `unpack_range` for dotted NCBI names, including:
  - a full region (`NC_039902.1:10000000-15000000`),
  - open-ended start (`NC_039902.1:-15000000`) and end (`NC_039902.1:10000000-`),
  - the whole-chromosome (no-colon) path through `unpack_range`.

## Why it's a real regression guard

The new test fails against the old `(\w+)?` regex (chromosome group captured as `None` → `from_label` raises `ValueError`) and passes against the current `(\w[\w.]*)?` regex.

## Notes

- The lengthy comment thread on #602 after PR #603 was a separate **user-data** issue (GFF3 key-value annotations dumped into the `.cnr` `gene` column), not a parser defect — out of scope here.
- **Test-only change**: no effect on `.cnr`/`.cns`/`.cnn`/SEG/VCF output, so no impact on downstream clinical pipelines.

Closes #602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)