### PR TITLE
segment: fast haar depth+BAF breakpoint union for copy-neutral LOH

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -272,7 +272,9 @@ def _do_segmentation(
     seg_out = ""
     match method:
         case "haar":
-            segarr = haar.segment_haar(filtered_cn, threshold)  # type: ignore[arg-type]
+            # With variants, segment jointly on depth+BAF (breakpoint union) to
+            # catch copy-neutral LOH; without, depth-only (byte-identical).
+            segarr = haar.segment_haar(filtered_cn, threshold, variants)  # type: ignore[arg-type]
         case "none":
             segarr = none.segment_none(filtered_cn)
         case "cbs" | "flasso":
@@ -333,18 +335,20 @@ def _do_segmentation(
             return segarr, seg_out
         return segarr
     if variants and method not in _HMM_METHODS:
-        # Re-segment the variant allele freqs within each segment.
-        # BAF re-segmentation intentionally uses the HMM (a 2-state Viterbi on
-        # mirrored BAF) for every non-HMM method, per commit 692d5a5; the older
-        # Haar-on-BAF path was removed as dead code. See bead for selectable/
-        # upgraded BAF refinement (beta-binomial) if this is revisited.
-        # TODO train on all segments together
-        logging.info("Re-segmenting on variant allele frequency")
-        newsegs = [
-            hmm.variants_in_segment(subvarr, segment)
-            for segment, subvarr in variants.by_ranges(segarr)
-        ]
-        segarr = segarr.as_dataframe(pd.concat(newsegs))
+        # ('hmm*' models BAF jointly in segment_hmm, so it's excluded here.)
+        if method != "haar":
+            # R backends (cbs/flasso) and 'none': re-segment the variant allele
+            # freqs within each segment using a 2-state Viterbi HMM on mirrored
+            # BAF (per commit 692d5a5).
+            # TODO train on all segments together
+            logging.info("Re-segmenting on variant allele frequency")
+            newsegs = [
+                hmm.variants_in_segment(subvarr, segment)
+                for segment, subvarr in variants.by_ranges(segarr)
+            ]
+            segarr = segarr.as_dataframe(pd.concat(newsegs))
+        # else: 'haar' already incorporated BAF via its depth+BAF breakpoint
+        # union, so no re-segmentation -- just attach the per-segment BAF below.
         segarr["baf"] = variants.baf_by_ranges(segarr)
 
     segarr = transfer_fields(segarr, cnarr)

--- a/cnvlib/segmentation/haar.py
+++ b/cnvlib/segmentation/haar.py
@@ -32,6 +32,7 @@ from scipy import stats
 
 if TYPE_CHECKING:
     from cnvlib.cnary import CopyNumArray
+    from cnvlib.vary import VariantArray
     from numpy import float64, ndarray
 
 # Lower bound for the wavelet-coefficient noise estimate, so a degenerate
@@ -39,8 +40,15 @@ if TYPE_CHECKING:
 # threshold's normal CDF. Far below any real log2/BAF step magnitude.
 SIGMA_FLOOR = 1e-10
 
+# Floor for per-bin BAF weights (read depths) so a window of all SNP-less bins
+# can't divide by zero in the weighted Haar convolution. Negligible vs real
+# read depths (~30-100x), so observed bins still dominate. (cnvkit-ugh)
+WEIGHT_FLOOR = 1e-6
 
-def segment_haar(cnarr: CopyNumArray, fdr_q: float) -> CopyNumArray:
+
+def segment_haar(
+    cnarr: CopyNumArray, fdr_q: float, variants: VariantArray | None = None
+) -> CopyNumArray:
     """Do segmentation for CNVkit.
 
     Calculate copy number segmentation by HaarSeg
@@ -52,6 +60,12 @@ def segment_haar(cnarr: CopyNumArray, fdr_q: float) -> CopyNumArray:
         Binned, normalized copy ratios.
     fdr_q : float
         False discovery rate q-value.
+    variants : VariantArray, optional
+        Heterozygous SNP allele frequencies. When given, segment jointly on
+        depth and B-allele frequency by taking the *union* of breakpoints from
+        haar applied to log2 and to per-bin BAF -- a fast way to catch
+        copy-neutral LOH on WGS (depth flat, BAF shifts). Without variants this
+        is byte-identical to the depth-only segmentation.
 
     Returns
     -------
@@ -60,32 +74,161 @@ def segment_haar(cnarr: CopyNumArray, fdr_q: float) -> CopyNumArray:
     """
     # Segment each chromosome individually
     # ENH - skip large gaps (segment chrom. arms separately)
-    chrom_tables = [
-        one_chrom(subprobes, fdr_q, chrom) for chrom, subprobes in cnarr.by_arm()
-    ]
+    if variants is None:
+        chrom_tables = [
+            one_chrom(subprobes, fdr_q, chrom) for chrom, subprobes in cnarr.by_arm()
+        ]
+    else:
+        chrom_tables = [
+            one_chrom_baf(subprobes, fdr_q, chrom, variants)
+            for chrom, subprobes in cnarr.by_arm()
+        ]
     segarr = cnarr.as_dataframe(pd.concat(chrom_tables))
     segarr.sort_columns()
     return segarr
 
 
+def _bin_weights(cnarr: CopyNumArray) -> ndarray | None:
+    return cnarr["weight"].to_numpy() if "weight" in cnarr else None
+
+
 def one_chrom(cnarr: CopyNumArray, fdr_q: float, chrom: str) -> pd.DataFrame:
     logging.debug("Segmenting %s", chrom)
-    results = haarSeg(
-        cnarr.smooth_log2(),
-        fdr_q,
-        weights=(cnarr["weight"].to_numpy() if "weight" in cnarr else None),
-    )
-    table = pd.DataFrame(
+    signal = cnarr.smooth_log2()
+    weights = _bin_weights(cnarr)
+    breakpoints = _haar_breakpoints(signal, fdr_q, weights)
+    return _segments_from_breakpoints(cnarr, signal, weights, breakpoints, chrom)
+
+
+def _haar_breakpoints(
+    signal: ndarray,
+    fdr_q: float,
+    weights: ndarray | None = None,
+    sigma_override: float | None = None,
+) -> ndarray:
+    """Bin-index breakpoints from haarSeg (i.e. ``results['start'][1:]``)."""
+    results = haarSeg(signal, fdr_q, weights=weights, sigma_override=sigma_override)
+    return results["start"][1:]
+
+
+def _baf_signal_and_sigma(
+    minor_counts: ndarray, depths: ndarray
+) -> tuple[ndarray, ndarray, float]:
+    """Build the BAF haar signal, per-bin weights, and noise floor.
+
+    The signal is the pooled minor-allele fraction ``minor/depth`` per bin
+    (already mirrored into [0, 0.5]); bins with no het SNP (depth 0) are
+    neutral-filled at 0.5 and given weight 0. Weights are read depth, which is
+    proportional to binomial precision (BAF variance ~= 0.25/depth).
+
+    The noise floor is the MAD of level-1 Haar coefficients computed over
+    *observed* bins only -- haarSeg's own ``peakSigmaEst`` is unweighted, so
+    the neutral fills would otherwise deflate it and trip the SIGMA_FLOOR path.
+    """
+    observed = depths > 0
+    baf_signal = np.where(observed, minor_counts / np.maximum(depths, 1.0), 0.5)
+    baf_weights = depths.astype(np.float64)
+    return baf_signal, baf_weights, _observed_baf_sigma(baf_signal, observed)
+
+
+def _observed_baf_sigma(baf_signal: ndarray, observed: ndarray) -> float:
+    """Noise floor from level-1 Haar coefficients of the *compacted* observed
+    BAF values.
+
+    Computing over the compacted observed values (not the full grid sampled at
+    observed positions) means SNP-less neutral-fill bins neither deflate the
+    estimate (flat 0.5 runs -> 0) nor inflate it (an observed LOH value vs its
+    0.5-filled neighbors), which would otherwise raise the FDR threshold and
+    suppress the LOH breakpoint we are trying to detect.
+    """
+    obs_vals = baf_signal[observed]
+    if len(obs_vals) < 2:
+        return SIGMA_FLOOR
+    level1 = HaarConv(obs_vals, None, 1)
+    return max(float(pd.Series(level1).abs().median() * 1.4826), SIGMA_FLOOR)
+
+
+def _baf_signal_from_frequencies(
+    baf_series: pd.Series,
+) -> tuple[ndarray, ndarray, float]:
+    """Fallback BAF signal/weights/noise when the VCF lacks allele counts.
+
+    Uses the per-bin mirrored BAF (NaN where no SNP) with binary observed/not
+    weights, and the same observed-only noise estimate as the count-based path.
+    """
+    vals = baf_series.to_numpy(dtype=np.float64)
+    observed = ~np.isnan(vals)
+    baf_signal = np.where(observed, vals, 0.5)
+    baf_weights = observed.astype(np.float64)
+    return baf_signal, baf_weights, _observed_baf_sigma(baf_signal, observed)
+
+
+def one_chrom_baf(
+    cnarr: CopyNumArray, fdr_q: float, chrom: str, variants: VariantArray
+) -> pd.DataFrame:
+    """Joint depth+BAF haar segmentation of one chromosome arm.
+
+    Union the breakpoints from haar on log2 (depth) and haar on per-bin BAF,
+    then rebuild segments. Detects copy-neutral LOH (BAF shift, flat depth).
+    """
+    logging.debug("Segmenting (depth+BAF) %s", chrom)
+    signal = cnarr.smooth_log2()
+    weights = _bin_weights(cnarr)
+    log2_bps = _haar_breakpoints(signal, fdr_q, weights)
+
+    # Build the BAF signal: prefer count-aware (depth-weighted) over frequencies,
+    # and skip BAF entirely if the VCF carries neither counts nor frequencies.
+    counts = variants.baf_counts_by_ranges(cnarr)
+    if counts is not None:
+        minor_counts, depths = (c.to_numpy(dtype=np.float64) for c in counts)
+        baf_signal, baf_weights, baf_sigma = _baf_signal_and_sigma(minor_counts, depths)
+    elif "alt_freq" in variants:
+        baf_signal, baf_weights, baf_sigma = _baf_signal_from_frequencies(
+            variants.baf_by_ranges(cnarr)
+        )
+    else:
+        baf_weights = None  # no usable allele data -> depth-only below
+
+    if baf_weights is not None and np.count_nonzero(baf_weights) >= 2:
+        baf_bps = _haar_breakpoints(
+            baf_signal,
+            fdr_q,
+            weights=np.maximum(baf_weights, WEIGHT_FLOOR),
+            sigma_override=baf_sigma,
+        )
+        breakpoints = UnifyLevels(log2_bps, baf_bps, 1)
+    else:
+        # Too few informative bins on this arm -> depth-only (no BAF breaks)
+        breakpoints = log2_bps
+    return _segments_from_breakpoints(cnarr, signal, weights, breakpoints, chrom)
+
+
+def _segments_from_breakpoints(
+    cnarr: CopyNumArray,
+    signal: ndarray,
+    weights: ndarray | None,
+    breakpoints: ndarray,
+    chrom: str,
+) -> pd.DataFrame:
+    """Build a segment table from breakpoint bin indices (shared by haar paths).
+
+    `signal` is the smoothed log2 used to find the breakpoints; reuse it (rather
+    than re-smoothing) so the segment means come from the same signal.
+    """
+    n = len(cnarr)
+    seg_starts = np.insert(breakpoints, 0, 0)
+    seg_ends = np.append(breakpoints, n)
+    log2_means = SegmentByPeaks(signal, breakpoints, weights)
+    return pd.DataFrame(
         {
             "chromosome": chrom,
-            "start": cnarr["start"].to_numpy().take(results["start"]),
-            "end": cnarr["end"].to_numpy().take(results["end"]),
-            "log2": results["mean"],
+            "start": cnarr["start"].to_numpy().take(seg_starts),
+            "end": cnarr["end"].to_numpy().take(seg_ends - 1),
+            "log2": log2_means[seg_starts],
             "gene": "-",
-            "probes": results["size"],
+            "probes": seg_ends - seg_starts,
         }
     )
-    return table
 
 
 def haarSeg(
@@ -95,6 +238,7 @@ def haarSeg(
     raw_signal: ndarray | None = None,
     haarStartLevel: int = 1,
     haarEndLevel: int = 5,
+    sigma_override: float | None = None,
 ) -> dict[str, ndarray]:
     r"""Perform segmentation according to the HaarSeg algorithm.
 
@@ -164,6 +308,12 @@ def haarSeg(
     # Real continuous log2/BAF data has noise, so peakSigmaEst >> the floor and
     # this is a no-op there.
     peakSigmaEst = max(peakSigmaEst, SIGMA_FLOOR)
+    if sigma_override is not None:
+        # Caller supplies a noise estimate computed over informative bins only
+        # (the BAF pass: peakSigmaEst above is contaminated by neutral-filled,
+        # SNP-less bins because it is computed unweighted). Default None keeps
+        # the depth pass byte-identical. (cnvkit-ugh)
+        peakSigmaEst = max(sigma_override, SIGMA_FLOOR)
 
     breakpoints = np.array([], dtype=np.int_)
     for level in range(haarStartLevel, haarEndLevel + 1):

--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -50,7 +50,10 @@ class VariantArray(GenomicArray):
         """
         if "alt_freq" not in self:
             logging.warning("VCF has no allele frequencies for BAF calculation")
-            return pd.Series(np.repeat(np.nan, len(ranges)), index=self.data.index)
+            # Length must match `ranges` (one value per bin), like the normal
+            # into_ranges path -- not the variant rows (self.data.index), which
+            # made a shorter/longer Series and crashed callers. (cnvkit-ugh)
+            return pd.Series(np.repeat(np.nan, len(ranges)))
 
         def summarize(vals):
             mirrored = _mirrored_baf(vals, above_half)

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -672,9 +672,23 @@ SNP allele frequencies
 
 If a :ref:`vcfformat` file is given with the
 ``--vcf`` option (and accompanying options ``-i``, ``-n``, ``-z``, and
-``--min-variant-depth``, which work as in other commands), then after segmenting
-log2 ratios, a second pass of segmentation will run within each log2-ratio-based
-segment on the SNP allele frequencies loaded from the VCF.
+``--min-variant-depth``, which work as in other commands), the b-allele
+frequencies (BAFs) of heterozygous SNPs are used to refine segmentation, so that
+allelic imbalance -- including copy-neutral loss of heterozygosity (LOH), where
+the log2 ratio is flat but one allele is lost -- produces its own breakpoints. A
+``baf`` column (the mean mirrored BAF per segment) is added to the output.
+
+How the BAF is incorporated depends on the method:
+
+- ``hmm``, ``hmm-tumor``, ``hmm-germline``: BAF is modeled *jointly* with the
+  log2 ratio in a single pass (allele-specific copy-number states).
+- ``haar``: a fast path for whole-genome sequencing -- HaarSeg is run separately
+  on the log2 signal and on the per-bin BAF, and the **union** of their
+  breakpoints is taken. A BAF shift with flat depth thus yields a breakpoint
+  (catching copy-neutral LOH) without the cost of the HMM.
+- ``cbs``, ``flasso``, ``none``: after segmenting log2 ratios, a second pass
+  re-segments the SNP allele frequencies within each log2-ratio-based segment
+  (a 2-state HMM on the mirrored BAF).
 
 See also :doc:`calling` for suggestions on how to interpret and post-process the
 resulting segments.

--- a/test/test_haar.py
+++ b/test/test_haar.py
@@ -9,11 +9,13 @@ from numpy.testing import assert_allclose, assert_array_equal
 from scipy import stats
 
 from cnvlib.segmentation.haar import (
+    SIGMA_FLOOR,
     FDRThres,
     FindLocalPeaks,
     HaarConv,
     PulseConv,
     SegmentByPeaks,
+    _baf_signal_and_sigma,
     haarSeg,
 )
 
@@ -226,9 +228,7 @@ class HaarSegIntegrationTests(unittest.TestCase):
         yielding 2 segments instead of 3 (scq.2). Real noisy data is unaffected
         (noise keeps peakSigmaEst > 0).
         """
-        signal = np.concatenate(
-            [np.zeros(30), np.full(30, -2.0), np.full(30, -2.3)]
-        )
+        signal = np.concatenate([np.zeros(30), np.full(30, -2.0), np.full(30, -2.3)])
         result = haarSeg(signal, breaksFdrQ=0.001)
         self.assertEqual(len(result["start"]), 3)
         assert_allclose(result["mean"], [0.0, -2.0, -2.3], atol=1e-9)
@@ -237,6 +237,55 @@ class HaarSegIntegrationTests(unittest.TestCase):
         """The peakSigmaEst floor must not over-segment a constant signal."""
         result = haarSeg(np.zeros(100), breaksFdrQ=0.01)
         self.assertEqual(len(result["start"]), 1)
+
+
+class HaarBafTests(unittest.TestCase):
+    """Tests for the depth+BAF breakpoint-union building blocks (cnvkit-ugh)."""
+
+    def test_baf_signal_and_sigma_observed_only(self):
+        # Noisy observed bins -> the bin-to-bin variation gives a real MAD
+        minor = np.array([12.0, 15.0, 11.0, 16.0, 13.0, 14.0, 10.0, 17.0])
+        depth = np.full(8, 30.0)
+        signal, weights, sigma = _baf_signal_and_sigma(minor, depth)
+        assert_allclose(signal, minor / depth)
+        assert_allclose(weights, depth)  # depth = binomial precision
+        self.assertGreater(sigma, SIGMA_FLOOR)  # real BAF noise, not deflated
+
+    def test_baf_sigma_not_deflated_by_neutral_fills(self):
+        # Same observed bins, but interleaved with many SNP-less (filled) bins.
+        # Computing the noise over observed bins only must keep sigma realistic;
+        # a full-grid (contaminated) estimate would collapse toward the floor.
+        obs_minor = np.array([12.0, 15.0, 11.0, 16.0, 13.0, 14.0, 10.0, 17.0])
+        minor = np.zeros(40)
+        depth = np.zeros(40)
+        minor[::5] = obs_minor
+        depth[::5] = 30.0
+        _s, _w, sigma_sparse = _baf_signal_and_sigma(minor, depth)
+        _s2, _w2, sigma_dense = _baf_signal_and_sigma(obs_minor, np.full(8, 30.0))
+        # Sparse layout's observed-only noise matches the dense one (not deflated)
+        self.assertAlmostEqual(sigma_sparse, sigma_dense)
+
+    def test_baf_signal_and_sigma_no_snps(self):
+        signal, weights, sigma = _baf_signal_and_sigma(
+            np.array([0.0, 5.0, 0.0]), np.array([0.0, 10.0, 0.0])
+        )
+        assert_allclose(signal, [0.5, 0.5, 0.5])  # depth=0 -> neutral fill
+        assert_allclose(weights, [0.0, 10.0, 0.0])
+        # Only 1 observed bin -> noise floor, computed over observed bins only
+        self.assertEqual(sigma, SIGMA_FLOOR)
+
+    def test_haarseg_sigma_override(self):
+        # Noisy signal with many local peaks (so FDRThres actually thresholds,
+        # not the M<2 short-circuit). The override controls FDR sensitivity;
+        # default (None) is byte-identical to the computed estimate.
+        rng = np.random.default_rng(0)
+        sig = rng.normal(0, 1.0, 120)
+        same = haarSeg(sig, 0.001, sigma_override=None)
+        assert_array_equal(haarSeg(sig, 0.001)["start"], same["start"])
+        tiny = haarSeg(sig, 0.001, sigma_override=1e-6)  # everything significant
+        huge = haarSeg(sig, 0.001, sigma_override=1e3)  # nothing significant
+        self.assertGreater(len(tiny["start"]), len(huge["start"]))
+        self.assertEqual(len(huge["start"]), 1)  # reject-all -> one segment
 
 
 class SegmentByPeaksTests(unittest.TestCase):

--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -128,6 +128,7 @@ class PreprocessingTests(unittest.TestCase):
         """bedcov keeps regions on BAM contigs and drops those on absent
         contigs instead of erroring out entirely (#620)."""
         bam = "formats/na12878-chrM-Y-trunc.bam"
+        samutil.ensure_bam_index(bam)  # self-contained: don't rely on test order
         bam_chroms = samutil.get_bam_chroms(bam)
         with tempfile.NamedTemporaryFile("w+t", suffix=".bed", delete=False) as f:
             f.write("chrM\t251\t277\tfoo\n")
@@ -144,6 +145,7 @@ class PreprocessingTests(unittest.TestCase):
         """bedcov on an all-absent BED: raise a clear error by default, but
         return empty when allow_empty=True (the per-chunk parallel path)."""
         bam = "formats/na12878-chrM-Y-trunc.bam"
+        samutil.ensure_bam_index(bam)  # self-contained: don't rely on test order
         bam_chroms = samutil.get_bam_chroms(bam)
         with tempfile.NamedTemporaryFile("w+t", suffix=".bed", delete=False) as f:
             f.write("absent_contig\t100\t200\tbar\n")

--- a/test/test_segmentation.py
+++ b/test/test_segmentation.py
@@ -72,9 +72,9 @@ class SegmentationTests(unittest.TestCase):
         )
         self.assertGreater(len(segments), n_chroms)
         self.assertTrue((segments.start < segments.end).all())
-        # haar segmentation with variants re-segments by BAF (routed through
-        # hmm.variants_in_segment); previously broken, working since the HMM
-        # rewrite. See bead cnvkit-scq.1 re: the unused haar.variants_in_segment.
+        # haar segmentation with variants unions depth+BAF breakpoints
+        # (cnvkit-ugh); see test_haar_vcf_detects_copy_neutral_loh for the LOH
+        # behavior. Here just confirm it runs and yields valid segments.
         varr = tabio.read("formats/na12878_na12882_mix.vcf", "vcf")
         segments = segmentation.do_segmentation(cnarr, "haar", variants=varr)
         self.assertGreater(len(segments), n_chroms)
@@ -172,6 +172,86 @@ class SegmentationTests(unittest.TestCase):
         msg = " ".join(cm.output)
         self.assertIn("significance threshold 0.0,", msg)
         self.assertNotIn("0.0001", msg)
+
+    def test_haar_vcf_detects_copy_neutral_loh(self):
+        """`-m haar --vcf` unions depth+BAF breakpoints -> catches copy-neutral
+        LOH (flat depth, BAF shift), and adds a 'baf' column (cnvkit-ugh)."""
+        n = 120
+        rng = np.random.default_rng(0)
+        cnarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * n,
+                    "start": np.arange(n) * 1000,
+                    "end": np.arange(n) * 1000 + 1000,
+                    "gene": "-",
+                    "log2": rng.normal(0.0, 0.05, n),  # flat depth, no CN change
+                    "weight": np.ones(n),
+                }
+            )
+        )
+        # Het SNPs: balanced (minor/depth=0.5) first half, LOH (0.3) second half
+        alt = np.concatenate([np.full(60, 15.0), np.full(60, 9.0)])
+        varr = vary.VariantArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * n,
+                    "start": np.arange(n) * 1000 + 500,
+                    "end": np.arange(n) * 1000 + 501,
+                    "ref": ["A"] * n,
+                    "alt": ["G"] * n,
+                    "zygosity": np.full(n, 0.5),
+                    "alt_count": alt,
+                    "depth": np.full(n, 30.0),
+                    "alt_freq": alt / 30.0,
+                }
+            )
+        )
+        # Depth-only: flat -> no BAF breakpoint, no 'baf' column
+        depth_only = segmentation.do_segmentation(cnarr, "haar")
+        self.assertNotIn("baf", depth_only.data.columns)
+        # Joint: the BAF shift at bin 60 must introduce a breakpoint there
+        joint = segmentation.do_segmentation(cnarr, "haar", variants=varr)
+        self.assertIn("baf", joint.data.columns)
+        self.assertGreater(len(joint), len(depth_only))
+        boundaries = set(joint.start.tolist()) | set(joint.end.tolist())
+        self.assertTrue(
+            any(55000 <= b <= 65000 for b in boundaries),
+            f"expected a breakpoint near the BAF shift (~60000); got {sorted(boundaries)}",
+        )
+
+    def test_haar_vcf_without_allele_info_falls_back(self):
+        """`-m haar --vcf` on a VCF lacking AF and AD/DP must not crash; it
+        falls back to depth-only segmentation (cnvkit-ugh)."""
+        n = 30
+        cnarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * n,
+                    "start": np.arange(n) * 1000,
+                    "end": np.arange(n) * 1000 + 1000,
+                    "gene": "-",
+                    "log2": np.zeros(n),
+                    "weight": np.ones(n),
+                }
+            )
+        )
+        # Genotype-only VCF: het zygosity, but no alt_freq / alt_count / depth
+        varr = vary.VariantArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * 10,
+                    "start": np.arange(10) * 100,
+                    "end": np.arange(10) * 100 + 1,
+                    "ref": ["A"] * 10,
+                    "alt": ["G"] * 10,
+                    "zygosity": np.full(10, 0.5),
+                }
+            )
+        )
+        seg = segmentation.do_segmentation(cnarr, "haar", variants=varr)
+        self.assertGreater(len(seg), 0)
+        self.assertTrue((seg.start < seg.end).all())
 
 
 class TransferFieldsTests(unittest.TestCase):

