### PR TITLE
Reconcile target/antitarget sex by chrX confidence (#846)

### DIFF
--- a/cnvlib/reference.py
+++ b/cnvlib/reference.py
@@ -218,28 +218,18 @@ def do_reference(
         logging.info("No FASTA reference genome provided; skipping GC, RM calculations")
 
     if female_samples is None:
-        # NB: Antitargets are usually preferred for inferring sex, but might be
-        # empty files, in which case no inference can be done. Since targets are
-        # guaranteed to exist, infer from those first, then replace those
-        # values where antitargets are suitable.
+        # Infer each sample's sex from coverage. Antitargets sample chrX broadly,
+        # but their chrY is often too sparse to tell male from female, so a naive
+        # antitarget guess can flip a genuine male to female. Reconcile the two
+        # sources by chrX confidence rather than always trusting antitargets
+        # (#846, #863).
         logging.info("Sample sex not provided; inferring from samples. ")
-        sexes = infer_sexes(target_fnames, False, diploid_parx_genome)
+        t_guesses = _guess_sexes(target_fnames, False, diploid_parx_genome)
         if antitarget_fnames:
-            a_sexes = infer_sexes(antitarget_fnames, False, diploid_parx_genome)
-            for sid, a_is_xx in a_sexes.items():
-                t_is_xx = sexes.get(sid)
-                if t_is_xx is None:
-                    sexes[sid] = a_is_xx
-                elif t_is_xx != a_is_xx and a_is_xx is not None:
-                    logging.warning(
-                        "Sample %s chromosomal X/Y ploidy looks "
-                        "like %s in targets but %s in antitargets; "
-                        "preferring antitargets",
-                        sid,
-                        "female" if t_is_xx else "male",
-                        "female" if a_is_xx else "male",
-                    )
-                    sexes[sid] = a_is_xx
+            a_guesses = _guess_sexes(antitarget_fnames, False, diploid_parx_genome)
+            sexes = _reconcile_sex_guesses(t_guesses, a_guesses)
+        else:
+            sexes = {sid: is_xx for sid, (is_xx, _lr) in t_guesses.items()}
     else:
         # In this case the gender of the samples is provided and won't be inferred
         logging.info(
@@ -276,13 +266,113 @@ def infer_sexes(
     For samples where the source file is empty or does not include either sex
     chromosome, that sample ID will not be in the returned dictionary.
     """
-    sexes = {}
+    return {
+        sid: is_xx
+        for sid, (is_xx, _lr) in _guess_sexes(
+            cnn_fnames, is_haploid_x, diploid_parx_genome
+        ).items()
+    }
+
+
+def _guess_sexes(
+    cnn_fnames: list[str],
+    is_haploid_x: bool,
+    diploid_parx_genome: str | None,
+    verbose: bool = True,
+) -> dict[str, tuple[bool_, float]]:
+    """Map sample IDs to ``(is_xx, chrx_male_lr)`` where sex is determinable.
+
+    ``chrx_male_lr`` is the chromosome-X "maleness" ratio (> 1 favors male);
+    it is the confidence signal used to reconcile conflicting target/antitarget
+    guesses, since chrX is well-sampled in both whereas antitarget chrY is not.
+    Samples whose source file is empty or lacks a sex chromosome are omitted.
+    """
+    guesses: dict[str, tuple[bool_, float]] = {}
     for fname in cnn_fnames:
         cnarr = read_cna(fname)
-        if cnarr:
-            is_xx = cnarr.guess_xx(is_haploid_x, diploid_parx_genome)
-            if is_xx is not None:
-                sexes[cnarr.sample_id] = is_xx
+        if not cnarr:
+            continue
+        is_xy, stats = cnarr.compare_sex_chromosomes(is_haploid_x, diploid_parx_genome)
+        if is_xy is None:
+            continue
+        if verbose:
+            # Mirrors CopyNumArray.guess_xx's per-sample log; kept here so the
+            # reference command still reports inference when it bypasses guess_xx.
+            logging.info(
+                "Relative log2 coverage of %s=%.3g, %s=%.3g "
+                "(maleness=%.3g x %.3g = %.3g) --> assuming %s",
+                cnarr.chr_x_label or "chrX",
+                stats["chrx_ratio"],
+                cnarr.chr_y_label or "chrY",
+                stats["chry_ratio"],
+                stats["chrx_male_lr"],
+                stats["chry_male_lr"],
+                stats["combined_score"],
+                "male" if is_xy else "female",
+            )
+        guesses[cnarr.sample_id] = (~is_xy, stats["chrx_male_lr"])
+    return guesses
+
+
+def _chrx_maleness_confidence(chrx_male_lr: float) -> float:
+    """Confidence of a chrX-based sex call: distance from the boundary (1.0).
+
+    Measured in log space so that, e.g., a ratio of 2 and 1/2 are equally
+    confident. Non-positive or non-finite ratios carry no information.
+    """
+    if not (chrx_male_lr > 0.0 and np.isfinite(chrx_male_lr)):
+        return 0.0
+    return abs(float(np.log(chrx_male_lr)))
+
+
+def _reconcile_sex_guesses(
+    target_guesses: dict[str, tuple[bool_, float]],
+    antitarget_guesses: dict[str, tuple[bool_, float]],
+) -> dict[str, bool_]:
+    """Merge target- and antitarget-based sex guesses into one per sample.
+
+    Each guess is ``(is_xx, chrx_male_lr)``. When the two sources agree (or only
+    one made a call), that call stands. When they disagree, the antitarget guess
+    is no longer trusted unconditionally: antitarget chrY is frequently too
+    sparse to carry signal and can drag a real male call to female (#846, #863).
+
+    chrX is well-sampled in both sources, so the conflict is resolved by chrX
+    confidence. The handling is deliberately asymmetric, mirroring chrY coverage
+    quality: the target's full chrX+chrY call stands unless the antitarget's chrX
+    signal is strictly more decisive, in which case only the antitarget's chrX
+    call is adopted (its chrY is discarded as unreliable). Ties favor the target,
+    whose sex chromosomes are deliberately baited.
+    """
+    sexes: dict[str, bool_] = {
+        sid: is_xx for sid, (is_xx, _lr) in target_guesses.items()
+    }
+    for sid, (a_is_xx, a_lr) in antitarget_guesses.items():
+        if sid not in target_guesses:
+            # Target couldn't tell (no chrX / empty); fall back to antitarget.
+            sexes[sid] = a_is_xx
+            continue
+        t_is_xx, t_lr = target_guesses[sid]
+        if t_is_xx == a_is_xx:
+            continue
+        # Disagreement. chrX is well-sampled in both sources, but antitarget chrY
+        # is frequently too sparse to carry signal, so let the antitarget win only
+        # when its chrX signal is strictly more decisive than the target's -- and
+        # then trust only its chrX call (chrx_male_lr > 1 == male), discarding its
+        # unreliable chrY. Otherwise the target's full chrX+chrY call stands.
+        if _chrx_maleness_confidence(a_lr) > _chrx_maleness_confidence(t_lr):
+            sexes[sid] = a_lr <= 1.0  # type: ignore[assignment]
+            preferred = "antitargets"
+        else:
+            sexes[sid] = t_is_xx
+            preferred = "targets"
+        logging.warning(
+            "Sample %s chromosomal X/Y ploidy looks like %s in targets but %s "
+            "in antitargets; preferring %s (more decisive chrX coverage)",
+            sid,
+            "female" if t_is_xx else "male",
+            "female" if a_is_xx else "male",
+            preferred,
+        )
     return sexes
 
 

--- a/doc/sex.rst
+++ b/doc/sex.rst
@@ -29,6 +29,17 @@ female control samples' X coverage depth is automatically halved so that it
 appears as haploid in the CNVkit pipeline. Chromosome Y is always treated as
 haploid in either case.
 
+When building a reference, each control sample's sex is inferred separately from
+its target and antitarget coverage. These can disagree: antitarget bins on
+chromosome Y are often too sparse to distinguish a male's Y from a female's
+absent Y, which can make a genuinely male sample look female in the antitargets.
+When the two sources conflict, CNVkit no longer simply defers to the antitargets;
+instead it trusts whichever source has the more decisive chromosome-X coverage
+(targets, by default, for capture panels). The status log reports the conflict
+and the chosen source, e.g. ``...looks like male in targets but female in
+antitargets; preferring targets``. You can always bypass inference by passing the
+sample sex explicitly with ``-x``/``--sample-sex``.
+
 Chromosomal sex in calling absolute copy number
 -----------------------------------------------
 

--- a/test/test_reference.py
+++ b/test/test_reference.py
@@ -56,6 +56,56 @@ from cnvlib import (
 )
 
 
+def _write_coverage_cnn(
+    path, chrx_log2, chry_log2, chrx_sd, chry_sd, n_auto=200, n_x=40, n_y=40, seed=7
+):
+    """Write a synthetic coverage .cnn with tunable sex-chromosome signal.
+
+    Used to reproduce target/antitarget sex-inference conflicts: autosomes sit
+    at log2 0, and chrX/chrY are drawn around the given means so a caller can
+    make, e.g., a haploid chrX with a near-empty (deeply negative) chrY.
+    """
+    rng = np.random.default_rng(seed)
+    rows = []
+    for chrom, n in [("chr1", n_auto), ("chr2", n_auto)]:
+        for i in range(n):
+            rows.append(
+                (
+                    chrom,
+                    i * 1000,
+                    i * 1000 + 1000,
+                    "Background",
+                    100,
+                    float(rng.normal(0, 0.2)),
+                )
+            )
+    for i in range(n_x):
+        rows.append(
+            (
+                "chrX",
+                i * 1000,
+                i * 1000 + 1000,
+                "Background",
+                50,
+                float(rng.normal(chrx_log2, chrx_sd)),
+            )
+        )
+    for i in range(n_y):
+        rows.append(
+            (
+                "chrY",
+                i * 1000,
+                i * 1000 + 1000,
+                "Background",
+                2,
+                float(rng.normal(chry_log2, chry_sd)),
+            )
+        )
+    pd.DataFrame(
+        rows, columns=["chromosome", "start", "end", "gene", "depth", "log2"]
+    ).to_csv(path, sep="\t", index=False)
+
+
 class ReferenceTests(unittest.TestCase):
     """Tests for the reference and fix commands."""
 
@@ -164,7 +214,7 @@ class ReferenceTests(unittest.TestCase):
         determined (preserving a None signal for target/antitarget
         reconciliation), so `shift_sex_chroms` must apply the safe default
         itself: no +1 shift on chrX. The old code fell through to the male
-        branch and silently inflated chrX (Defect A / gh#360 family).
+        branch and silently inflated chrX (Defect A / #360 family).
         """
         cnarr = cnvlib.read("formats/ref_test_female.cnn")
         is_chr_x = cnarr.chr_x_filter()
@@ -175,6 +225,100 @@ class ReferenceTests(unittest.TestCase):
         after_x = cnarr["log2"][is_chr_x].to_numpy()
         # Female default: chrX unchanged (would be +1 under the None->male bug).
         np.testing.assert_allclose(after_x, before_x)
+
+    def test_reconcile_sex_guesses(self):
+        """Target/antitarget sex conflicts resolve by chrX confidence (#846).
+
+        chrX is well-sampled in both targets and antitargets, whereas
+        antitarget chrY is frequently too sparse to carry signal -- an empty
+        antitarget chrY can drag a real male call to female. So when the two
+        sources disagree, trust whichever source's chrX 'maleness' ratio is
+        furthest from the male/female boundary (1.0). Each guess is
+        ``(is_xx, chrx_male_lr)``; ``chrx_male_lr > 1`` favors male.
+        """
+        reconcile = reference._reconcile_sex_guesses
+        MALE, FEMALE = np.False_, np.True_  # is_xx: True == female
+
+        # The #846 bug: target clearly male, antitarget flipped female by an
+        # empty chrY (its chrX is far less decisive). Keep the target's male call.
+        out = reconcile({"S1": (MALE, 499.0)}, {"S1": (FEMALE, 0.29)})
+        self.assertFalse(out["S1"])
+
+        # The legitimate rescue this reconciliation must preserve: target chrX
+        # was too sparse to look male, antitarget chrX decisively haploid.
+        out = reconcile({"S2": (FEMALE, 0.9)}, {"S2": (MALE, 5.0)})
+        self.assertFalse(out["S2"])
+
+        # Agreement is untouched; confidence is irrelevant.
+        out = reconcile({"S3": (FEMALE, 0.5)}, {"S3": (FEMALE, 0.6)})
+        self.assertTrue(out["S3"])
+
+        # Target couldn't tell (absent) -> fall back to the antitarget guess.
+        out = reconcile({}, {"S4": (MALE, 3.0)})
+        self.assertFalse(out["S4"])
+
+        # A tie favors the target (its sex chromosomes are deliberately baited).
+        out = reconcile({"S5": (FEMALE, 0.5)}, {"S5": (MALE, 2.0)})
+        self.assertTrue(out["S5"])
+
+        # When the target wins, its FULL chrX+chrY call stands -- we must not
+        # re-derive sex from chrX alone. Here the target's chrX is weak (0.8,
+        # chrX-only would say female) but its reliable chrY made the combined
+        # call male; the sparse antitarget must not strip that chrY evidence.
+        out = reconcile({"S6": (MALE, 0.8)}, {"S6": (FEMALE, 0.9)})
+        self.assertFalse(out["S6"])
+
+        # When the antitarget wins, only its chrX counts (its chrY is junk): both
+        # sources' chrX read male, but the antitarget's sparse chrY flipped its
+        # combined call to female. Trusting that combined call would re-break #846.
+        out = reconcile({"S7": (MALE, 1.1)}, {"S7": (FEMALE, 1.5)})
+        self.assertFalse(out["S7"])
+
+    def test_reference_antitarget_empty_chry_keeps_male(self):
+        """do_reference's inference must not flip a male sample to female when
+        the antitarget chrY is near-empty (#846, #863).
+
+        Builds a clearly-male target (haploid chrX, covered chrY) and an
+        antitarget whose chrY is near-absent -- the configuration that made
+        antitarget inference report 'female' and override the target. The fix
+        keeps the male call without users having to delete antitarget chrY.
+        """
+        tmpdir = tempfile.mkdtemp()
+        try:
+            tgt = os.path.join(tmpdir, "S1.targetcoverage.cnn")
+            anti = os.path.join(tmpdir, "S1.antitargetcoverage.cnn")
+            _write_coverage_cnn(
+                tgt,
+                chrx_log2=-1.0,
+                chry_log2=-1.0,
+                chrx_sd=0.2,
+                chry_sd=0.3,
+                n_x=60,
+                n_y=40,
+            )
+            # Antitarget chrY: deep, scattered -> looks absent (female-leaning),
+            # even though the antitarget chrX still reads haploid (male). The
+            # empty chrY alone is what flips the combined guess to female.
+            _write_coverage_cnn(
+                anti,
+                chrx_log2=-0.5,
+                chry_log2=-4.0,
+                chrx_sd=0.6,
+                chry_sd=2.0,
+                n_x=40,
+                n_y=80,
+            )
+
+            t_guesses = reference._guess_sexes([tgt], False, None, verbose=False)
+            a_guesses = reference._guess_sexes([anti], False, None, verbose=False)
+            # Precondition: this fixture really does trigger the conflict.
+            self.assertFalse(t_guesses["S1"][0])  # target -> male
+            self.assertTrue(a_guesses["S1"][0])  # antitarget -> female (the trap)
+
+            sexes = reference._reconcile_sex_guesses(t_guesses, a_guesses)
+            self.assertFalse(sexes["S1"])  # reconciled -> male, not flipped
+        finally:
+            shutil.rmtree(tmpdir)
 
     def test_fix(self):
         """The 'fix' command."""


### PR DESCRIPTION
## Problem

When building a reference without an explicit `--sample-sex`, `do_reference`
infers each control sample's sex separately from its **target** and
**antitarget** coverage. When the two sources disagreed, the antitarget guess
*always* won.

But antitarget chrY is intrinsically sparse — chrY is small and repetitive, so
few off-target background reads map there. A genuine **male's** antitarget chrY
therefore looks just as empty as a female's, which drags
`combined_score = chrx_male_lr × chry_male_lr` below the male/female boundary and
flips a real male to **female**. That corrupts the chrX baseline of the pooled
reference. Users have been working around it by manually deleting antitarget chrY
(#846, #863; related auto-detect inconsistency #505).

## Fix

chrX, unlike chrY, is well-sampled in **both** targets and antitargets, so it is
the trustworthy shared axis. Conflicts are now resolved by chrX confidence
(distance of `log(chrx_male_lr)` from the 1.0 boundary) instead of blindly
preferring antitargets.

The handling is deliberately **asymmetric**, mirroring chrY coverage quality:

- The **target's full chrX+chrY call stands** unless the antitarget's chrX signal
  is *strictly* more decisive.
- When the antitarget does win, only its **chrX** call is adopted — its chrY is
  discarded as unreliable.
- Ties favor the target, whose sex chromosomes are deliberately baited.

This is correct in the cases that broke the two naive alternatives:
- *Use the winner's combined call* → re-breaks #846 when a sparse-chrX antitarget
  narrowly wins but its own chrY flipped it female.
- *Use the winner's chrX-only call* → throws away a target's reliable chrY (e.g. a
  weak-chrX-but-clear-chrY male).

## Implementation

- New `_guess_sexes` returns `(is_xx, chrx_male_lr)` per sample;
  `infer_sexes` delegates to it (contract unchanged).
- New `_chrx_maleness_confidence` and `_reconcile_sex_guesses`.
- The conflict warning now names the chosen source and why.

## Safety / output stability

Behavior is unchanged when there are no antitargets or when the two sources
agree, so existing references are byte-identical. Full suite green (378 passed),
mypy + ruff clean. Two new tests: a deterministic unit test of the reconciliation
policy (including the two counter-examples above) and an end-to-end test that
reproduces the empty-antitarget-chrY flip and confirms the male call is kept.

Also updates `doc/sex.rst` and fixes a stray `gh#360` → `#360` comment.

Fixes #846. Refs #863, #505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)