### PR TITLE
rna: guard weight normalization against zero-spread cohorts

### DIFF
--- a/cnvlib/rna.py
+++ b/cnvlib/rna.py
@@ -393,9 +393,20 @@ def align_gene_info_to_samples(gene_info, sample_counts, tx_lengths, normal_ids)
         weights.append(np.vstack(corr_weights).mean(axis=0))
 
     weight = gmean(np.vstack(weights), axis=0)
-    gi["weight"] = weight / weight.max()
-    if gi["weight"].isna().all():
+    # Guard against degenerate cohorts: if every per-gene weight collapses to
+    # zero (e.g. zero cross-sample spread from uniform counts -> gmean is 0)
+    # or any NaN leaks into the weights (numpy's .max() does NOT skip NaN),
+    # ``weight / weight.max()`` would emit a RuntimeWarning and produce NaN.
+    # Fall back to uniform weights instead.
+    max_weight = weight.max()
+    if not np.isfinite(max_weight) or max_weight <= 0:
+        logging.warning(
+            "Per-gene weights are degenerate (max=%s); using uniform weights",
+            max_weight,
+        )
         gi["weight"] = 1.0
+    else:
+        gi["weight"] = weight / max_weight
     logging.debug(" --> final zeros: %d / %d", (gi["weight"] == 0).sum(), len(gi))
     return gi, sc, sample_depths_log2
 

--- a/test/test_rna.py
+++ b/test/test_rna.py
@@ -3,6 +3,7 @@
 
 import logging
 import unittest
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -123,6 +124,41 @@ class RNAImportTests(unittest.TestCase):
 
         error_msg = str(cm.exception)
         self.assertIn("All genes have invalid transcript lengths", error_msg)
+
+    def test_align_gene_info_zero_spread_cohort(self):
+        """Degenerate cohort (uniform counts across samples) yields uniform weights without a RuntimeWarning.
+
+        Regression for the divide-by-zero at ``weight / weight.max()``: when every
+        sample has identical counts, ``gene_spreads = std(axis=1)`` collapses to
+        zero, so ``gmean(weights)`` is all-zero and ``weight.max() == 0`` would
+        produce ``0 / 0`` → NaN with ``RuntimeWarning: invalid value encountered
+        in divide``. The guard must short-circuit to uniform 1.0 weights.
+        """
+        uniform_counts = pd.DataFrame(
+            {
+                "sample1": [100, 200, 50, 150, 75],
+                "sample2": [100, 200, 50, 150, 75],
+                "sample3": [100, 200, 50, 150, 75],
+            },
+            index=[
+                "ENSG00000001",
+                "ENSG00000002",
+                "ENSG00000003",
+                "ENSG00000004",
+                "ENSG00000005",
+            ],
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            result_gi, _result_sc, _result_log2 = rna.align_gene_info_to_samples(
+                self.gene_info, uniform_counts, self.tx_lengths, normal_ids=[]
+            )
+
+        # No NaN weights, and the degenerate case falls back to uniform 1.0.
+        self.assertFalse(result_gi["weight"].isna().any())
+        self.assertTrue(np.isfinite(result_gi["weight"]).all())
+        self.assertTrue((result_gi["weight"] == 1.0).all())
 
     def test_normalize_read_depths_empty(self):
         """Test error when sample depths are empty."""


### PR DESCRIPTION
## Summary

`align_gene_info_to_samples()` in `cnvlib/rna.py` emitted `RuntimeWarning: invalid value encountered in divide` and produced NaN per-gene weights when a cohort had zero cross-sample spread (e.g. uniform counts across all samples). Surfaced while building the `import-rna` integration fixtures.

## Root cause

At `cnvlib/rna.py:395-396`:

```python
weight = gmean(np.vstack(weights), axis=0)
gi["weight"] = weight / weight.max()
```

When samples have identical counts, `gene_spreads = sample_depths_log2.std(axis=1)` is identically `0`, so `gmean([positive_component, 0]) = 0` for every gene → `weight` is all-zero → `0 / 0` → `RuntimeWarning` + NaN. The existing `if gi["weight"].isna().all(): gi["weight"] = 1.0` fallback only fired *after* the warning leaked and only when *every* value was NaN.

## Fix

Replace the bare divide with a single guard:

```python
max_weight = weight.max()
if not np.isfinite(max_weight) or max_weight <= 0:
    logging.warning("Per-gene weights are degenerate (max=%s); using uniform weights", max_weight)
    gi["weight"] = 1.0
else:
    gi["weight"] = weight / max_weight
```

`np.isfinite(max_weight) and max_weight > 0` catches:
- All-zero weights (the reported bug)
- All-NaN or partial-NaN weights — `numpy.ndarray.max()` does **not** skip NaN (unlike pandas), so any NaN in `weight` makes `max_weight == NaN` and the guard fires
- `±inf` contamination

On healthy cohorts (`max_weight > 0` finite), behavior is unchanged.

## Test

`test_align_gene_info_zero_spread_cohort` feeds uniform-count input through `align_gene_info_to_samples` under `warnings.simplefilter("error", RuntimeWarning)` and asserts the returned weights are finite, non-NaN, and uniform 1.0. Fails on master at exactly `rna.py:396`; passes after the fix.

## Clinical-impact note

No change to numerical output on non-degenerate cohorts — the division runs unchanged when `max_weight > 0`. Behavior change is limited to:

- **All-NaN weights**: same end-state (uniform 1.0), but reached without the spurious warning.
- **Partial-NaN weights**: previously slipped through as NaN; now uniform 1.0. A single NaN making the whole normalization NaN was already broken — uniform-on-any-contamination is more defensible for downstream `.cnr`/`.cns` math.
- **All-zero weights (zero-spread cohort)**: previously NaN-then-recovered-to-1.0 after the warning; now uniform 1.0 directly. End result identical.

No `.cnr`/`.cns`/`.cnn`/SEG/VCF format change.

## Verification

- `python -m pytest test/test_rna.py -v` → 11/11 pass
- `python -m pytest test/` → 398 passed, 45 subtests passed
- `ruff check` / `ruff format --check` / `mypy cnvlib/rna.py` → clean

Closes `bd cnvkit-frk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)