### PR TITLE
Label only requested genes in scatter -g, not co-binned neighbors (gh#458)

### DIFF
--- a/cnvlib/plots.py
+++ b/cnvlib/plots.py
@@ -283,10 +283,13 @@ def gene_coords_by_name(probes, names):
         start = gene_probes["start"].min()
         end = gene_probes["end"].max()
         chrom = core.check_unique(gene_probes["chromosome"], name)
-        # Deduce the unique set of gene names for this region
-        uniq_names = set()
+        # Deduce the unique set of *requested* gene names for this region.
+        # A bin label may pack several genes (e.g. "ERBB2,MIR4728"); only the
+        # names the caller asked for should be surfaced, never co-binned
+        # neighbors (gh#458).
+        uniq_names: set[str] = set()
         for oname in gene_probes["gene"].dropna().unique():
-            uniq_names.update(oname.split(","))
+            uniq_names.update(g for g in oname.split(",") if g in names)
         all_coords[chrom][start, end].update(uniq_names)
     # Consolidate each region's gene names into a string
     uniq_coords = {}

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -15,7 +15,17 @@ import pandas as pd
 from skgenome import GenomicArray, tabio
 
 import cnvlib
-from cnvlib import cnary, fix, params, reports, segfilters, segmentation, segmetrics, vary
+from cnvlib import (
+    cnary,
+    fix,
+    params,
+    plots,
+    reports,
+    segfilters,
+    segmentation,
+    segmetrics,
+    vary,
+)
 from conftest import linecount
 
 
@@ -149,6 +159,36 @@ class CNATests(unittest.TestCase):
             par2y_overlapping_gene not in par_on_y["gene"].tolist(),
             "The overlapping region is not part of the filter.",
         )
+
+    def test_gene_coords_by_name(self):
+        """`-g` labels only requested genes, not co-binned neighbors (gh#458).
+
+        A bin whose `gene` column packs several names (e.g. "ERBB2,MIR4728")
+        must not surface the unrequested neighbor (MIR4728) when only ERBB2
+        is selected.
+        """
+        cnarr = cnary.CopyNumArray.from_rows(
+            [
+                ["chr17", 37800000, 37850000, "STARD3", 0.0],
+                ["chr17", 37850000, 37860000, "ERBB2,MIR4728", 0.0],
+                ["chr17", 37860000, 37870000, "ERBB2", 0.0],
+                ["chr17", 37880000, 37890000, "GRB7", 0.0],
+            ]
+        )
+        # Single requested gene: co-binned MIR4728 must be hidden
+        coords = plots.gene_coords_by_name(cnarr, ["ERBB2"])
+        self.assertEqual(list(coords.keys()), ["chr17"])
+        self.assertEqual(len(coords["chr17"]), 1)
+        start, end, name = coords["chr17"][0]
+        self.assertEqual(name, "ERBB2")
+        self.assertEqual((start, end), (37850000, 37870000))
+        # When MIR4728 *is* requested, it should appear
+        names_seen = set()
+        for _s, _e, label in plots.gene_coords_by_name(
+            cnarr, ["ERBB2", "MIR4728"]
+        )["chr17"]:
+            names_seen.update(label.split(","))
+        self.assertEqual(names_seen, {"ERBB2", "MIR4728"})
 
     def test_autosomes(self):
         """Test selection of autosomes specific to CNA."""


### PR DESCRIPTION
## Summary

`cnvkit scatter -c chr17:37850000-37890000 -g ERBB2` also labeled **MIR4728** — a gene the user never requested — contradicting the documented behavior (`doc/plots.rst`: *"Any other genes in the plotted region will not be shown unless also specified with -g"*).

## Root cause

CNVkit stores gene annotation inside each bin's `gene` column rather than as a separate track, so one bin label can pack several comma-joined genes (e.g. `"ERBB2,MIR4728"`). In `cnvlib/plots.py::gene_coords_by_name`, bins were *selected* correctly by the requested name, but the region's label was then *reconstructed* from the union of **all** gene names appearing in those bins — leaking co-binned neighbors.

## Fix

Restrict the reconstructed label to the requested names:

```python
uniq_names.update(g for g in oname.split(",") if g in names)
```

When several genes are requested and happen to share bins, all requested names still appear. Because every selected bin necessarily contains the requested `name`, no region can become unlabeled.

## Tests

- New `CNATests::test_gene_coords_by_name` (in `test/test_cnvlib.py`): asserts `-g ERBB2` against a bin labeled `"ERBB2,MIR4728"` yields only `ERBB2`, and that requesting both names surfaces both. The test fails against the old code (`'ERBB2,MIR4728' != 'ERBB2'`) and passes with the fix.
- Full `test_cnvlib.py` (30) and `test_commands.py` (73) pass; `mypy` and `ruff` clean.

## Notes

- **Plotting-label fix only** — no change to `.cnr`/`.cns`/`.cnn`/SEG/VCF output, so no impact on downstream clinical pipelines.
- The code now matches the existing docs, so no doc change is needed.

Closes #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)