### PR TITLE
Guard _mirrored_baf against all-NaN median to fix 3.11-min CI (gh#407)

### DIFF
--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -196,6 +196,11 @@ class VariantArray(GenomicArray):
 def _mirrored_baf(vals: pd.Series, above_half: bool | None = None) -> pd.Series:
     shift = (vals - 0.5).abs()
     if above_half is None:
+        if vals.isna().all():
+            # No usable frequencies: the median is undefined and np.nanmedian
+            # warns ("Mean of empty slice") on an all-NaN slice under older
+            # numpy. The mirrored result is all-NaN regardless of direction. (#407)
+            return shift
         above_half = vals.median() > 0.5
     if above_half:
         return 0.5 + shift

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -2,7 +2,9 @@
 """Unit tests for the CNVkit library, cnvlib."""
 
 import logging
+import math
 import unittest
+import warnings
 
 import pytest
 
@@ -13,7 +15,7 @@ import pandas as pd
 from skgenome import GenomicArray, tabio
 
 import cnvlib
-from cnvlib import cnary, fix, params, reports, segfilters, segmentation, segmetrics
+from cnvlib import cnary, fix, params, reports, segfilters, segmentation, segmetrics, vary
 from conftest import linecount
 
 
@@ -863,6 +865,29 @@ class VATests(unittest.TestCase):
         """Instantiate from a VCF file."""
         variants = tabio.read("formats/na12878_na12882_mix.vcf", "vcf")
         self.assertGreater(len(variants), 0)
+
+    def test_mirrored_baf_all_nan(self):
+        """All-NaN frequencies mirror to all-NaN without warning (gh#407).
+
+        np.nanmedian warns 'Mean of empty slice' on an all-NaN slice under
+        older numpy; with pytest's filterwarnings=error that breaks the build
+        (the 3.11-min job). _mirrored_baf must short-circuit before calling
+        .median() on such a slice.
+        """
+        vals = pd.Series([np.nan, np.nan, np.nan])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            out = vary._mirrored_baf(vals)
+        self.assertEqual(len(out), len(vals))
+        self.assertTrue(out.isna().all())
+        # A partially-NaN slice still mirrors normally (median over real values)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            mixed = vary._mirrored_baf(pd.Series([np.nan, 0.2, 0.3]))
+        self.assertTrue(math.isnan(mixed.iloc[0]))
+        # median 0.25 < 0.5 -> below-half branch (0.5 - shift); both already minor
+        self.assertAlmostEqual(mixed.iloc[1], 0.2)
+        self.assertAlmostEqual(mixed.iloc[2], 0.3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**master is currently red on the `3.11-min` CI job** (e.g. the merge of #1077, run `26365341592`), and every PR branched off master inherits the failure (#1078, #1079). This fixes the root cause.

## Root cause

PR #407 keeps `alt_freq` as NaN when a VCF lacks allele counts. A bin whose heterozygous SNPs all lack frequencies then hands `_mirrored_baf` an **all-NaN** slice, where it calls:

```python
above_half = vals.median() > 0.5   # cnvlib/vary.py
```

Under the **min-pinned (older) numpy**, `pd.Series.median()` on an all-NaN slice routes through `np.nanmedian` → `np.nanmean` of an empty slice, which emits `RuntimeWarning: "Mean of empty slice"`. Because `pyproject.toml` sets `filterwarnings = ["error"]`, that warning becomes a test failure. Newer numpy (the regular jobs) doesn't warn, so only `3.11-min` fails.

#407 added an all-NaN guard in the **outer** `summarize()` (protecting `summary_func`), but the **inner** `median()` in `_mirrored_baf` runs first and was left unguarded.

Affected tests (both via `baf_by_ranges → summarize → _mirrored_baf`):
- `test/test_commands.py::CallTests::test_call_filter`
- `test/test_io.py::IOTests::test_read_vcf_het_no_alt_count`

## Fix

Short-circuit `_mirrored_baf` for an all-NaN slice before calling `.median()`; the mirrored result is all-NaN regardless of mirroring direction:

```python
if vals.isna().all():
    return shift   # all-NaN
above_half = vals.median() > 0.5
```

## Tests

- New `VATests::test_mirrored_baf_all_nan` (`test/test_cnvlib.py`): under `warnings.simplefilter("error")`, asserts an all-NaN input mirrors to all-NaN without warning, and that a partially-NaN slice still mirrors correctly (median taken over the real values).
- Locally (numpy 2.4.3) `test_cnvlib.py` + `test_io.py` + `test_commands.py` = 119 passed; `mypy` and `ruff` clean. The warning is numpy-version-dependent, so the warnings-as-error assertion is the guard that bites in the `3.11-min` environment.

## Clinical-impact note

Behavior is unchanged for VCFs that **do** carry allele counts (the `median()` path is untouched there). For the no-allele-count case the BAF was already meant to be NaN (#407); this only stops a spurious warning/crash. **No change to `.cnr`/`.cns`/`.cnn`/SEG/VCF numeric output.**

Refs #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)