### PR TITLE
CLAUDE.md tidy: distribute textbook content to docs, keep invariants here

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,60 +19,37 @@ CNVkit is a command-line toolkit and Python library for detecting copy number va
 
 ## Development Commands
 
-### Development Environment
+See `doc/development.rst` for the full developer guide (environment
+setup, pre-commit hooks, code style, testing matrix, PR process, Docker
+release flow). The notes below are the AI-session-specific quirks not
+already in that guide.
 
-**Conda (recommended):**
-```bash
-conda env create -f environment-dev.yml   # All deps, R, testing tools
-conda activate cnvkit
-```
+**Conda env quirk:** `conda run -n cnvkit <command>` is unreliable in
+this repo (the dev tools sometimes fail to find their dependencies).
+Use `conda activate cnvkit && <command>` instead — including inside
+scripts and parallel agent runs.
 
-**Note:** The conda env must be activated before running pytest, mypy, or other dev tools -- they are not installed globally. The conda env includes R with DNAcopy for segmentation. Use `conda activate cnvkit && <command>` in scripts; `conda run` is unreliable here.
+**`# type: ignore` requirement:** `pyproject.toml` sets
+`enable_error_code = ["ignore-without-code"]`, so every `# type: ignore`
+must specify the error code (e.g. `# type: ignore[return-value]`). Bare
+`# type: ignore` fails mypy.
 
