### PR TITLE
segmentation: DRY hmm emissions, fix threshold=0 trap, typing cleanup

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
 
 
 SEGMENT_METHODS = ("cbs", "flasso", "haar", "none", "hmm", "hmm-tumor", "hmm-germline")
+# HMM method variants, for dispatch (replaces scattered method.startswith("hmm"))
+_HMM_METHODS = frozenset({"hmm", "hmm-tumor", "hmm-germline"})
 
 
 def do_segmentation(
@@ -107,7 +109,7 @@ def do_segmentation(
         variants = variants.copy()
         variants.sort()
 
-    if not threshold:
+    if threshold is None:
         threshold = {
             "cbs": 0.0001,
             "flasso": 0.0001,
@@ -115,7 +117,7 @@ def do_segmentation(
         }.get(method)
     msg = "Segmenting with method " + repr(method)
     if threshold is not None:
-        if method.startswith("hmm"):
+        if method in _HMM_METHODS:
             msg += f", smoothing window size {threshold},"
         else:
             msg += f", significance threshold {threshold},"
@@ -124,7 +126,7 @@ def do_segmentation(
 
     # NB: parallel cghFLasso segfaults in R ('memory not mapped'),
     # even when run on a single chromosome
-    if method == "flasso" or method.startswith("hmm"):
+    if method == "flasso" or method in _HMM_METHODS:
         # ENH segment p/q arms separately
         # -> assign separate identifiers via chrom name suffix?
         cna = _do_segmentation(
@@ -138,6 +140,7 @@ def do_segmentation(
             min_weight,
             save_dataframe,
             rscript_path,
+            smooth_cbs,
         )
         if save_dataframe:
             cna, rstr = cna  # type: ignore[misc]
@@ -190,7 +193,19 @@ def _to_str(s, enc=locale.getpreferredencoding()):  # noqa: B008
 
 
 def _ds(
-    args: tuple[CNA, str, None, float, None, bool, int, int, bool, str, bool],
+    args: tuple[
+        CNA,
+        str,
+        str | None,
+        float | None,
+        VariantArray | None,
+        bool,
+        int,
+        int,
+        bool,
+        str,
+        bool,
+    ],
 ) -> CNA | tuple[CNA, str]:
     """Wrapper for parallel map"""
     return _do_segmentation(*args)
@@ -317,7 +332,7 @@ def _do_segmentation(
         if save_dataframe:
             return segarr, seg_out
         return segarr
-    if variants and not method.startswith("hmm"):
+    if variants and method not in _HMM_METHODS:
         # Re-segment the variant allele freqs within each segment.
         # BAF re-segmentation intentionally uses the HMM (a 2-state Viterbi on
         # mirrored BAF) for every non-HMM method, per commit 692d5a5; the older

--- a/cnvlib/segmentation/hmm.py
+++ b/cnvlib/segmentation/hmm.py
@@ -66,12 +66,15 @@ def enumerate_states(
 
 def _expected_log2(
     cn: NDArray[np.float64],
-    purity: float,
-    ploidy: float,
+    purity: float | NDArray[np.float64],
+    ploidy: float | NDArray[np.float64],
 ) -> NDArray[np.float64]:
     """Expected log2 ratio for given CN, purity, ploidy.
 
     Formula: log2((p*cn + (1-p)*2) / (p*ploidy + (1-p)*2))
+
+    All arguments broadcast together, so this serves both the per-state (1-D)
+    and the batched grid-search (3-D) emission paths.
     """
     p = purity
     numerator = p * cn + (1 - p) * 2.0
@@ -84,12 +87,14 @@ def _expected_log2(
 def _expected_minor_freq(
     minor: NDArray[np.float64],
     cn: NDArray[np.float64],
-    purity: float,
+    purity: float | NDArray[np.float64],
 ) -> NDArray[np.float64]:
     """Expected minor allele frequency (<= 0.5) for given minor allele count, CN, purity.
 
     Formula: (p*minor + (1-p)*1) / (p*cn + (1-p)*2)
     For cn=0, return 0.5 (no allelic information).
+
+    All arguments broadcast together (per-state and batched grid paths).
     """
     p = purity
     numerator = p * minor + (1 - p) * 1.0
@@ -97,7 +102,15 @@ def _expected_minor_freq(
     # Avoid division by zero for cn=0 at high purity
     with np.errstate(divide="ignore", invalid="ignore"):
         baf = np.where(denominator > 0, numerator / denominator, 0.5)
-    return baf
+    return baf  # type: ignore[no-any-return]
+
+
+def _gaussian_log_pdf(diff: NDArray[np.float64], stdev: float) -> NDArray[np.float64]:
+    """Log of the Gaussian density N(diff | 0, stdev), elementwise.
+
+    log N(x|mu,s) = -0.5*((x-mu)/s)^2 - log(s*sqrt(2*pi)); pass diff = x - mu.
+    """
+    return -0.5 * (diff / stdev) ** 2 - np.log(stdev * np.sqrt(2.0 * np.pi))  # type: ignore[no-any-return]
 
 
 def _betabinom_logpmf(
@@ -159,9 +172,7 @@ def log_emission_probs(
     # Log2 component: N(obs | expected, stdev)
     # log N(x|mu,s) = -0.5*((x-mu)/s)^2 - log(s) - 0.5*log(2*pi)
     diff_l2 = log2_obs[:, np.newaxis] - expected_l2[np.newaxis, :]  # (T, N)
-    log_p = -0.5 * (diff_l2 / log2_stdev) ** 2 - np.log(
-        log2_stdev * np.sqrt(2.0 * np.pi)
-    )
+    log_p = _gaussian_log_pdf(diff_l2, log2_stdev)
 
     # BAF component: beta-binomial on aggregated allele counts
     if minor_counts is not None and depths is not None:
@@ -474,10 +485,7 @@ def _batched_emission_log2(
     plo = ploidies[np.newaxis, :, np.newaxis]  # (1, G_l, 1)
     cn = cn_arr[np.newaxis, np.newaxis, :]  # (1, 1, N)
 
-    numerator = p * cn + (1.0 - p) * 2.0
-    denominator = p * plo + (1.0 - p) * 2.0
-    ratio = np.maximum(numerator, 1e-4) / denominator
-    expected_l2 = np.log2(ratio)  # (G_p, G_l, N)
+    expected_l2 = _expected_log2(cn, p, plo)  # (G_p, G_l, N)
 
     # Reshape to (G, N) where G = G_p * G_l
     G_p, G_l, N = expected_l2.shape
@@ -486,8 +494,8 @@ def _batched_emission_log2(
     # Compute log emission: N(obs | expected, stdev)
     # log2_obs: (T,), expected_l2: (G, N) -> diff: (G, T, N)
     diff = log2_obs[np.newaxis, :, np.newaxis] - expected_l2[:, np.newaxis, :]
-    log_p = -0.5 * (diff / log2_stdev) ** 2 - np.log(log2_stdev * np.sqrt(2.0 * np.pi))
-    return log_p  # type: ignore[no-any-return]  # (G, T, N)
+    log_p = _gaussian_log_pdf(diff, log2_stdev)
+    return log_p  # (G, T, N)
 
 
 def _batched_emission_baf(
@@ -509,11 +517,7 @@ def _batched_emission_baf(
     cn = cn_arr[np.newaxis, :]  # (1, N)
     mn = minor_arr[np.newaxis, :]  # (1, N)
 
-    numerator = p * mn + (1.0 - p) * 1.0
-    denominator = p * cn + (1.0 - p) * 2.0
-    with np.errstate(divide="ignore", invalid="ignore"):
-        expected_freq = np.where(denominator > 0, numerator / denominator, 0.5)
-    # (G_p, N)
+    expected_freq = _expected_minor_freq(mn, cn, p)  # (G_p, N)
 
     # Repeat for each ploidy (BAF doesn't depend on ploidy)
     expected_freq = np.repeat(expected_freq, n_ploidies, axis=0)  # (G, N)
@@ -670,7 +674,7 @@ def grid_search_purity_ploidy(
 # --- Method parameters ---
 
 
-def _method_params(method: str) -> dict:
+def _method_params(method: str) -> dict[str, float | int]:
     """Get HMM parameters for the given method variant."""
     match method:
         case "hmm-germline":
@@ -724,7 +728,7 @@ def segment_hmm(
     """
     params = _method_params(method)
     include_baf = variants is not None
-    max_copies: int = params["max_copies"]
+    max_copies = int(params["max_copies"])
 
     # 1. Smooth log2
     orig_log2 = cnarr["log2"].to_numpy().copy()
@@ -860,7 +864,9 @@ def segment_hmm(
 # --- BAF re-segmentation (for non-HMM methods) ---
 
 
-def variants_in_segment(varr, segment, min_variants=MIN_VARIANTS_THRESHOLD):
+def variants_in_segment(
+    varr: VariantArray, segment, min_variants: int = MIN_VARIANTS_THRESHOLD
+) -> pd.DataFrame:
     """Re-segment a segment based on variant allele frequencies.
 
     Uses a simple 2-state HMM (neutral BAF=0.5 vs alt BAF=0.67) with
@@ -891,7 +897,7 @@ def variants_in_segment(varr, segment, min_variants=MIN_VARIANTS_THRESHOLD):
 
             # Log emission: N(obs | mean, stdev)
             diff = obs[:, np.newaxis] - means[np.newaxis, :]  # (T, 2)
-            log_emit = -0.5 * (diff / stdev) ** 2 - np.log(stdev * np.sqrt(2.0 * np.pi))
+            log_emit = _gaussian_log_pdf(diff, stdev)
 
             # Homogeneous transitions: strongly prefer staying
             p_stay = 0.99

--- a/cnvlib/segmentation/none.py
+++ b/cnvlib/segmentation/none.py
@@ -1,29 +1,34 @@
-"""Trivial segmentation: one segment per chromosome (or arm).
+"""Trivial segmentation: one segment per chromosome arm.
 
-Assume the input CopyNumArray has already been split by chromosome and arm (if
-the centromere location can be inferred) via CNA.by_arm().
-
-This procedure calculates a single segment's mean and coordinates across the
-given array.
+This procedure calculates a single segment's mean and coordinates for each
+chromosome arm in the given array (splitting via CNA.by_arm()).
 """
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
 from ..segmetrics import segment_mean
 
+if TYPE_CHECKING:
+    from ..cnary import CopyNumArray
 
-def segment_none(cnarr):
-    """Return a single segment for the given region."""
+
+def segment_none(cnarr: CopyNumArray) -> CopyNumArray:
+    """Return one trivial segment per chromosome arm in the given array."""
     colnames = ["chromosome", "start", "end", "log2", "gene", "probes"]
     rows = [
         (
-            cnarr.chromosome.iat[0],
-            cnarr.start.iat[0],
-            cnarr.end.iat[-1],
-            segment_mean(cnarr),
+            arm.chromosome.iat[0],
+            arm.start.iat[0],
+            arm.end.iat[-1],
+            segment_mean(arm),
             "-",
-            len(cnarr),
+            len(arm),
         )
+        for _label, arm in cnarr.by_arm()
+        if len(arm)
     ]
     table = pd.DataFrame.from_records(rows, columns=colnames)
     segarr = cnarr.as_dataframe(table)

--- a/test/test_segmentation.py
+++ b/test/test_segmentation.py
@@ -160,6 +160,19 @@ class SegmentationTests(unittest.TestCase):
         self.assertEqual(len(segments_df), 0)
         self.assertEqual(rstr, "")
 
+    def test_threshold_zero_not_overridden(self):
+        """threshold=0.0 is honored, not treated as 'unset' (scq.4).
+
+        'if not threshold' replaced the valid value 0.0 with the method default;
+        'if threshold is None' keeps it.
+        """
+        cnarr = cnvlib.read("formats/amplicon.cnr")
+        with self.assertLogs(level="INFO") as cm:
+            segmentation.do_segmentation(cnarr, "haar", threshold=0.0, processes=1)
+        msg = " ".join(cm.output)
+        self.assertIn("significance threshold 0.0,", msg)
+        self.assertNotIn("0.0001", msg)
+
 
 class TransferFieldsTests(unittest.TestCase):
     """Tests for transfer_fields and do_segmentation NaN handling."""


### PR DESCRIPTION
Second of two PRs from the pre-release segmentation review (epic `cnvkit-scq`). **Non-behavioral scaffolding cleanup.**

## Clinical-impact note
**Verified output-neutral.** HMM segmentation (`hmm`, `hmm-tumor`, `hmm-germline`) on the test `.cnr` files is **bit-identical** before/after this change (chromosome/start/end/log2, `atol=0 rtol=0`). The `none` change is output-identical on the real per-arm call path; the `threshold` fix only affects the degenerate `threshold=0.0` case.

## Changes
- **`threshold=0` trap (scq.4)** — `if not threshold` replaced a valid user `threshold=0.0` with the method default; use `if threshold is None`. (+ regression test.)
- **hmm.py DRY (scq.5)** — extract `_gaussian_log_pdf` (the Gaussian log-density was inlined 3×); widen `_expected_log2` / `_expected_minor_freq` to broadcast arrays so the **batched grid-search** emission path reuses them instead of re-implementing the expected-value formulas.
- **typing & dispatch (scq.6)** — annotate `none.segment_none`, `hmm.variants_in_segment`, `_method_params` (`-> dict[str, float | int]`); fix the `_ds` parallel-arg tuple annotation (`str|None` / `VariantArray|None`, not `None`); forward `smooth_cbs` on the serial `_do_segmentation` call; replace scattered `method.startswith("hmm")` with a `_HMM_METHODS` frozenset; make `none.segment_none` iterate `by_arm` (was assuming pre-split single-arm input).

## Tests
- `mypy` clean (77 files); `ruff` clean; `test_segmentation` + `test_haar` + `test_hmm` + segmentation consumers: 82 passed.

## Merge note
This and PR #1082 (haar fixes) both touch `cnvlib/segmentation/__init__.py` in nearby lines (the `variants` BAF-refinement block). They're logically independent; if a trivial adjacency conflict appears on the second merge, I'll rebase. Suggest merging #1082 first.

Refs epic (cnvkit-scq). Follow-up feature (selectable/beta-binomial BAF refinement) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)