### PR TITLE
Default to female when chromosomal sex is indeterminate (#360)

### DIFF
--- a/cnvlib/batch.py
+++ b/cnvlib/batch.py
@@ -25,6 +25,7 @@ from . import (
     target,
 )
 from .cmdutil import read_cna
+from .cnary import is_female_default
 
 
 def batch_make_reference(
@@ -529,7 +530,9 @@ def batch_run_sample(
         logging.info("Wrote %s-scatter.png", sample_pfx)
 
     if plot_diagram:
-        is_xx = cnarr.guess_xx(is_haploid_x_reference, diploid_parx_genome)
+        is_xx = is_female_default(
+            cnarr.guess_xx(is_haploid_x_reference, diploid_parx_genome)
+        )
         outfname = sample_pfx + "-diagram.pdf"
         diagram.create_diagram(
             cnarr.shift_xx(is_haploid_x_reference, is_xx, diploid_parx_genome),

--- a/cnvlib/cmdutil.py
+++ b/cnvlib/cmdutil.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from skgenome import tabio
 
-from .cnary import CopyNumArray as CNA
+from .cnary import CopyNumArray as CNA, is_female_default
 from skgenome import GenomicArray as GA
 from typing import TYPE_CHECKING
 
@@ -128,18 +128,20 @@ def verify_sample_sex(
     is_haploid_x_reference: bool,
     diploid_parx_genome: str | None,
 ) -> bool:
-    is_sample_female: bool = cnarr.guess_xx(  # type: ignore[assignment]
-        is_haploid_x_reference, diploid_parx_genome, verbose=False
-    )
+    guess = cnarr.guess_xx(is_haploid_x_reference, diploid_parx_genome, verbose=False)
+    # None means "couldn't tell" (no chrX / degenerate); default to female so an
+    # indeterminate sample is never silently treated as male (gh#360 family).
+    is_sample_female = is_female_default(guess)
     if sex_arg:
         is_sample_female_given = sex_arg.lower() not in ["y", "m", "male"]
-        if is_sample_female != is_sample_female_given:
+        # Only warn on a real disagreement -- not when we merely defaulted.
+        if guess is not None and is_sample_female != is_sample_female_given:
             logging.warning(
                 "Sample sex specified as %s but chromosomal X/Y ploidy looks like %s",
                 "female" if is_sample_female_given else "male",
                 "female" if is_sample_female else "male",
             )
-            is_sample_female = is_sample_female_given
+        is_sample_female = is_sample_female_given
     logging.info(
         "Treating sample %s as %s",
         cnarr.sample_id or "",

--- a/cnvlib/cnary.py
+++ b/cnvlib/cnary.py
@@ -22,6 +22,20 @@ if TYPE_CHECKING:
     from pandas.core.series import Series
 
 
+def is_female_default(is_xx: bool | bool_ | None) -> bool:
+    """Resolve an indeterminate chromosomal-sex guess to the safe default.
+
+    `CopyNumArray.guess_xx` returns None when sex can't be determined (no X
+    chromosome present, or a degenerate coverage comparison). For copy-number
+    purposes the only effect of a "male" call is that a haploid X is treated as
+    the expected baseline; assuming male for a sample whose X is actually
+    diploid would spuriously inflate chrX by +1 (the gh#360 failure family). So
+    when there isn't positive evidence either way, default to female (diploid-X
+    baseline). A real (non-None) guess is returned unchanged as a plain ``bool``.
+    """
+    return True if is_xx is None else bool(is_xx)
+
+
 class CopyNumArray(GenomicArray):
     """An array of genomic intervals, treated like aCGH probes.
 
@@ -401,9 +415,13 @@ class CopyNumArray(GenomicArray):
         """
         outprobes = self.copy()
         if is_xx is None:
-            is_xx = self.guess_xx(
-                is_haploid_x_reference=is_haploid_x_reference,
-                diploid_parx_genome=diploid_parx_genome,
+            # guess_xx may still return None (no chrX); default to female so an
+            # indeterminate sample is never silently given the male +1 shift.
+            is_xx = is_female_default(
+                self.guess_xx(
+                    is_haploid_x_reference=is_haploid_x_reference,
+                    diploid_parx_genome=diploid_parx_genome,
+                )
             )
         if is_xx and is_haploid_x_reference:
             # Female: divide X coverages by 2 (in log2: subtract 1)
@@ -612,8 +630,10 @@ class CopyNumArray(GenomicArray):
         chromosomes based on whether the reference is male (XX or XY).
         """
         if is_haploid_x_reference is None:
-            is_haploid_x_reference = not self.guess_xx(
-                diploid_parx_genome=diploid_parx_genome, verbose=False
+            # Default to a female (diploid-X) reference when sex is unknown,
+            # rather than letting a None guess become a male (haploid-X) one.
+            is_haploid_x_reference = not is_female_default(
+                self.guess_xx(diploid_parx_genome=diploid_parx_genome, verbose=False)
             )
         cvg = np.zeros(len(self), dtype=np.float64)
         if is_haploid_x_reference:

--- a/cnvlib/reference.py
+++ b/cnvlib/reference.py
@@ -11,7 +11,7 @@ import pyfaidx
 from skgenome import tabio, GenomicArray as GA
 from . import core, fix, descriptives, params
 from .cmdutil import read_cna
-from .cnary import CopyNumArray as CNA
+from .cnary import CopyNumArray as CNA, is_female_default
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -586,7 +586,16 @@ def shift_sex_chroms(
         xy sample, xy ref: 0    (from -1)   +1
 
     """
-    is_xx = sexes.get(cnarr.sample_id)
+    # infer_sexes omits samples whose sex couldn't be determined, so a missing
+    # entry means "unknown" -- default to female (diploid X) rather than letting
+    # None fall through to the male branch and silently add +1 to chrX (gh#360).
+    known_sex = sexes.get(cnarr.sample_id)
+    if known_sex is None:
+        logging.warning(
+            "Cannot determine sex for sample %s; treating chrX as diploid (female)",
+            cnarr.sample_id or "",
+        )
+    is_xx = is_female_default(known_sex)
     cnarr["log2"] += ref_flat_logr
     if is_xx:
         # chrX has same ploidy as autosomes; chrY is just unusable noise

--- a/cnvlib/reports.py
+++ b/cnvlib/reports.py
@@ -13,6 +13,7 @@ import pandas as pd
 from scipy import stats
 
 from . import params, descriptives, segmetrics
+from .cnary import is_female_default
 from .segmetrics import segment_mean
 
 if TYPE_CHECKING:
@@ -194,9 +195,11 @@ def do_genemetrics(
         chromosome, log2 ratio, and probe counts.
     """
     if is_sample_female is None:
-        is_sample_female = cnarr.guess_xx(  # type: ignore[assignment]
-            is_haploid_x_reference=is_haploid_x_reference,
-            diploid_parx_genome=diploid_parx_genome,
+        is_sample_female = is_female_default(
+            cnarr.guess_xx(
+                is_haploid_x_reference=is_haploid_x_reference,
+                diploid_parx_genome=diploid_parx_genome,
+            )
         )
     cnarr = cnarr.shift_xx(
         is_haploid_x_reference, is_sample_female, diploid_parx_genome

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -17,6 +17,7 @@ from skgenome import GenomicArray, tabio
 import cnvlib
 from cnvlib.cnary import CopyNumArray
 from cnvlib import (
+    cmdutil,
     cnary,
     fix,
     params,
@@ -293,6 +294,43 @@ class CNATests(unittest.TestCase):
                 sample_is_f,
                 f"{fname}: guessed XX {guess} but is {sample_is_f}",
             )
+
+    def test_guess_xx_indeterminate_defaults_female(self):
+        """Indeterminate sex (no chrX) defaults to female, never silently male.
+
+        `guess_xx` still returns None -- an honest "can't tell" that the
+        reference target/antitarget reconciliation relies on -- but the
+        decision-level helper `is_female_default` and `verify_sample_sex`
+        collapse None to female. Female is the safe default: guessing male
+        for a sample whose X is actually diploid would spuriously inflate
+        chrX by +1 (the gh#360 failure family).
+        """
+        from cnvlib.cnary import is_female_default
+
+        # The helper: None -> female; real guesses pass through as plain bool.
+        self.assertIs(is_female_default(None), True)
+        self.assertIs(is_female_default(np.bool_(True)), True)
+        self.assertIs(is_female_default(np.bool_(False)), False)
+
+        # An autosomes-only sample: guess_xx genuinely can't tell (None) ...
+        auto_only = CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * 5 + ["chr2"] * 5,
+                    "start": list(range(0, 5000, 1000)) * 2,
+                    "end": list(range(1000, 6000, 1000)) * 2,
+                    "gene": ["-"] * 10,
+                    "log2": [0.0] * 10,
+                    "weight": [1.0] * 10,
+                }
+            )
+        )
+        self.assertIsNone(auto_only.guess_xx(verbose=False))
+        # ... but verify_sample_sex returns female (a real bool), not None/male.
+        result = cmdutil.verify_sample_sex(auto_only, None, False, None)
+        self.assertIs(result, True)
+        # An explicit override still wins, with no misleading mismatch warning.
+        self.assertIs(cmdutil.verify_sample_sex(auto_only, "male", False, None), False)
 
     def test_residuals(self):
         cnarr = cnvlib.read("formats/amplicon.cnr")

--- a/test/test_reference.py
+++ b/test/test_reference.py
@@ -157,6 +157,25 @@ class ReferenceTests(unittest.TestCase):
             expected_haploid_log2,
         )
 
+    def test_shift_sex_chroms_unknown_defaults_female(self):
+        """A sample absent from the inferred-sexes dict is treated as female.
+
+        `infer_sexes` deliberately omits samples whose sex couldn't be
+        determined (preserving a None signal for target/antitarget
+        reconciliation), so `shift_sex_chroms` must apply the safe default
+        itself: no +1 shift on chrX. The old code fell through to the male
+        branch and silently inflated chrX (Defect A / gh#360 family).
+        """
+        cnarr = cnvlib.read("formats/ref_test_female.cnn")
+        is_chr_x = cnarr.chr_x_filter()
+        is_chr_y = cnarr.chr_y_filter()
+        before_x = cnarr["log2"][is_chr_x].to_numpy().copy()
+        # Empty sexes dict => this sample's sex is unknown.
+        reference.shift_sex_chroms(cnarr, {}, np.zeros(len(cnarr)), is_chr_x, is_chr_y)
+        after_x = cnarr["log2"][is_chr_x].to_numpy()
+        # Female default: chrX unchanged (would be +1 under the None->male bug).
+        np.testing.assert_allclose(after_x, before_x)
+
     def test_fix(self):
         """The 'fix' command."""
         # Extract fake target/antitarget bins from a combined file


### PR DESCRIPTION
## Problem

`CopyNumArray.guess_xx` returns `None` when chromosomal sex can't be determined (no chrX present, or a degenerate coverage comparison). Every consumer silently collapsed that `None` into the **male** branch via Python truthiness (`if is_xx:` / `sexes.get(id)` → `None` → `else`). So an indeterminate sample was treated as male — the dangerous direction, because a male (haploid-X) baseline spuriously inflates a genuinely diploid chrX by +1. That's the failure *family* behind #360. `verify_sample_sex` even returned `None` despite its `-> bool` annotation (masked by a `# type: ignore`).

## Fix

Add `cnary.is_female_default()` — one pure helper — and apply it at every decision point: `verify_sample_sex`, `reference.shift_sex_chroms`, `cnary.shift_xx`, `cnary.expect_flat_log2`, `batch` diagram, `reports.do_genemetrics`.

Key design choice: `guess_xx`/`infer_sexes` still return `None` (an honest "couldn't tell"), which the reference target/antitarget reconciliation relies on as a sentinel. The female default is applied **only at the point of use**, not at inference. Also stop `verify_sample_sex` from emitting a sex-"mismatch" warning when it merely defaulted (no evidence) rather than genuinely disagreeing with the user.

## Clinical-impact / output stability

- **Output is unchanged for any sample with chrX data** — the helper returns `bool(guess)` unchanged when the guess isn't `None`. Verified by the existing `test_reference_gender_input` (auto-detect == explicit `-g female`, byte-identical) and `test_guess_xx` (8 real fixtures) staying green.
- Output changes **only** for samples that were previously indeterminate-and-silently-male (no chrX / degenerate test), now female — the safe (diploid-X) direction. This can never mute a real chrX CNV, since a sample with chrX data yields a non-`None` guess that passes through untouched.

## Tests

- `test_guess_xx_indeterminate_defaults_female` (test_cnvlib.py): the helper's contract + `verify_sample_sex` returns female (a real `bool`, not `None`/male) for an autosomes-only sample, and an explicit `--sample-sex male` override still wins.
- `test_shift_sex_chroms_unknown_defaults_female` (test_reference.py): a sample absent from the inferred-sexes dict gets no +1 on chrX (would be inflated under the old None→male path).

Full suite: 376 passed, 40 subtests; mypy + ruff clean.

Resolves #360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)