--- a/test/test_vary.py
+++ b/test/test_vary.py
@@ -36,6 +36,29 @@ class VariantArrayTests(unittest.TestCase):
         variants = tabio.read("formats/na12878_na12882_mix.vcf", "vcf")
         self.assertGreater(len(variants), 0)
 
+    def test_baf_by_ranges_no_alt_freq_matches_ranges_length(self):
+        """Without an alt_freq column, baf_by_ranges returns one NaN per *range*
+        (not per variant), so callers assigning it as a column don't crash."""
+        varr = vary.VariantArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * 5,
+                    "start": np.arange(5) * 100,
+                    "end": np.arange(5) * 100 + 1,
+                    "ref": ["A"] * 5,
+                    "alt": ["G"] * 5,
+                    "zygosity": np.full(5, 0.5),
+                }
+            )
+        )
+        ranges = cnary.CopyNumArray.from_rows(
+            [["chr1", i * 100, i * 100 + 100, "-", 0.0] for i in range(3)],
+            columns=["chromosome", "start", "end", "gene", "log2"],
+        )
+        baf = varr.baf_by_ranges(ranges)
+        self.assertEqual(len(baf), len(ranges))  # 3, not 5 (the variant count)
+        self.assertTrue(baf.isna().all())
+
     def test_mirrored_baf_all_nan(self):
         """All-NaN frequencies mirror to all-NaN without warning (gh#407).
 
@@ -82,9 +105,7 @@ class VariantArrayTests(unittest.TestCase):
 
     def test_tumor_boost_branches(self):
         # t<n -> 0.5*t/n ; t>=n -> 1 - 0.5*(1-t)/(1-n); equal -> stays
-        out = vary._tumor_boost(
-            np.array([0.3, 0.7, 0.5]), np.array([0.5, 0.5, 0.5])
-        )
+        out = vary._tumor_boost(np.array([0.3, 0.7, 0.5]), np.array([0.5, 0.5, 0.5]))
         np.testing.assert_allclose(out.to_numpy(), [0.3, 0.7, 0.5])
 
     def test_tumor_boost_requires_matched_normal(self):


### PR DESCRIPTION
## Summary

`cnvkit segment -m haar --vcf` now segments **jointly on depth and B-allele frequency** by taking the **union** of breakpoints from HaarSeg run separately on the log2 signal and on per-bin BAF. A BAF shift where depth is flat yields its own breakpoint, so **copy-neutral LOH** is detected — at a fraction of the HMM's cost, which suits WGS (haar is fast and the WGS signal is clean). A `baf` column is added to the `.cns` output for this mode.

This came out of a design discussion: the HMM (`-m hmm*`) remains the principled *joint* reference (allele-specific states, beta-binomial emission) but is O(T·N²)+grid-search; haar-union is the fast option. `cbs`/`flasso`/`none` keep their 2-state-HMM BAF re-segmentation.

Designed via the feature-dev triple-architect + 3-reviewer protocol.

## Design (option B: depth-weighted, observed-only noise)
- **BAF signal** = pooled `minor/depth` per bin (from `baf_counts_by_ranges`), already mirrored into [0, 0.5]; SNP-less bins neutral-filled at 0.5 with weight 0.
- **Weights** = read depth (binomial precision ≈ depth); floored to `WEIGHT_FLOOR` so an all-SNP-less window can't divide by zero in the weighted Haar conv.
- **Noise floor** for the BAF pass = level-1 MAD of the **compacted observed** values, injected via a new internal `haarSeg(sigma_override=…)` (default `None` ⇒ the depth pass is byte-identical). Computing it over observed bins only avoids the neutral fills both *deflating* it (flat runs → the scq.2 degenerate case) and *inflating* it (LOH-vs-0.5-fill jumps, which would raise the FDR threshold and suppress the LOH break).
- Falls back to **depth-only** when an arm has <2 informative bins or the VCF carries no usable allele data.

## Clinical-impact note
- **`-m haar` without `--vcf` is byte-identical** to before — verified on the test `.cnr` files (chrom/start/end/log2/probes/columns).
- **`-m haar --vcf` output changes intentionally**: it was haar-depth + 2-state-HMM BAF re-seg; it's now haar-depth ∪ haar-BAF, plus a new additive `baf` column. Documented in `doc/pipeline.rst`.

## Also fixed (separate commit)
`vary.baf_by_ranges` returned a malformed Series (values length `len(ranges)` but index length `len(variants)`) when a VCF lacks an `alt_freq` column — crashing any caller that assigns it as a column (incl. the existing cbs/flasso/none BAF path), not just this feature. Fixed at the root.

## Tests
- Unit (`test_haar.py`): BAF signal/weights/observed-only-sigma (incl. not-deflated-by-fills), `haarSeg sigma_override`.
- Integration (`test_segmentation.py`): copy-neutral LOH produces a breakpoint where depth is flat + a `baf` column; no-allele-info VCF falls back without crashing; no `baf` column without `--vcf`.
- `vary` length regression test.
- Full `mypy` (77 files) clean; `ruff` clean; local suites pass.

## Reviewer findings handled
Addressed: the no-allele-info crash (root-caused in `vary.py`), double `smooth_log2()` per arm (threaded the signal through), post-hoc dispatch tidy-up, `sigma_override` floor, `WEIGHT_FLOOR` constant. Verified-and-skipped (pre-existing, not triggered, will not expand scope): `_haar_conv_weighted` using `.sum()` (NaN weights filtered upstream), and the noise-calibration approach mirrors `haarSeg`'s own depth-path `peakSigmaEst`.

Implements the `cnvkit-ugh` feature bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)