-### Testing
-
-Run tests directly with pytest (not tox):
-```bash
-pytest test/                           # Run all tests
-pytest test/test_cnvlib.py            # Run specific test file
-pytest test/test_commands.py::CommandTests::test_batch  # Run specific test
-pytest test/test_commands.py -k "batch or coverage"  # Run tests matching patterns
-```
-
-**Comprehensive testing:**
-- `tox` - Full matrix: Python 3.11-3.14, linting, security, coverage, docs
-- `cd test/ && make mini` - Integration tests with real genomic data (used in CI)
-
-### Type Checking
-
-```bash
-mypy                              # Check both cnvlib and skgenome
-mypy cnvlib/batch.py              # Check a single file
-```
-
-**mypy configuration** (`pyproject.toml [tool.mypy]`):
-- `check_untyped_defs = true`, `warn_unreachable = true`, `warn_return_any = true`
-- `enable_error_code = ["ignore-without-code"]` - All `# type: ignore` must include error codes
-
-**Common type patterns in this codebase:**
-- `tabio.read()` returns union types -- use `# type: ignore[return-value]` at call sites
-- Pandas operations often return `Any` -- use `# type: ignore[no-any-return]`
-- Closures don't narrow types in mypy -- use `# type: ignore[index]` or local asserts
-- Parameters typed `param: None = None` cause unreachable blocks -- use `Optional[Type] = None` instead
-- Generator functions must use `-> Generator[YieldType, SendType, ReturnType]`, not `-> Iterator` or `-> None`
-- When a variable changes type (e.g. `str` → `list[int]`), rename it to avoid shadowing (e.g. `copies` → `copy_strs`)
-- Use `assert x is not None` to narrow `Optional` types when control flow guarantees non-None
-- `numpy.bool_` is not assignable to `bool` in mypy -- use `# type: ignore[assignment]` or widen parameters to `bool | bool_ | None`
-
-### Code Quality & Security
-
-Pre-commit hooks run automatically on `git commit` (ruff, bandit, whitespace, YAML/TOML checks). Install with `pre-commit install`.
-
-**Manual commands:**
-- `make lint` / `make format` - Ruff linting and formatting
-- `make security` - Safety + Bandit scans
-- `tox -e lint` / `tox -e security` / `tox -e coverage` / `tox -e doc`
-- `make help` - Show all Makefile targets
+**Common type-ignore patterns in this codebase** (the footguns mypy
+flags most often here):
+- `tabio.read()` returns union types — `# type: ignore[return-value]`
+  at call sites.
+- Pandas operations often return `Any` — `# type: ignore[no-any-return]`.
+- Closures don't narrow types in mypy — `# type: ignore[index]` or a
+  local `assert`.
+- Parameters typed `param: None = None` produce unreachable blocks —
+  use `Optional[Type] = None` (or `Type | None = None`) instead.
+- Generator functions must use `-> Generator[YieldType, SendType,
+  ReturnType]`, not `-> Iterator` or `-> None`.
+- When a variable changes type (e.g. `str` → `list[int]`), rename it to
+  avoid shadowing (e.g. `copies` → `copy_strs`).
+- `numpy.bool_` is not assignable to `bool` in mypy — use
+  `# type: ignore[assignment]` or widen parameters to
+  `bool | bool_ | None`.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,20 +99,49 @@ Pre-commit hooks run automatically on `git commit` (ruff, bandit, whitespace, YA
 GenomicArray uses `typing.Self` (PEP 673) so that methods like `.copy()`, `.concat()`, and `.as_dataframe()` preserve the subclass type through type checking.
 
 ### Chromosome-name handling
-All chromosome-name classification goes through `skgenome.chromnames` -- do NOT add inline regexes or `.startswith("chr")` / `chromosome.iat[0]` heuristics. Key facts:
-- Genomes may use arabic (`chr1`) or Roman (`chrI`..`chrXVI`, e.g. yeast) numerals. `chrX` is a sex chromosome in human but autosome 10 in yeast, so sex-chromosome detection is *context-aware* (`infer_sex_chrom_labels` inspects the whole chromosome set, not one name).
-- `CopyNumArray.chr_x_label` / `chr_y_label` return `str | None`; `None` means no sex chromosome detected. Callers must handle `None` (the `chr_*_filter` methods return all-False in that case).
-- `GenomicArray.autosomes()` falls back to returning the whole array (with a warning) when no autosomes are recognized -- be permissive on unfamiliar assemblies rather than silently dropping data.
-- PAR coordinates live in `skgenome.genomebuild`; `cnvlib.params.PSEUDO_AUTSOMAL_REGIONS` is a back-compat re-export.
 
-### Sex inference (compare_sex_chromosomes + is_female_default)
-Per-chromosome maleness is a **ratio of residuals** to the two expected log2 positions: `chrx_male_lr = abs(chrx_ratio + female_shift) / max(abs(chrx_ratio + male_shift), 1e-6)`, and the same shape for chrY. >1 means closer to the male expected position; the 1.0 boundary is the geometric midpoint between expectations, so the decision is threshold-free up to that geometry.
-- chrX shifts follow `is_haploid_x_reference` (the existing `-y` flag): `(female=-1, male=0)` with `-y`, `(female=0, male=+1)` without.
-- chrY female expected position is `params.NULL_LOG2_COVERAGE` (the no-reads sentinel ≈ -20); male expected is autosome-median. This wide separation makes the chrY check a presence/absence detector with a generous margin.
-- Decision is an **AND-gate**: male iff `chrx_male_lr > 1 AND chry_male_lr > 1`. Monotonic toward the safe female default; chrY noise cannot push a diploid-looking chrX to male and vice versa.
-- When chrY data is absent entirely (yeast, female-only reference, panel with no chrY targets), the AND-gate collapses cleanly to `is_male = chrx_male_lr > 1.0`. The strict `>` ties the exact-midpoint case to female.
-- `guess_xx` / `infer_sexes` still return `None` when sex is undeterminable (yeast, autosome-only inputs). The decision-level helper `cnary.is_female_default(guess) -> bool` collapses `None` → `True`; apply it at every consumer that needs a concrete bool. The honest `None` is preserved so the target/antitarget reconciliation in `do_reference` can do its asymmetric chrX-confidence merge (target full call wins unless antitarget chrX is strictly more decisive, then antitarget chrX-only call wins).
-- Do NOT re-introduce a multiplicative `combined_score` or chi-square test statistic; the median is already robust, and a chi-square wrapped around it brings sample-size dependence (.cnr vs .cns inconsistency).
+**All chromosome-name classification goes through `skgenome.chromnames`** —
+do NOT add inline regexes or `.startswith("chr")` / `chromosome.iat[0]`
+heuristics. The classifier is *context-aware* (it inspects the whole
+chromosome set, not one name), because `chrX` is a sex chromosome in
+human but autosome 10 in yeast. See `doc/sex.rst` "Non-human and
+Roman-numeral genomes" for the user-facing behavior.
+
+API points worth knowing:
+- `CopyNumArray.chr_x_label` / `chr_y_label` return `str | None`. `None`
+  means "no sex chromosome detected in this assembly" — callers must
+  handle `None` (the `chr_*_filter` methods return all-False in that
+  case rather than crashing).
+- `GenomicArray.autosomes()` falls back to returning the whole array
+  (with a warning) when no autosomes are recognized. Be permissive on
+  unfamiliar assemblies; don't silently drop data.
+- PAR coordinates live in `skgenome.genomebuild`;
+  `cnvlib.params.PSEUDO_AUTSOMAL_REGIONS` is a back-compat re-export.
+
+### Sex inference
+
+`doc/sex.rst` is the source of truth for the math (ratio-of-residuals
+maleness ratios + AND-gate, VCF heterozygous-SNP confirmer, target /
+antitarget reconciliation in `do_reference`). The rules below are
+project invariants that, if broken, silently regress the design
+without breaking tests:
+
+- **`verify_sample_sex` is the canonical resolver.** Don't reinvent
+  `is_female_default(guess_xx(...))` inline; route through it so user
+  `--sample-sex` and the VCF het-density confirmer both apply.
+- **Honest `None` propagates on inference paths**; concrete `bool` only
+  at decision consumers via `is_female_default`. `do_reference`'s
+  target/antitarget reconciliation needs the honest `None` to work.
+- **Reporting commands stay honest**: `do_sex` reports `Unknown` for an
+  undeterminable sample; don't collapse `None` → `Female` at the report
+  layer.
+- **VCF het confirmer is one-way (male → female only).** Absent chrX
+  hets is non-evidence — true haploid X and "too few SNPs" are
+  indistinguishable.
+- Do NOT re-introduce a chi-square or multiplicative `combined_score`
+  on top of the median; the median is already the robust quantity, and
+  wrapping it in a chi-square brought sample-size dependence that
+  produced `.cnr` vs `.cns` inconsistency (#785).
 
 ### File Formats
 - `.cnn` - Coverage/reference data


### PR DESCRIPTION
Following the cnvkit-3n3 epic close, CLAUDE.md had accreted parallel
copies of content that now lives more authoritatively in doc/*.rst:

* **doc/sex.rst** (rewritten in 3n3.6) now has the full algorithm
  exposition for sex inference (ratio-of-residuals, AND-gate, VCF
  heterozygous-SNP confirmer, target/antitarget reconciliation).
  CLAUDE.md was carrying a parallel paragraph + 8-bullet copy of the
  math.
* **doc/development.rst** (recent, comprehensive) covers conda setup,
  pre-commit hooks, code style, testing matrix, PR process, Docker
  releases — and explicitly cross-references CLAUDE.md as its
  complement. CLAUDE.md was carrying a parallel ~55-line copy of the
  same operating instructions.

## What this PR changes

Two focused commits, each trimming one CLAUDE.md surface:

### Commit 1: `Sex inference` + `Chromosome-name handling`

* **Sex inference**: dropped the textbook math; kept the five
  invariants an AI session can violate silently (canonical resolver,
  honest `None` vs. concrete `bool`, reporting-vs-deciding seam,
  one-way VCF confirmer, do-not-chi-square). Pointer at the top to
  `doc/sex.rst`. Net: the section is *slightly* longer because three
  newly-captured rules from 3n3.4/3n3.6 (the seam, the resolver, the
  one-way override) are now in CLAUDE.md where they belong, while the
  algorithm exposition moved out.
* **Chromosome-name handling**: kept the hard rule (route through
  ``skgenome.chromnames``, no inline regexes) + the API points
  callers need to know (`None` handling, `autosomes()` fallback, PAR
  coordinate location). Pointer to `doc/sex.rst` "Non-human and
  Roman-numeral genomes" for the user-facing behavior.

### Commit 2: `Development Commands`

* Replaced the conda-setup / pytest / pre-commit / make-lint
  invocations (all duplicated in `doc/development.rst`) with a pointer
  to that file.
* **Kept**: the `conda run is unreliable` quirk (a genuine
  AI-session footgun, not in the dev guide), the
  `enable_error_code = ["ignore-without-code"]` requirement, and the
  common type-ignore patterns mypy flags most often in this
  codebase.

## Net effect

CLAUDE.md goes from 148 → 153 lines, but content distribution sharply
improves: invariants + AI-specific footguns here, textbook + operating
instructions in `doc/`. Cross-pointers in both directions keep readers
on the right surface.

## Verification

* Pre-commit clean on `CLAUDE.md`.
* No code changes — pure documentation distribution.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)