### PR TITLE
Floor genome-wide scatter y-axis so deep deletions don't distort it (gh#385)

### DIFF
--- a/cnvlib/scatter.py
+++ b/cnvlib/scatter.py
@@ -24,6 +24,11 @@ POINT_COLOR = "#606060"
 SEG_COLOR = "darkorange"
 TREND_COLOR = "#A0A0A0"
 
+# Floor for the auto-scaled y-axis lower limit, so a single deep homozygous
+# deletion (log2 far below 0) can't compress the rest of the plot into a sliver.
+# Segments below this are flagged; override with the --y-min option. (gh#385)
+AUTO_Y_MIN_FLOOR = -5.0
+
 
 def _sex_labels(arr) -> tuple[str | None, str | None]:
     """Best-effort ``(x_label, y_label)`` from any genomic array.
@@ -216,7 +221,7 @@ def cnv_on_genome(
             seg_auto_vals = segments[~low_chroms]["log2"].dropna()
             if not y_min:
                 y_min = (
-                    np.nanmin([seg_auto_vals.min() - 0.2, -1.5])
+                    max(AUTO_Y_MIN_FLOOR, np.nanmin([seg_auto_vals.min() - 0.2, -1.5]))
                     if len(seg_auto_vals)
                     else -2.5
                 )
@@ -232,6 +237,18 @@ def cnv_on_genome(
             if not y_max:
                 y_max = 2.5
     axis.set_ylim(y_min, y_max)
+    if segments:
+        # Flag segments clipped below the (possibly floored) y-axis, so a deep
+        # homozygous deletion isn't silently dropped off the bottom (gh#385).
+        hidden_seg = segments["log2"] < y_min
+        if hidden_seg.sum():
+            logging.warning(
+                "With y_min=%s, %d genome-wide segment(s) are hidden below the "
+                "plot --> add '--y-min %s' to see them",
+                y_min,
+                int(hidden_seg.sum()),
+                int(np.floor(segments["log2"].min())),
+            )
 
     # Group probes by chromosome (to calculate plotting coordinates)
     if probes:
@@ -580,7 +597,7 @@ def cnv_on_chromosome(
 
     # Configure axes
     if not y_min:
-        y_min = max(-5.0, min(y.min() - 0.1, -0.3)) if len(y) else -1.1
+        y_min = max(AUTO_Y_MIN_FLOOR, min(y.min() - 0.1, -0.3)) if len(y) else -1.1
     if not y_max:
         y_max = max(0.3, y.max() + (0.25 if genes else 0.1)) if len(y) else 1.1
     if x_limits:

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -1786,6 +1786,45 @@ class PlotTests(unittest.TestCase):
         fig = scatter.do_scatter(cnarr, segarr, show_gene="BRAF")
         self.assertIsNotNone(fig)
 
+    def test_scatter_genome_y_floor(self):
+        """Genome-wide autoscale floors y_min so a single deep homozygous
+        deletion can't compress the whole plot (gh#385)."""
+        from matplotlib import pyplot
+
+        probes = cnary.CopyNumArray.from_rows(
+            [
+                ["chr1", 100, 200, "A", 0.0],
+                ["chr1", 200, 300, "A", -0.1],
+                ["chr1", 300, 400, "A", -12.0],
+                ["chr2", 100, 200, "B", 0.05],
+                ["chr2", 200, 300, "B", -0.2],
+            ],
+            columns=["chromosome", "start", "end", "gene", "log2"],
+        )
+        segments = cnary.CopyNumArray.from_rows(
+            [
+                ["chr1", 100, 400, "A", -12.0],
+                ["chr2", 100, 300, "B", 0.0],
+            ],
+            columns=["chromosome", "start", "end", "gene", "log2"],
+        )
+        segments.data["probes"] = [3, 2]
+        _fig, ax = pyplot.subplots()
+        scatter.cnv_on_genome(ax, probes, segments)
+        y_lo, _y_hi = ax.get_ylim()
+        pyplot.close(_fig)
+        self.assertGreaterEqual(
+            y_lo,
+            scatter.AUTO_Y_MIN_FLOOR,
+            "Deep deletion must not pull the genome-wide y-axis below the floor",
+        )
+        # An explicit --y-min still overrides the floor
+        _fig, ax = pyplot.subplots()
+        scatter.cnv_on_genome(ax, probes, segments, y_min=-15.0, y_max=2.0)
+        y_lo, _y_hi = ax.get_ylim()
+        pyplot.close(_fig)
+        self.assertAlmostEqual(y_lo, -15.0)
+
     def test_heatmap(self):
         """The 'heatmap' command."""
         cnarrs = [cnvlib.read("formats/amplicon.cnr")]


### PR DESCRIPTION
## Summary

Plotting homozygous deletions (very large negative log2) distorted the y-axis of `cnvkit.py scatter`. The **region/chromosome** view was fixed long ago — it clamps its auto-scaled lower limit at `-5.0` and flags clipped segments (commits `ca8d5cc` / `0920829`). The **genome-wide** view (`cnv_on_genome`) never got the same treatment.

## Root cause

`cnv_on_genome` computed `y_min = np.nanmin([seg_auto_vals.min() - 0.2, -1.5])` with **no lower bound**. A single homozygous-deletion segment (log2 ≈ -12) drove `y_min` to ≈ `-12.2`, compressing all real signal into the top ~10% of the plot.

Empirically, before the fix:

| view | ylim with a log2≈-12 segment |
|------|------|
| region (`cnv_on_chromosome`) | `(-5.0, 0.3)` ✓ |
| genome (`cnv_on_genome`) | `(-12.2, 1.5)` ✗ |

## Fix

- Add a shared `AUTO_Y_MIN_FLOOR = -5.0` constant.
- Apply it in `cnv_on_genome`: `max(AUTO_Y_MIN_FLOOR, np.nanmin([seg.min() - 0.2, -1.5]))`. This keeps the existing `-1.5` default-extend (quiet genomes are unaffected), extends to fit moderate deletions, and floors pathological ones at `-5.0`.
- Warn when segments are clipped below the floor — parity with the region view — pointing users to `--y-min`.
- Switch the region view's literal `-5.0` to the shared constant (no behavior change).

After the fix: genome `(-5.0, 1.5)`; quiet genome (no deep deletion) still `(-1.5, 1.5)`; explicit `--y-min -15` still honored.

## Tests

- New `PlotTests::test_scatter_genome_y_floor` (`test/test_commands.py`): asserts the genome-wide y-axis is floored at `AUTO_Y_MIN_FLOOR` for a deep-deletion dataset, and that an explicit `--y-min` overrides it. Written failing first (`-12.2 not >= -5.0`), passes with the fix.
- `test_commands.py` (74) and `test_cnvlib.py` (30) pass; `mypy` and `ruff` clean.

## Clinical-impact note

**Plotting-only.** Genome-wide scatter plots containing very deep deletions now render with a `-5.0` lower bound instead of an arbitrarily low one (this is the intended fix). **No change to `.cnr`/`.cns`/`.cnn`/SEG/VCF output**, so downstream pipelines are unaffected. The `--y-min` escape hatch is preserved.

Closes #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)