### PR TITLE
haar: fix degenerate-input FDR threshold + NaN-safe weights, drop dead code

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -318,7 +318,11 @@ def _do_segmentation(
             return segarr, seg_out
         return segarr
     if variants and not method.startswith("hmm"):
-        # Re-segment the variant allele freqs within each segment
+        # Re-segment the variant allele freqs within each segment.
+        # BAF re-segmentation intentionally uses the HMM (a 2-state Viterbi on
+        # mirrored BAF) for every non-HMM method, per commit 692d5a5; the older
+        # Haar-on-BAF path was removed as dead code. See bead for selectable/
+        # upgraded BAF refinement (beta-binomial) if this is revisited.
         # TODO train on all segments together
         logging.info("Re-segmenting on variant allele frequency")
         newsegs = [

--- a/cnvlib/segmentation/haar.py
+++ b/cnvlib/segmentation/haar.py
@@ -34,6 +34,11 @@ if TYPE_CHECKING:
     from cnvlib.cnary import CopyNumArray
     from numpy import float64, ndarray
 
+# Lower bound for the wavelet-coefficient noise estimate, so a degenerate
+# (all-flat / quantized) signal can't drive it to exactly 0 and break the FDR
+# threshold's normal CDF. Far below any real log2/BAF step magnitude.
+SIGMA_FLOOR = 1e-10
+
 
 def segment_haar(cnarr: CopyNumArray, fdr_q: float) -> CopyNumArray:
     """Do segmentation for CNVkit.
@@ -81,114 +86,6 @@ def one_chrom(cnarr: CopyNumArray, fdr_q: float, chrom: str) -> pd.DataFrame:
         }
     )
     return table
-
-
-def variants_in_segment(varr, segment, fdr_q):
-    """Segment a single genomic interval based on B-allele frequencies.
-
-    Applies HaarSeg segmentation to variant allele frequencies within a segment
-    to detect sub-clonal changes or allelic imbalances. This is used for
-    allele-specific copy number analysis.
-
-    Parameters
-    ----------
-    varr : VariantArray
-        Variant allele frequency data (from VCF) within the segment region.
-        Contains SNV positions and their B-allele frequencies.
-    segment : Row or CopyNumArray
-        A single segment from copy number segmentation results.
-        Must have 'chromosome', 'start', 'end', 'gene', 'log2', 'probes' fields.
-    fdr_q : float
-        False discovery rate q-value for HaarSeg breakpoint detection.
-        Typical values: 0.01, 0.001, 0.0001. Lower = less sensitive.
-
-    Returns
-    -------
-    pandas.DataFrame
-        Segmentation results as a table with columns:
-        - chromosome, start, end: Genomic coordinates
-        - gene: Gene name from parent segment
-        - log2: Copy ratio from parent segment (not re-calculated)
-        - probes: Number of variants in each sub-segment
-
-        If no sub-segmentation is detected (≤1 breakpoint), returns the
-        original segment as a single-row DataFrame.
-
-    Notes
-    -----
-    The function:
-
-    1. Transforms B-allele frequencies to mirrored values (0.5-1.0 range)
-       with tumor purity boosting
-    2. Applies HaarSeg to detect breakpoints in allele frequencies
-    3. If multiple segments found, places breakpoints midway between SNVs
-    4. If no segmentation needed, returns original segment unchanged
-
-    The log2 copy ratio is inherited from the parent segment and not
-    recalculated, as this function focuses on allelic changes.
-
-    This is primarily used internally by the `call` command when VCF data
-    is provided to refine segment boundaries based on heterozygous SNPs.
-
-    See Also
-    --------
-    haarSeg : The underlying HaarSeg segmentation algorithm
-    VariantArray.mirrored_baf : Transforms BAF values for segmentation
-    """
-    if len(varr):
-        values = varr.mirrored_baf(above_half=True, tumor_boost=True)
-        results = haarSeg(values, fdr_q, weights=None)  # ENH weight by sqrt(DP)
-    else:
-        values = pd.Series()
-        results = None
-    if results is not None and len(results["start"]) > 1:
-        logging.info(
-            "Segmented on allele freqs in %s:%d-%d",
-            segment.chromosome,
-            segment.start,
-            segment.end,
-        )
-        # Ensure breakpoint locations make sense
-        # - Keep original segment start, end positions
-        # - Place breakpoints midway between SNVs, I guess?
-        # NB: 'results' are indices, i.e. enumerated bins
-        gap_rights = varr["start"].to_numpy().take(results["start"][1:])
-        gap_lefts = varr["end"].to_numpy().take(results["end"][:-1])
-        mid_breakpoints = (gap_lefts + gap_rights) // 2
-        starts = np.concatenate([[segment.start], mid_breakpoints])
-        ends = np.concatenate([mid_breakpoints, [segment.end]])
-        table = pd.DataFrame(
-            {
-                "chromosome": segment.chromosome,
-                "start": starts,
-                "end": ends,
-                # 'baf': results['mean'],
-                "gene": segment.gene,  # '-'
-                "log2": segment.log2,
-                "probes": results["size"],
-                # 'weight': (segment.weight * results['size']
-                #            / (segment.end - segment.start)),
-            }
-        )
-    else:
-        table = pd.DataFrame(
-            {
-                "chromosome": segment.chromosome,
-                "start": segment.start,
-                "end": segment.end,
-                # 'baf': values.median(),
-                "gene": segment.gene,  # '-',
-                "log2": segment.log2,
-                "probes": segment.probes,
-                # 'weight': segment.weight,
-            },
-            index=[0],
-        )
-
-    return table
-
-
-# ---- from HaarSeg R code -- the API ----
 
 
 def haarSeg(
@@ -259,6 +156,15 @@ def haarSeg(
     else:
         peakSigmaEst = med_abs_diff(diff_signal)
 
+    # Floor the noise estimate: for mostly-flat / quantized input (>=50% of
+    # adjacent bins bit-identical) the median absolute coefficient is exactly 0,
+    # which would make FDRThres' norm.cdf(scale=0) return NaN p-values and
+    # silently drop real breakpoints. A tiny positive floor keeps genuine steps
+    # (magnitude >> SIGMA_FLOOR) significant without admitting numerical noise.
+    # Real continuous log2/BAF data has noise, so peakSigmaEst >> the floor and
+    # this is a no-op there.
+    peakSigmaEst = max(peakSigmaEst, SIGMA_FLOOR)
+
     breakpoints = np.array([], dtype=np.int_)
     for level in range(haarStartLevel, haarEndLevel + 1):
         stepHalfSize = 2**level
@@ -297,6 +203,11 @@ def FDRThres(x: ndarray, q: float, stdev: float64) -> int | float64:
     M = len(x)
     if M < 2:
         return 0
+    if stdev <= 0:
+        # Zero/negative noise: norm.cdf(scale<=0) is NaN. Against a zero noise
+        # floor every nonzero peak is infinitely significant, so admit them all
+        # (threshold 0); the caller floors stdev (SIGMA_FLOOR) so this is a guard.
+        return np.float64(0.0)
 
     m = np.arange(1, M + 1) / M
     x_sorted = np.sort(np.abs(x))[::-1]
@@ -310,7 +221,11 @@ def FDRThres(x: ndarray, q: float, stdev: float64) -> int | float64:
         logging.debug(
             "No passing p-values: min p=%.4g, min m=%.4g, q=%s", p[0], m[0], q
         )
-        T = x_sorted[0] + 1e-16  # ~= 2^-52, like MATLAB "eps"
+        # No peak is significant -> set the threshold just above the largest so
+        # the '>=' test admits nothing. Use nextafter, not '+1e-16': near
+        # magnitude 1 that addend is below the float64 ULP (~2.22e-16) and is a
+        # no-op, which let the largest peak slip through.
+        T = np.nextafter(x_sorted[0], np.inf)
     return T  # type: ignore[no-any-return]
 
 
@@ -330,8 +245,9 @@ def SegmentByPeaks(
     """
     if len(peaks) == 0:
         # Single segment spanning all data
-        if weights is not None and weights.sum() > 0:
-            mean_val = np.average(data, weights=weights)
+        if weights is not None and np.nansum(weights) > 0:
+            valid = ~np.isnan(weights)
+            mean_val = np.average(data[valid], weights=weights[valid])
         else:
             mean_val = np.mean(data)
         return np.full_like(data, mean_val)
@@ -350,11 +266,13 @@ def SegmentByPeaks(
         seg_means = np.empty(n_segs, dtype=np.float64)
         for i in range(n_segs):
             start, end = bounds[i], bounds[i + 1]
+            seg_data = data[start:end]
             w = weights[start:end]
-            if w.sum() > 0:
-                seg_means[i] = np.average(data[start:end], weights=w)
+            if np.nansum(w) > 0:
+                valid = ~np.isnan(w)
+                seg_means[i] = np.average(seg_data[valid], weights=w[valid])
             else:
-                seg_means[i] = np.mean(data[start:end])
+                seg_means[i] = np.mean(seg_data)
 
     # Expand segment means to full array using repeat
     return np.repeat(seg_means, seg_lengths)
@@ -364,6 +282,8 @@ def SegmentByPeaks(
 
 
 # --- HaarSeg.h
+
+
 def HaarConv(
     signal: ndarray,  # const double * signal,
     weight: ndarray | None,  # const double * weight,
@@ -628,6 +548,8 @@ def PulseConv(
 
 
 # XXX Apply afterward to the segmentation result? (not currently used)
+
+
 def AdjustBreaks(
     signal,  # const double * signal,
     peakLoc,  # const int * peakLoc,
@@ -679,40 +601,3 @@ def AdjustBreaks(
 
 
 # Testing
-
-
-def table2coords(seg_table):
-    """Return x, y arrays for plotting."""
-    x = []
-    y = []
-    for start, size, val in seg_table:
-        x.append(start)
-        x.append(start + size)
-        y.append(val)
-        y.append(val)
-    return x, y
-
-
-if __name__ == "__main__":
-    real_data = np.concatenate(
-        (np.zeros(800), np.ones(200), np.zeros(800), 0.8 * np.ones(200), np.zeros(800))
-    )
-    # rng = np.random.default_rng(0x5EED)
-    rng = np.random.default_rng()
-    noisy_data = real_data + rng.standard_normal(len(real_data)) * 0.2
-
-    # # Run using default parameters
-    seg_table = haarSeg(noisy_data, 0.005)
-
-    logging.info("%s", seg_table)
-
-    from matplotlib import pyplot
-
-    indices = np.arange(len(noisy_data))
-    pyplot.scatter(indices, noisy_data, alpha=0.2, color="gray")
-    x, y = table2coords(seg_table)
-    pyplot.plot(x, y, color="r", marker="x", lw=2, snap=False)
-    pyplot.show()
-
-    # # The complete segmented signal
-    # lines(seg.data$Segmented, col="red", lwd=3)

--- a/test/test_haar.py
+++ b/test/test_haar.py
@@ -13,6 +13,7 @@ from cnvlib.segmentation.haar import (
     FindLocalPeaks,
     HaarConv,
     PulseConv,
+    SegmentByPeaks,
     haarSeg,
 )
 
@@ -67,6 +68,26 @@ class FDRThresTests(unittest.TestCase):
         # With larger stdev, same x values have larger p-values (less significant),
         # so fewer pass the FDR criterion, resulting in a higher threshold
         self.assertGreaterEqual(T2, T1)
+
+    def test_fdr_thres_zero_stdev(self):
+        """stdev=0 must not yield NaN p-values; all peaks are admitted (scq.2).
+
+        norm.cdf(scale=0) returns NaN, which previously made every p-value NaN
+        and silently dropped real breakpoints.
+        """
+        T = FDRThres(np.array([1.0, 0.5, 0.2]), 0.05, 0.0)
+        self.assertFalse(np.isnan(T))
+        self.assertEqual(T, 0.0)
+
+    def test_fdr_thres_rejects_all_when_none_significant(self):
+        """When no peak is significant, T strictly exceeds max|x| (scq.2).
+
+        The old fallback `x_sorted[0] + 1e-16` is a no-op near magnitude 1.0
+        (1e-16 < ULP), so the largest peak slipped through `>=`.
+        """
+        x = np.array([1.0, 0.9, 0.8])
+        T = FDRThres(x, 1e-12, 10.0)  # tiny q, large stdev -> nothing significant
+        self.assertGreater(T, np.max(np.abs(x)))
 
 
 class HaarConvTests(unittest.TestCase):
@@ -196,6 +217,46 @@ class HaarSegIntegrationTests(unittest.TestCase):
         self.assertIn("start", result)
         self.assertIn("end", result)
         self.assertEqual(result["start"][0], 0)
+
+    def test_haarseg_mostly_flat_keeps_small_breakpoint(self):
+        """Mostly-flat (zero-noise) input must not drop a smaller breakpoint.
+
+        Here median(|level-1 Haar coef|) == 0 so peakSigmaEst was 0, which made
+        FDR p-values NaN and silently dropped the small -2 -> -2.3 step,
+        yielding 2 segments instead of 3 (scq.2). Real noisy data is unaffected
+        (noise keeps peakSigmaEst > 0).
+        """
+        signal = np.concatenate(
+            [np.zeros(30), np.full(30, -2.0), np.full(30, -2.3)]
+        )
+        result = haarSeg(signal, breaksFdrQ=0.001)
+        self.assertEqual(len(result["start"]), 3)
+        assert_allclose(result["mean"], [0.0, -2.0, -2.3], atol=1e-9)
+
+    def test_haarseg_constant_signal_stays_one_segment(self):
+        """The peakSigmaEst floor must not over-segment a constant signal."""
+        result = haarSeg(np.zeros(100), breaksFdrQ=0.01)
+        self.assertEqual(len(result["start"]), 1)
+
+
+class SegmentByPeaksTests(unittest.TestCase):
+    """Tests for weighted segment-mean computation."""
+
+    def test_segment_by_peaks_nan_weight_single_segment(self):
+        """A NaN weight is excluded, not treated as 'no valid weights' (scq.3)."""
+        data = np.array([1.0, 3.0])
+        weights = np.array([1.0, np.nan])
+        out = SegmentByPeaks(data, np.array([], dtype=int), weights)
+        # Exclude the NaN-weighted bin -> mean is just the first value (1.0);
+        # the old code fell back to the unweighted mean (2.0).
+        assert_allclose(out, [1.0, 1.0])
+
+    def test_segment_by_peaks_nan_weight_per_segment(self):
+        """Per-segment weighted means also exclude NaN weights (scq.3)."""
+        data = np.array([1.0, 3.0, 10.0, 10.0])
+        weights = np.array([1.0, np.nan, 1.0, 1.0])
+        out = SegmentByPeaks(data, np.array([2]), weights)
+        assert_allclose(out, [1.0, 1.0, 10.0, 10.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
First of two PRs from the pre-release segmentation review (epic `cnvkit-scq`). All changes are in `cnvlib/segmentation/haar.py` (+ one comment in `__init__.py`).

## Clinical-impact note
**Verified output-neutral on real data:** haar segmentation of every chromosome in the test `.cnr`/`.cns` files is byte-identical before/after this change (start indices + segment means). The behavior changes only manifest on **degenerate/quantized** signals (≥50% bit-identical adjacent bins) or inputs with **NaN weights** — i.e. the bug cases. No change to `.cns` output for normal continuous log2 data.

## Fixes

**1. FDR threshold robustness (scq.2)** — When `median(|level-1 Haar coef|) == 0` (mostly-flat/quantized input), `peakSigmaEst` was `0`, so `scipy.norm.cdf(scale=0)` returned all-NaN p-values and the fallback `T = x_sorted[0] + 1e-16` — a **no-op** below the float64 ULP near magnitude 1 — let only the single largest peak through, silently dropping smaller real breakpoints (verified: flat `0/-2/-2.3` → 2 segments instead of 3).
  - Floor the noise estimate at `SIGMA_FLOOR = 1e-10` (a no-op for real noisy data, where it's already far larger).
  - Guard `FDRThres` against `stdev <= 0`.
  - Replace the `+1e-16` fallback with `np.nextafter(..., inf)` so "reject all" actually rejects (fixes the misleading `~= MATLAB eps` comment too).

**2. NaN-safe segment weights (scq.3)** — `SegmentByPeaks` used `weights.sum()`/`np.average` without masking NaN, silently falling back to an *unweighted* mean when any weight was NaN. Now uses `np.nansum` + a `~isnan` mask (matching `transfer_fields`). Latent (upstream filters NaN-weight bins), per the CLAUDE.md NaN rule.

**3. Dead-code removal (scq.1, + part of scq.6)** — Delete `haar.variants_in_segment` (~100 lines, orphaned when `692d5a5` *deliberately* switched BAF re-segmentation to the HMM — confirmed via git history), plus the unused `__main__` demo block and `table2coords` helper. A comment at the `__init__.py` call site documents the intentional HMM choice. Follow-up for selectable/upgraded (beta-binomial) BAF refinement is tracked in a separate feature bead.

## Tests
- New `test_haar.py` tests for all three (written failing-first): zero-stdev / non-significant FDR fallback, mostly-flat-keeps-small-breakpoint, constant-signal-stays-one-segment, and `SegmentByPeaks` NaN-weight handling.
- `test_haar.py` + `test_segmentation.py` + haar consumers: 128 passed. `mypy` + `ruff` clean.

Refs epic #(cnvkit-scq). PR 2 (scaffolding cleanup: `if threshold is None`, hmm DRY, typing) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)