### PR TITLE
Add VCF chrX heterozygous-SNP density confirmer for sex inference (#341)

### DIFF
--- a/cnvlib/cmdutil.py
+++ b/cnvlib/cmdutil.py
@@ -7,6 +7,7 @@ import sys
 import numpy as np
 
 from skgenome import tabio
+from skgenome.chromnames import infer_sex_chrom_labels
 
 from .cnary import CopyNumArray as CNA, is_female_default
 from skgenome import GenomicArray as GA
@@ -78,6 +79,33 @@ def load_het_snps(
                 + "based on T/N genotypes",
             )
         varr = varr[~somatic_idx]
+    # Count chrX SNPs (and chrX hets) BEFORE the global het filter, so the
+    # downstream chrX-het-density confirmer (verify_sample_sex with VCF, #341)
+    # has both numerator and denominator. Detect the chrX label via
+    # skgenome's context-aware classifier rather than an inline regex.
+    chrx_label, _ = infer_sex_chrom_labels(set(varr.chromosome.unique()))
+    if chrx_label is not None:
+        on_chrx = varr.chromosome == chrx_label
+        n_chrx_total = int(on_chrx.sum())
+        # Match VariantArray.heterozygous()'s column-selection: when a matched
+        # normal VCF is loaded both ``zygosity`` (tumor) and ``n_zygosity``
+        # (normal) are present, and the germline-het signal lives in the
+        # normal. Use the same precedence so the binomial test's numerator
+        # comes from the same population the het-filter would have selected.
+        if "n_zygosity" in varr:
+            zyg = varr["n_zygosity"]
+        elif "zygosity" in varr:
+            zyg = varr["zygosity"]
+        else:
+            zyg = None
+        if zyg is not None:
+            n_chrx_het = int((on_chrx & (zyg != 0.0) & (zyg != 1.0)).sum())
+        else:
+            n_chrx_het = 0
+    else:
+        n_chrx_total = 0
+        n_chrx_het = 0
+
     orig_len = len(varr)
     varr = varr.heterozygous()  # type: ignore[attr-defined]
     logging.info("Kept %d heterozygous of %d VCF records", len(varr), orig_len)
@@ -85,6 +113,10 @@ def load_het_snps(
     # TODO use/explore tumor_boost option
     if tumor_boost:
         varr["alt_freq"] = varr.tumor_boost()
+    # Stash the pre-filter chrX counts so verify_sample_sex can run the
+    # chrX-het-density confirmer below.
+    varr.meta["chrx_snp_total"] = n_chrx_total
+    varr.meta["chrx_het_count"] = n_chrx_het
     return varr  # type: ignore[no-any-return]
 
 
@@ -127,10 +159,11 @@ def verify_sample_sex(
     sex_arg: str | None,
     is_haploid_x_reference: bool,
     diploid_parx_genome: str | None,
+    variants: VariantArray | None = None,
 ) -> bool:
     guess = cnarr.guess_xx(is_haploid_x_reference, diploid_parx_genome, verbose=False)
     # None means "couldn't tell" (no chrX / degenerate); default to female so an
-    # indeterminate sample is never silently treated as male (gh#360 family).
+    # indeterminate sample is never silently treated as male (#360 family).
     is_sample_female = is_female_default(guess)
     if sex_arg:
         is_sample_female_given = sex_arg.lower() not in ["y", "m", "male"]
@@ -142,6 +175,36 @@ def verify_sample_sex(
                 "female" if is_sample_female else "male",
             )
         is_sample_female = is_sample_female_given
+    elif (
+        variants is not None and not is_sample_female and cnarr.chr_x_label is not None
+    ):
+        # No user override + coverage inferred male: ask the VCF for an
+        # independent chrX-heterozygous-SNP confirmer. True haploid X has
+        # ~no het SNPs, so observing many of them rejects the haploid-X
+        # null and we override to female -- the chrX expected ploidy used
+        # downstream (purity rescaling, diagram shift_xx, etc.) is then
+        # diploid, which is the correct baseline for calls and LOH (#341).
+        # Coverage-based call stays untouched when the test isn't decisive,
+        # so this is a one-way upgrade toward female (the safe direction
+        # for #360-family indeterminacy).
+        from .vary import chrx_het_density_rejects_haploid
+
+        n_total = variants.meta.get("chrx_snp_total", 0)
+        n_het = variants.meta.get("chrx_het_count", 0)
+        rejected, p_value = chrx_het_density_rejects_haploid(n_total, n_het)
+        if rejected:
+            logging.warning(
+                "Coverage inferred male, but chrX heterozygous-SNP density "
+                "(%d het of %d total chrX SNPs in the VCF) rejects the "
+                "haploid-X null at binomial p=%.2g; treating sample as "
+                "female so chrX copy-number calls use a diploid-X "
+                "baseline. Pass --sample-sex male to suppress this "
+                "override.",
+                n_het,
+                n_total,
+                p_value,
+            )
+            is_sample_female = True
     logging.info(
         "Treating sample %s as %s",
         cnarr.sample_id or "",

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -1273,12 +1273,18 @@ def _cmd_call(args: argparse.Namespace) -> None:
         args.min_variant_depth,
         args.zygosity_freq,
     )
-    is_sample_female = (
-        verify_sample_sex(
-            cnarr, args.sample_sex, args.male_reference, args.diploid_parx_genome
-        )
-        if args.purity and args.purity < 1.0
-        else None
+    # Resolve per-sample sex unconditionally so the VCF het-density confirmer
+    # (#341) and the audit log line ("Treating sample X as ...") apply
+    # uniformly, not only on the purity-rescaled path. The threshold-method
+    # branch of do_call doesn't consume ``is_sample_female`` directly
+    # (chrX reference copies come from ``-y`` alone in ``_reference_copies_pure``),
+    # so this is output-neutral in the common germline case.
+    is_sample_female = verify_sample_sex(
+        cnarr,
+        args.sample_sex,
+        args.male_reference,
+        args.diploid_parx_genome,
+        variants=varr,
     )
     cnarr = call.do_call(
         cnarr,

--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -227,6 +227,64 @@ def _tumor_boost(t_freqs, n_freqs):
     return out
 
 
+#: Maximum chrX heterozygous-SNP rate allowed under the "haploid X" null.
+#: True haploid X has zero het SNPs in principle; a small ceiling allows for
+#: sequencing-error het calls without rejecting the null on every panel.
+_HAPLOID_X_HET_RATE_CEILING = 0.05
+
+#: Minimum total chrX SNP count required to power the binomial test. With
+#: fewer than this many SNPs the test is too uncertain to override the
+#: coverage-based sex call, and the helper returns ``(False, None)``.
+_MIN_CHRX_SNPS_FOR_HET_TEST = 10
+
+#: One-sided p-value threshold for rejecting the haploid-X null. Set
+#: conservatively because rejection flips ``is_sample_female`` and so
+#: changes the chrX expected ploidy downstream of ``verify_sample_sex``.
+_HET_TEST_ALPHA = 0.001
+
+
+def chrx_het_density_rejects_haploid(
+    n_chrx_total: int,
+    n_chrx_het: int,
+    *,
+    haploid_x_het_rate_ceiling: float = _HAPLOID_X_HET_RATE_CEILING,
+    min_snps: int = _MIN_CHRX_SNPS_FOR_HET_TEST,
+    alpha: float = _HET_TEST_ALPHA,
+) -> tuple[bool, float | None]:
+    """One-sided binomial test of chrX heterozygous-SNP density vs. haploid X.
+
+    True diploid X has SNP heterozygosity comparable to autosomes
+    (~30% in panel-typical populations); true haploid X has essentially
+    zero heterozygous calls modulo sequencing-error noise. This test
+    compares the observed chrX het count against a permissive haploid-X
+    null (``haploid_x_het_rate_ceiling`` = 5% by default, generous enough
+    to absorb sequencing-error het calls), and rejects if the observation
+    exceeds what the null allows at the chosen ``alpha``.
+
+    Used by :func:`cnvlib.cmdutil.verify_sample_sex` as an independent
+    confirmer of chrX ploidy when the user supplies a VCF (gh#341). The
+    test only fires when coverage already inferred a male call -- a
+    rejected null means the VCF says diploid X, which overrides to
+    female. (A non-rejected null leaves the coverage call alone; "no
+    het signal" is consistent with either true haploid X or simply not
+    enough data, so it is non-evidence in the female direction.)
+
+    Returns ``(rejected, p_value)``. ``rejected`` is False when
+    ``n_chrx_total < min_snps`` because the test is then underpowered,
+    and ``p_value`` is None in that case to signal "no test was run."
+    """
+    if n_chrx_total < min_snps:
+        return False, None
+    # Imported locally so that callers that never touch sex inference don't
+    # pay the scipy import cost.
+    from scipy.stats import binom
+
+    # binom.sf(k-1, n, p) = P(X >= k | n, p); a small value means the
+    # observation is unlikely under haploid X, so we reject the null.
+    p_value = float(binom.sf(n_chrx_het - 1, n_chrx_total, haploid_x_het_rate_ceiling))
+    return p_value < alpha, p_value
+
+
 def _allele_specific_copy_numbers(segarr, varr, ploidy=2):
     """Split total copy number between alleles based on BAF.
 

--- a/doc/sex.rst
+++ b/doc/sex.rst
@@ -181,6 +181,36 @@ no chrY bins -- the AND-gate naturally collapses to a chrX-only check
 applies, and the strict inequality means a sample sitting exactly at the
 chrX midpoint ties to female (the safe default).
 
+VCF heterozygous-SNP confirmer
+``````````````````````````````
+
+When a VCF is supplied to :ref:`call`, CNVkit additionally runs an
+independent confirmer of chrX ploidy. A diploid X chromosome has
+heterozygous SNPs at roughly the same population rate as autosomes
+(~30% of polymorphic sites in panel-typical populations); a haploid X
+has essentially zero heterozygous calls, modulo sequencing-error noise.
+Observing many het SNPs on chrX is therefore strong evidence that chrX
+is diploid -- evidence that the presence of a chromosome Y *cannot
+fake* (a chrY+haploid-chrX male has no chrX het sites; a Klinefelter
+XXY does).
+
+CNVkit runs a one-sided binomial test of the observed chrX het count
+against a permissive haploid-X null (5% error-rate ceiling) at
+α = 0.001. If the haploid-X null is rejected and coverage had
+inferred male, the sample is upgraded to female so chrX expected
+ploidy is diploid in downstream calls (purity-rescaled copy number,
+diagram chrX shift, etc.). The override is logged at WARNING level
+with the het/total counts and the p-value, and is suppressed when the
+user supplies ``--sample-sex`` explicitly. The test requires at least
+10 chrX SNPs in the VCF; smaller panels skip the test silently
+(non-evidence in either direction).
+
+This is a one-way upgrade toward female (the safe direction in the
+"no positive male evidence" sense of the AND-gate above); a no-het
+VCF never flips a coverage-female call to male, because absent het
+SNPs are consistent with either true haploid X or simply not enough
+data.
+
 PAR handling
 ------------
 

--- a/test/test_call.py
+++ b/test/test_call.py
@@ -745,3 +745,219 @@ class LoadHetSnpsTests(unittest.TestCase):
             any("Median allele frequency" in msg for msg in ctx.output),
             ctx.output,
         )
+
+    def test_load_het_snps_records_chrx_counts_in_meta(self):
+        """``cmdutil.load_het_snps`` stashes pre-filter chrX SNP and het counts
+        in ``varr.meta`` so the chrX-het-density confirmer (#341) can compare
+        chrX het rate against the haploid-X null.
+
+        NA12878 is XX, so the test VCF should have a non-trivial chrX het
+        count if the panel covers chrX at all. We don't pin exact numbers
+        (those depend on the fixture VCF's chrX content) -- we just verify
+        the meta keys are populated as ints, in the right ordering
+        (het count <= total).
+        """
+        varr = cmdutil.load_het_snps(
+            "formats/na12878_na12882_mix.vcf", "NA12878", "NA12882", 15, None
+        )
+        self.assertIn("chrx_snp_total", varr.meta)
+        self.assertIn("chrx_het_count", varr.meta)
+        self.assertIsInstance(varr.meta["chrx_snp_total"], int)
+        self.assertIsInstance(varr.meta["chrx_het_count"], int)
+        self.assertLessEqual(varr.meta["chrx_het_count"], varr.meta["chrx_snp_total"])
+
+
+class VerifySampleSexHetConfirmerTests(unittest.TestCase):
+    """Integration tests for the chrX-het-density confirmer plumbing inside
+    ``cmdutil.verify_sample_sex`` (#341).
+
+    The confirmer fires only when (a) the user did NOT pass --sample-sex,
+    (b) coverage inferred male, and (c) the VCF supplies enough chrX SNPs
+    to power a binomial test of the haploid-X null. A rejected null flips
+    is_sample_female to True; otherwise the coverage-based call stands.
+    """
+
+    def _make_male_cnarr(self):
+        """Build a tiny .cnr that the coverage inference will call male."""
+        rng = np.random.default_rng(0)
+        rows = []
+        # 200 autosome bins centered on log2=0
+        for c in ("chr1", "chr2"):
+            for i in range(100):
+                rows.append(
+                    (c, i * 1000, i * 1000 + 100, "-", float(rng.normal(0, 0.05)), 1.0)
+                )
+        # 50 chrX bins at log2 ~ -1 (haploid-X relative to a diploid-X reference)
+        for i in range(50):
+            rows.append(
+                (
+                    "chrX",
+                    i * 1000,
+                    i * 1000 + 100,
+                    "-",
+                    float(rng.normal(-1.0, 0.05)),
+                    1.0,
+                )
+            )
+        # 30 chrY bins around log2=0 (presence, autosome-like = male)
+        for i in range(30):
+            rows.append(
+                (
+                    "chrY",
+                    i * 1000,
+                    i * 1000 + 100,
+                    "-",
+                    float(rng.normal(0.0, 0.05)),
+                    1.0,
+                )
+            )
+        return cnary.CopyNumArray(
+            pd.DataFrame(
+                rows,
+                columns=["chromosome", "start", "end", "gene", "log2", "weight"],
+            ),
+            {"sample_id": "synthetic_male"},
+        )
+
+    def _make_varr(self, n_total, n_het):
+        """Build a VariantArray with pre-stamped chrX meta counts."""
+        # Minimal VariantArray with the required schema (chromosome/start/end/ref/alt).
+        # Row contents don't matter for the confirmer -- only meta counts do.
+        varr = vary.VariantArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chrX"],
+                    "start": [100],
+                    "end": [101],
+                    "ref": ["A"],
+                    "alt": ["G"],
+                }
+            )
+        )
+        varr.meta["chrx_snp_total"] = n_total
+        varr.meta["chrx_het_count"] = n_het
+        return varr
+
+    def test_high_chrx_het_density_overrides_male_to_female(self):
+        """Many chrX hets in the VCF flip a coverage-inferred male call."""
+        cnarr = self._make_male_cnarr()
+        # Sanity: coverage alone calls this sample male.
+        self.assertFalse(
+            cmdutil.is_female_default(cnarr.guess_xx(verbose=False)),
+            "Synthetic fixture must be male by coverage before the confirmer.",
+        )
+        varr = self._make_varr(n_total=50, n_het=15)  # ~30% het rate, clearly diploid
+        with self.assertLogs(level="WARNING") as ctx:
+            is_female = cmdutil.verify_sample_sex(
+                cnarr,
+                sex_arg=None,
+                is_haploid_x_reference=False,
+                diploid_parx_genome=None,
+                variants=varr,
+            )
+        self.assertTrue(is_female)
+        self.assertTrue(
+            any("rejects the haploid-X null" in msg for msg in ctx.output),
+            ctx.output,
+        )
+
+    def test_low_chrx_het_density_keeps_male_call(self):
+        """Few/no chrX hets do not override -- the male call stands."""
+        cnarr = self._make_male_cnarr()
+        varr = self._make_varr(n_total=50, n_het=1)  # consistent with haploid + noise
+        is_female = cmdutil.verify_sample_sex(
+            cnarr,
+            sex_arg=None,
+            is_haploid_x_reference=False,
+            diploid_parx_genome=None,
+            variants=varr,
+        )
+        self.assertFalse(is_female)
+
+    def test_user_override_wins_over_het_confirmer(self):
+        """``--sample-sex male`` suppresses the confirmer even with clear het signal."""
+        cnarr = self._make_male_cnarr()
+        varr = self._make_varr(n_total=50, n_het=15)  # would otherwise flip to female
+        is_female = cmdutil.verify_sample_sex(
+            cnarr,
+            sex_arg="male",
+            is_haploid_x_reference=False,
+            diploid_parx_genome=None,
+            variants=varr,
+        )
+        self.assertFalse(is_female)
+
+    def test_confirmer_inert_when_no_chrx_label(self):
+        """A non-human / yeast / autosome-only cnarr (chr_x_label is None)
+        short-circuits the confirmer regardless of VCF meta counts (#669).
+
+        The ``elif`` guard in verify_sample_sex requires
+        ``cnarr.chr_x_label is not None``. Independently, load_het_snps
+        wouldn't have set non-zero meta counts on such a VCF either, but
+        defending both sides keeps the confirmer safely inert on
+        unfamiliar assemblies.
+        """
+        rng = np.random.default_rng(0)
+        rows = []
+        # Autosome-only (custom non-human assembly)
+        for c in ("chrA", "chrB"):
+            for i in range(50):
+                rows.append(
+                    (c, i * 1000, i * 1000 + 100, "-", float(rng.normal(0, 0.05)), 1.0)
+                )
+        cnarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                rows,
+                columns=["chromosome", "start", "end", "gene", "log2", "weight"],
+            ),
+            {"sample_id": "fungus"},
+        )
+        self.assertIsNone(cnarr.chr_x_label)
+        # Even with VCF meta that WOULD reject haploid-X for a chrX-having
+        # sample, the confirmer must not fire here.
+        varr = self._make_varr(n_total=50, n_het=15)
+        is_female = cmdutil.verify_sample_sex(
+            cnarr,
+            sex_arg=None,
+            is_haploid_x_reference=False,
+            diploid_parx_genome=None,
+            variants=varr,
+        )
+        # is_female_default(None) -> True; the female default is preserved,
+        # not because the confirmer overrode anything but because the
+        # coverage layer returned None (no determination) for an assembly
+        # without sex chromosomes.
+        self.assertTrue(is_female)
+
+    def test_confirmer_inert_for_female_coverage_call(self):
+        """If coverage already says female, the confirmer doesn't run / matter."""
+        # A female-coverage fixture: chrX at autosome median, chrY missing.
+        rng = np.random.default_rng(0)
+        rows = []
+        for c in ("chr1", "chr2"):
+            for i in range(100):
+                rows.append(
+                    (c, i * 1000, i * 1000 + 100, "-", float(rng.normal(0, 0.05)), 1.0)
+                )
+        for i in range(50):
+            rows.append(
+                ("chrX", i * 1000, i * 1000 + 100, "-", float(rng.normal(0, 0.05)), 1.0)
+            )
+        cnarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                rows,
+                columns=["chromosome", "start", "end", "gene", "log2", "weight"],
+            ),
+            {"sample_id": "synthetic_female"},
+        )
+        varr = self._make_varr(n_total=50, n_het=15)
+        # Whether the confirmer "fired" is invisible here -- the only observable
+        # is the final is_sample_female, which stays True (female) regardless.
+        is_female = cmdutil.verify_sample_sex(
+            cnarr,
+            sex_arg=None,
+            is_haploid_x_reference=False,
+            diploid_parx_genome=None,
+            variants=varr,
+        )
+        self.assertTrue(is_female)

--- a/test/test_vary.py
+++ b/test/test_vary.py
@@ -142,5 +142,67 @@ class VariantArrayTests(unittest.TestCase):
         self.assertEqual(list(varr["zygosity"]), [0.5, 0.5, 0.5])
 
 
+class ChrXHetDensityTests(unittest.TestCase):
+    """Tests for ``vary.chrx_het_density_rejects_haploid`` (gh#341).
+
+    A diploid X chromosome has SNP heterozygosity comparable to autosomes
+    (~30% in panel-typical populations); a haploid X has essentially zero
+    heterozygous calls modulo sequencing-error noise. The helper runs a
+    one-sided binomial test of the observed chrX het count against a
+    permissive haploid-X null (5% error-rate ceiling), rejecting when
+    the observation cannot be reconciled with haploid X at the chosen
+    alpha. This is the independent sex confirmer used in
+    ``verify_sample_sex`` when a VCF is supplied.
+    """
+
+    def test_diploid_x_population_het_rate_rejects_haploid(self):
+        """Realistic diploid-X panel (~30% het) confidently rejects haploid."""
+        rejected, p = vary.chrx_het_density_rejects_haploid(
+            n_chrx_total=50, n_chrx_het=15
+        )
+        self.assertTrue(rejected)
+        self.assertIsNotNone(p)
+        self.assertLess(p, 0.001)
+
+    def test_haploid_x_with_sequencing_noise_does_not_reject(self):
+        """True haploid X with a sprinkling of error-rate hets is not rejected."""
+        # 50 total chrX SNPs, 1 het (matches the 5% ceiling, well within noise)
+        rejected, _ = vary.chrx_het_density_rejects_haploid(
+            n_chrx_total=50, n_chrx_het=1
+        )
+        self.assertFalse(rejected)
+
+    def test_underpowered_below_min_snps(self):
+        """Fewer than the min-snps floor returns (False, None) regardless."""
+        # Even with 100% het rate, can't reject with only 5 SNPs.
+        rejected, p = vary.chrx_het_density_rejects_haploid(
+            n_chrx_total=5, n_chrx_het=5
+        )
+        self.assertFalse(rejected)
+        self.assertIsNone(p)
+
+    def test_borderline_n10_needs_strong_signal(self):
+        """With only 10 SNPs the test demands a very high het rate to reject.
+
+        Per calibration (binom.sf at alpha=0.001, p_null=0.05): n=10 needs
+        k>=5 (50% het rate) to reject; k=4 (40%) is not enough.
+        """
+        rejected_at_5, _ = vary.chrx_het_density_rejects_haploid(
+            n_chrx_total=10, n_chrx_het=5
+        )
+        rejected_at_4, _ = vary.chrx_het_density_rejects_haploid(
+            n_chrx_total=10, n_chrx_het=4
+        )
+        self.assertTrue(rejected_at_5)
+        self.assertFalse(rejected_at_4)
+
+    def test_zero_hets_never_rejects(self):
+        """No observed hets → cannot reject haploid (the null prediction)."""
+        rejected, _ = vary.chrx_het_density_rejects_haploid(
+            n_chrx_total=100, n_chrx_het=0
+        )
+        self.assertFalse(rejected)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #341.

## What this PR does

When the user supplies a VCF to ``cnvkit.py call``, CNVkit now runs an
**independent** confirmer of chrX ploidy using heterozygous-SNP
density. A diploid X chromosome has SNP heterozygosity comparable to
autosomes (~30% in panel-typical populations); a haploid X has
essentially zero heterozygous calls modulo sequencing-error noise.
Critically, **the presence of a chromosome Y cannot fake chrX het
SNPs** — so this signal is genuinely independent of the coverage
inference machinery (which can be tricked by chrY-coverage anomalies,
small panels, or chrY masking).

A one-sided binomial test of the observed chrX het count against a
permissive haploid-X null (5% sequencing-error rate ceiling) at
α = 0.001 rejects when the observed exceeds the null. On rejection,
``is_sample_female`` flips True, downstream chrX expected ploidy is
diploid in the purity-rescaled call path, BAF / cn1+cn2 calculation,
and diagram shift_xx.

This is a **one-way upgrade toward female** — the safe direction per
the AND-gate "no positive male evidence → female default" design
shipped in 3n3.3. A no-het VCF never flips a coverage-female call to
male, because absent het SNPs are consistent with either true
haploid X or simply not enough data (non-evidence).

## Architecture

Three layers, in dependency order:

1. **``cnvlib.vary.chrx_het_density_rejects_haploid``** — pure
   integer-in / float-out binomial test. Module-level constants for
   the rate ceiling (0.05), min-SNP floor (10), and α (0.001).

2. **``cnvlib.cmdutil.load_het_snps``** — counts chrX total + chrX het
   BEFORE the existing ``.heterozygous()`` filter (which would
   otherwise discard the denominator) and stashes both in
   ``varr.meta``. chrX label detection routes through
   ``skgenome.chromnames.infer_sex_chrom_labels`` (no inline regex).
   Column selection for the het count mirrors
   ``VariantArray.heterozygous()``'s precedence
   (``n_zygosity`` if present, else ``zygosity``) so the binomial
   numerator and the heterozygous-filter numerator come from the same
   population — a correctness point the parallel-reviewer gate caught.

3. **``cnvlib.cmdutil.verify_sample_sex``** — new optional
   ``variants=`` kwarg. When supplied + no user override + coverage
   inferred male + cnarr has a chrX label, runs the confirmer and
   flips ``is_sample_female=True`` on rejection. Logs the override at
   WARNING with the het/total counts and p-value for audit.

The ``_cmd_call`` integration now calls ``verify_sample_sex``
unconditionally (previously only on the purity<1 path) so the audit
log line appears in both germline and tumor mode. This is
output-neutral in germline since the threshold-method branch of
``do_call`` doesn't consume ``is_sample_female``; the confirmer's
behavioral effect today is on purity-rescaled calls, diagrams, and
allele-specific copy number — the workflows where chrX expected
ploidy actually matters.

## Tests

* ``test_vary.py::ChrXHetDensityTests`` — 5 unit tests of the binomial
  helper covering realistic diploid, haploid + noise, underpowered,
  threshold-of-rejection, and zero-hets.
* ``test_call.py::VerifySampleSexHetConfirmerTests`` — 5 integration
  tests covering: many-hets flip, low-hets no-op, ``--sample-sex``
  override wins, female-coverage inert, and chr_x_label-None
  (non-human / yeast) inert.
* ``test_call.py::LoadHetSnpsTests`` gains a smoke test that the
  ``chrx_snp_total`` / ``chrx_het_count`` meta keys are populated
  consistently (het count <= total).

## Clinical impact

When the confirmer fires, ``.call.cns`` chrX cn values, BAF, and
cn1/cn2 change because is_sample_female flips. The override is loudly
logged with the underlying counts and p-value, and is suppressed when
the user supplies ``--sample-sex``. The override never flips a
coverage-female call to male.

The unconditional ``verify_sample_sex`` call in ``_cmd_call`` is
output-neutral in pure germline mode (the threshold-method calling
path doesn't consume ``is_sample_female``) but adds a "Treating
sample X as ..." audit log line that previously appeared only in
tumor mode.

## Verification

* 391 tests pass locally (``pytest test/ --ignore=test/test_r.py``).
* mypy clean, ruff clean, pre-commit clean.
* 3-reviewer parallel gate (simplicity / correctness / conventions)
  ran; all findings addressed:
  - R2 critical (95): ``load_het_snps`` was counting hets from
    ``zygosity`` (tumor) but ``heterozygous()`` filters on
    ``n_zygosity`` (normal) when both are present. Mirrored the
    precedence so the numerator population matches the filter
    population — important for matched T/N tumor VCFs.
  - R1+R2 important (88): confirmer was gated behind
    ``args.purity and args.purity < 1.0``. Moved
    ``verify_sample_sex`` out of the conditional so the audit log
    appears uniformly.
  - R2 important (80): missing test for chr_x_label-None added.
  - R3 important (85): new test method now references
    ``cmdutil.load_het_snps`` (the defining module) matching the
    class docstring.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)