### PR TITLE
Stop alarmist warning on sex-chrom-less assemblies; report 'Unknown' (#669)

### DIFF
--- a/cnvlib/cnary.py
+++ b/cnvlib/cnary.py
@@ -542,10 +542,20 @@ class CopyNumArray(GenomicArray):
 
         chrx = self[self.chr_x_filter(diploid_parx_genome)]
         if not len(chrx):
-            logging.warning(
-                "No %s found in sample; is the input truncated?",
-                self.chr_x_label or "X chromosome",
-            )
+            # No usable chrX rows for inference. Two shapes both land here:
+            # (a) the context-aware classifier
+            # (``skgenome.chromnames.infer_sex_chrom_labels``) returned
+            # ``chr_x_label is None`` -- the assembly has no chrX (yeast
+            # and other Roman-numeral genomes, where ``chrX`` is autosome
+            # 10; ZW-sex species; custom non-human assemblies, #669); and
+            # (b) ``chr_x_label`` is set but the filter still yielded no
+            # rows -- e.g. all chrX bins fall inside PAR under
+            # ``--diploid-parx-genome``, or the data has been pre-filtered
+            # to autosomes only. Both correctly map to "sex inference is
+            # not applicable here"; the honest ``None`` propagates to
+            # ``is_female_default`` at decision consumers. The pre-#669
+            # WARNING ("is the input truncated?") falsely framed the
+            # structurally-correct cases as data corruption.
             return None, {}
 
         auto = self.autosomes(diploid_parx_genome=diploid_parx_genome)

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -2071,9 +2071,17 @@ def do_sex(
         is_xy, stats = cna.compare_sex_chromosomes(
             is_haploid_x_reference, diploid_parx_genome
         )
+        if is_xy is None:
+            # Indeterminate -- e.g. an assembly with no chrX (#669). Report
+            # 'Unknown' honestly rather than collapsing to the safe female
+            # default at the reporting layer; consumers that need a concrete
+            # bool still get one via `cnary.is_female_default`.
+            sex = "Unknown"
+        else:
+            sex = "Male" if is_xy else "Female"
         return (
             cna.meta["filename"] or cna.sample_id,
-            "Male" if is_xy else "Female",
+            sex,
             strsign(stats["chrx_ratio"]) if stats else "NA",
             strsign(stats["chry_ratio"]) if stats else "NA",
         )

--- a/doc/sex.rst
+++ b/doc/sex.rst
@@ -153,8 +153,18 @@ Sex-chromosome handling is *only* activated when both an ``X``/``chrX`` and
 a ``Y``/``chrY`` (or just an ``X``/``chrX`` in a clearly arabic-numeral
 genome) are detected in the data. In yeast — where ``chrX`` is the 10th
 chromosome by Roman numeral rather than a sex chromosome —
-sex-chromosome inference is automatically disabled and ``cnvkit.py sex``
-will report no result.
+sex-chromosome inference is automatically disabled. The same applies to
+ZW-sex species (birds, reptiles, butterflies) whose chrZ/chrW are not
+currently recognized, and to any custom assembly that doesn't include an
+X/Y pair. In all these cases:
+
+* ``cnvkit.py sex`` reports the sample as ``Unknown`` with ``NA`` for
+  both log-ratios, rather than silently presenting the safe female
+  default as a positive call.
+* Commands that consume the inference internally (e.g. :ref:`call`,
+  :ref:`diagram`) fall back to the safe female default and the
+  per-sample ``Relative log2 coverage ...`` status line is simply
+  omitted; nothing alarming is logged.
 
 FAQ
 ---

--- a/test/test_cnvlib.py
+++ b/test/test_cnvlib.py
@@ -19,6 +19,7 @@ from cnvlib.cnary import CopyNumArray
 from cnvlib import (
     cmdutil,
     cnary,
+    commands,
     fix,
     params,
     plots,
@@ -554,6 +555,80 @@ class CNATests(unittest.TestCase):
             ".cnr-like (many bins) and .cns-like (few segments) with same "
             "chrX/chrY medians must agree on sex (#785).",
         )
+
+    @staticmethod
+    def _make_cna_no_sex_chroms(chrom_names):
+        """Build a small CopyNumArray with the given non-sex chromosome names."""
+        rng = np.random.default_rng(0)
+        rows = []
+        for c in chrom_names:
+            for i in range(20):
+                rows.append(
+                    (c, i * 100, i * 100 + 50, "-", float(rng.normal(0, 0.05)), 1.0)
+                )
+        return CopyNumArray(
+            pd.DataFrame(
+                rows,
+                columns=["chromosome", "start", "end", "gene", "log2", "weight"],
+            )
+        )
+
+    def test_guess_xx_silent_on_non_human_assembly(self):
+        """No false 'is the input truncated?' warning on a custom genome that
+        legitimately lacks chrX (#669).
+
+        ``infer_sex_chrom_labels`` (in ``skgenome.chromnames``) returns
+        ``(None, None)`` for assemblies with no chrX/chrY (custom non-human
+        genomes; ZW-sex species like birds/reptiles; Roman-numeral genomes
+        like yeast where ``chrX`` is autosome 10). In those cases the
+        ``compare_sex_chromosomes`` short-circuit must return ``(None, {})``
+        *without* the alarmist warning -- the warning's premise (that "no
+        chrX" implies truncated input) predates context-aware sex-chromosome
+        detection.
+        """
+        # Three legitimate "no sex chromosome" shapes; each must return None
+        # silently (no WARNING-level records mentioning truncation).
+        for chrom_names in (
+            ("chrA", "chrB", "chrC"),  # custom non-human / scaffold names
+            ("chrI", "chrII", "chrX"),  # yeast: chrX is autosome 10
+            ("chr1", "chr2", "chrZ", "chrW"),  # ZW species (chickens, reptiles)
+        ):
+            cna = self._make_cna_no_sex_chroms(chrom_names)
+            # Sanity: the context-aware classifier already returns None here.
+            self.assertIsNone(cna.chr_x_label)
+            with self.assertLogs(level="WARNING") as captured:
+                # Force at least one WARNING record so assertLogs doesn't
+                # error; assert that NONE of them are the truncation warning.
+                logging.warning("sentinel")
+                result = cna.guess_xx()
+            self.assertIsNone(result)
+            self.assertFalse(
+                any("truncated" in m for m in captured.output),
+                f"Spurious truncation warning on {chrom_names}: {captured.output}",
+            )
+
+    def test_sex_command_reports_unknown_on_non_human_assembly(self):
+        """``cnvkit.py sex`` (``do_sex``) reports 'Unknown' -- not a misleading
+        'Female' default -- when the assembly lacks sex chromosomes (#669).
+
+        ``compare_sex_chromosomes`` returns ``(None, {})`` for these inputs.
+        The previous report path collapsed ``None`` to 'Female' via Python
+        truthiness, which silently presented the safe-default as a positive
+        inference. The reporting layer should be honest about indeterminacy
+        even though decision consumers (like ``shift_xx``) still collapse
+        ``None`` -> female via ``is_female_default``.
+        """
+        cna = self._make_cna_no_sex_chroms(("chrA", "chrB", "chrC"))
+        cna.meta["filename"] = "fungus.cnr"
+
+        df = commands.do_sex(
+            [cna], is_haploid_x_reference=False, diploid_parx_genome=None
+        )
+        # One row, columns: sample, sex, X_logratio, Y_logratio
+        self.assertEqual(len(df), 1)
+        self.assertEqual(df.iloc[0]["sex"], "Unknown")
+        self.assertEqual(df.iloc[0]["X_logratio"], "NA")
+        self.assertEqual(df.iloc[0]["Y_logratio"], "NA")
 
     def test_residuals(self):
         cnarr = cnvlib.read("formats/amplicon.cnr")


### PR DESCRIPTION
Fixes #669.

A user running CNVkit on a custom non-human genome reported the log
message `No X chromosome found in sample; is the input truncated?`.
That wording is written as if the data were corrupted, but it actually
fires every time the assembly legitimately lacks chrX:

- yeast and other Roman-numeral genomes (where `chrX` is autosome 10);
- ZW-sex species (birds, reptiles, butterflies — chrZ/chrW are not
  classified as sex chromosomes by CNVkit's current detector);
- any custom assembly without an X/Y pair.

The same root cause makes `cnvkit.py sex` report such samples as
`Female` with `NA` log-ratios, which silently presents the safe female
default as a positive call.

## Fix

Two layers, same root cause (`compare_sex_chromosomes` returning
`(None, {})`):

1. **`CopyNumArray.compare_sex_chromosomes`** now returns `(None, {})`
   silently when there are no usable chrX rows. The pre-existing
   WARNING dates to before context-aware sex-chromosome detection
   (`skgenome.chromnames.infer_sex_chrom_labels`); `chr_x_label is
   None` is now the canonical "this assembly has no chrX" signal, so
   the warning's premise no longer holds. Consumers that need a
   concrete bool still collapse `None` → female via
   `cnary.is_female_default`.

2. **`cnvlib.commands.do_sex`** reports `Unknown` (with `NA`
   log-ratios) when `compare_sex_chromosomes` returns `None`, rather
   than collapsing to `Female` via Python truthiness. The reporting
   layer should be honest about indeterminacy even though decision
   consumers default to female — those are different responsibilities.

## Tests

Two new tests in `test/test_cnvlib.py::CNATests`:

- `test_guess_xx_silent_on_non_human_assembly`: covers three legitimate
  "no sex chromosome" shapes (custom non-human, yeast Roman-numeral,
  ZW species) and asserts no `truncated`-shaped WARNING is emitted.
- `test_sex_command_reports_unknown_on_non_human_assembly`: covers the
  full pipeline through `do_sex`, asserting `Unknown` / `NA` / `NA`.

Existing `test_guess_xx_*` suite continues to pass, as does the full
local test run (378 passed).

## Docs

`doc/sex.rst` "Non-human and Roman-numeral genomes" section now
explicitly distinguishes the two layers: `cnvkit.py sex` reports
`Unknown`, while internal-consumer commands (`call`, `diagram`) fall
back to female silently and the per-sample status line is omitted.

## Clinical-impact note

This does not alter numerical output for any sample where chrX is
present. Behavior changes only for samples where `compare_sex_chromosomes`
previously returned `(None, {})` — the WARNING is gone, and `do_sex`'s
table cell flips from `Female` to `Unknown` for those samples.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)