### PR TITLE
segmentation: defend savgol path against non-finite log2 and lstsq LinAlgError (#508)

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -229,17 +229,21 @@ def _do_segmentation(
         return cnarr
 
     filtered_cn = cnarr.copy()
-    # Drop bins with no log2 value before any analysis (#881). They carry no
-    # signal and cannot be segmented, but a bare comparison treats NaN as False,
-    # so without this they survive the gates below and reach either the
-    # Savitzky-Golay outlier filter (scipy's lstsq rejects non-finite input) or
-    # DNAcopy's CBS -- both of which then crash. read_tab drops them on the file
-    # path; do it here too for the in-memory/API path (e.g. batch).
-    log2_missing = filtered_cn["log2"].isna()
-    n_log2_missing = int(log2_missing.sum())
-    if n_log2_missing:
-        filtered_cn = filtered_cn[~log2_missing]
-        logging.info("Dropped %d bins with missing log2 values", n_log2_missing)
+    # Drop bins with non-finite log2 (NaN or +/-inf) before any analysis
+    # (#881, gh#508). They carry no signal and cannot be segmented, but a
+    # bare comparison treats NaN as False, so without this they survive the
+    # gates below and reach either the Savitzky-Golay outlier filter (scipy's
+    # lstsq rejects non-finite input with "array must not contain infs or
+    # NaNs") or DNAcopy's CBS -- both of which then crash. ``.isna()`` only
+    # catches NaN; broadening to ``~np.isfinite`` covers the flat-reference
+    # WGS path of gh#508 where degenerate reference subtraction can yield
+    # +/-inf. read_tab drops them on the file path; do it here too for the
+    # in-memory/API path (e.g. batch).
+    log2_bad = ~np.isfinite(filtered_cn["log2"])
+    n_log2_bad = int(log2_bad.sum())
+    if n_log2_bad:
+        filtered_cn = filtered_cn[~log2_bad]
+        logging.info("Dropped %d bins with non-finite log2 values", n_log2_bad)
     # Filter out bins with no or near-zero sequencing coverage
     if skip_low:
         filtered_cn = filtered_cn.drop_low_coverage(verbose=False)

--- a/cnvlib/smoothing.py
+++ b/cnvlib/smoothing.py
@@ -238,7 +238,23 @@ def savgol(
     if weights is None:
         y = signal
         for _i in range(n_iter):
-            y = savgol_filter(y, window_width, order, mode="interp")
+            try:
+                y = savgol_filter(y, window_width, order, mode="interp")
+            except np.linalg.LinAlgError as exc:
+                # mode='interp' uses np.polyfit at the array edges; lstsq can
+                # fail on numerically degenerate inputs (gh#508: WGS
+                # flat-reference data triggered an MKL DGELSD error -- and
+                # the non-MKL path raised "SVD did not converge in Linear
+                # Least Squares" -- on the edge polyfit). Fall back to
+                # mode='nearest', which extends the boundary value instead
+                # of polyfitting it, so the smoother degrades gracefully
+                # instead of crashing the whole segmentation run.
+                logging.warning(
+                    "Savitzky-Golay edge polyfit failed (%s); "
+                    "falling back to mode='nearest'",
+                    exc,
+                )
+                y = savgol_filter(y, window_width, order, mode="nearest")
         # y = convolve_unweighted(window, signal, wing)
     else:
         # TODO fit edges here, too

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -439,6 +439,43 @@ class TestSavgol:
         result = savgol(x, total_width=width)
         assert np.allclose(result, c, atol=1e-6)
 
+    def test_linalg_error_falls_back_to_nearest(self, monkeypatch):
+        """Savgol recovers when scipy's edge polyfit raises LinAlgError (gh#508).
+
+        scipy's ``savgol_filter(mode='interp')`` invokes ``np.polyfit`` at
+        the array edges; on numerically degenerate inputs ``lstsq`` can raise
+        ``LinAlgError: SVD did not converge`` (and MKL prints the
+        ``Parameter 6 was incorrect on entry to DGELSD`` message that
+        originally surfaced gh#508 on WGS flat-reference data). The wrapper
+        must catch the error and retry with a non-polyfit mode rather than
+        let it propagate up through ``do_segmentation`` and crash the run.
+        """
+        import cnvlib.smoothing as smoothing_mod
+
+        real_savgol_filter = smoothing_mod.savgol_filter
+        calls = {"interp": 0, "fallback": 0}
+
+        def flaky_savgol_filter(*args, **kwargs):
+            mode = kwargs.get("mode", "interp")
+            if mode == "interp":
+                calls["interp"] += 1
+                raise np.linalg.LinAlgError(
+                    "SVD did not converge in Linear Least Squares"
+                )
+            calls["fallback"] += 1
+            return real_savgol_filter(*args, **kwargs)
+
+        monkeypatch.setattr(smoothing_mod, "savgol_filter", flaky_savgol_filter)
+
+        rng = np.random.default_rng(0)
+        x = np.linspace(-1.0, 1.0, 60) + rng.normal(0, 0.1, 60)
+        result = savgol(x, total_width=11)
+
+        assert len(result) == len(x)
+        assert np.isfinite(result).all()
+        assert calls["interp"] >= 1, "Interp path should have been attempted"
+        assert calls["fallback"] >= 1, "Fallback (non-polyfit) path should have run"
+
 
 # ---------------------------------------------------------------------------
 # Tests: cnvlib/call.py (pure arithmetic helpers)

--- a/test/test_segmentation.py
+++ b/test/test_segmentation.py
@@ -428,3 +428,38 @@ class TransferFieldsTests(unittest.TestCase):
         cns = segmentation.do_segmentation(cnarr, "haar", processes=1)
         self.assertGreater(len(cns), 0)
         self.assertFalse(np.isnan(cns["log2"].to_numpy()).any())
+
+    def test_do_segmentation_drops_inf_log2(self):
+        """do_segmentation tolerates ±inf-log2 bins (gh#508, sibling to #881).
+
+        The #881 fix dropped NaN-log2 bins before drop_outliers' Savitzky-Golay
+        smoother because scipy's lstsq rejects non-finite input ("array must
+        not contain infs or NaNs"). But pandas ``.isna()`` does NOT catch
+        ±inf, so degenerate flat-reference WGS data (gh#508) -- where some
+        bins can land at ±inf after reference subtraction -- still crashed
+        on the same path. Broadening the prefilter from ``.isna()`` to
+        ``~np.isfinite`` covers both.
+        """
+        n = 120  # > drop_outliers' width (50) so savgol actually runs
+        rng = np.random.default_rng(0)
+        log2 = rng.normal(0, 0.2, n)
+        log2[5] = np.inf  # inside the leading savgol edge window
+        log2[60] = -np.inf
+        log2[80] = np.nan  # confirm NaN is still handled alongside ±inf
+        cnarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * n,
+                    "start": np.arange(0, n * 1000, 1000),
+                    "end": np.arange(1000, n * 1000 + 1000, 1000),
+                    "gene": ["G"] * n,
+                    "log2": log2,
+                    "depth": np.ones(n) * 100.0,
+                    "weight": np.ones(n),
+                }
+            )
+        )
+        # Must not raise, and the segment log2 must be finite (no inf/nan leaks).
+        cns = segmentation.do_segmentation(cnarr, "haar", processes=1)
+        self.assertGreater(len(cns), 0)
+        self.assertTrue(np.isfinite(cns["log2"].to_numpy()).all())


### PR DESCRIPTION
## Summary

[Issue #508](https://github.com/etal/cnvkit/issues/508) reports CNVkit crashing on a flat-reference WGS run (C. elegans) with:

> Intel MKL ERROR: Parameter 6 was incorrect on entry to DGELSD.
> numpy.linalg.LinAlgError: SVD did not converge in Linear Least Squares

The traceback lands inside scipy's `savgol_filter(mode='interp')` → `_fit_edge` → `np.polyfit` → `lstsq`, called from `drop_outliers` in `_do_segmentation`. The `nomkl` workaround that issue commenters found just changes which LAPACK implementation shouts — it doesn't fix the underlying fragility.

## Root cause

Two distinct paths into the same failure exist for this code path:

1. **Non-finite input** (`±inf` log2): scipy raises `ValueError: array must not contain infs or NaNs` *before* polyfit is even invoked. The existing #881 prefilter (`filtered_cn["log2"].isna()`) catches `NaN` but `pd.Series.isna()` does **not** catch `±inf`, so degenerate flat-reference data where reference subtraction yields `±inf` used to slip past it.
2. **Numerically degenerate finite input**: `polyfit`'s underlying `lstsq` can raise `LinAlgError: SVD did not converge` on certain MKL/LAPACK combos with pathological log2 distributions at segment edges. This is what #508 actually reports.

## Fix

Two complementary defenses:

### 1. Widen the `_do_segmentation` prefilter (`cnvlib/segmentation/__init__.py`)

```diff
- log2_missing = filtered_cn["log2"].isna()
- n_log2_missing = int(log2_missing.sum())
- if n_log2_missing:
-     filtered_cn = filtered_cn[~log2_missing]
-     logging.info("Dropped %d bins with missing log2 values", n_log2_missing)
+ log2_bad = ~np.isfinite(filtered_cn["log2"])
+ n_log2_bad = int(log2_bad.sum())
+ if n_log2_bad:
+     filtered_cn = filtered_cn[~log2_bad]
+     logging.info("Dropped %d bins with non-finite log2 values", n_log2_bad)
```

`~np.isfinite` covers `NaN`, `+inf`, and `-inf` in one expression.

### 2. Catch `LinAlgError` in `cnvlib.smoothing.savgol` (`cnvlib/smoothing.py`)

```diff
  for _i in range(n_iter):
-     y = savgol_filter(y, window_width, order, mode="interp")
+     try:
+         y = savgol_filter(y, window_width, order, mode="interp")
+     except np.linalg.LinAlgError as exc:
+         logging.warning(
+             "Savitzky-Golay edge polyfit failed (%s); "
+             "falling back to mode='nearest'", exc,
+         )
+         y = savgol_filter(y, window_width, order, mode="nearest")
```

`mode='nearest'` extends the boundary value (constant extrapolation), so no polyfit, no LAPACK call, no LinAlgError. Per-iteration scope means later iterations still attempt the more accurate `interp` path first.

## Tests

- `test_do_segmentation_drops_inf_log2` — companion to existing `test_do_segmentation_drops_nan_log2` (#881). Seeds `+inf`, `-inf`, and `NaN` into a CNA with n=120 (> `drop_outliers` width=50 so savgol actually runs); asserts no crash and finite segment log2. Fails on master with `ValueError: array must not contain infs or NaNs`.
- `test_linalg_error_falls_back_to_nearest` — monkey-patches `cnvlib.smoothing.savgol_filter` to raise `LinAlgError` on `mode='interp'` calls; verifies `savgol` returns a finite same-length result and that the fallback was actually used. Fails on master with the injected `LinAlgError`.

## Clinical-impact note

No change to numerical output on healthy inputs:
- Defense 1 only drops bins that *currently* crash segmentation; non-finite bins were never producing usable output.
- Defense 2 only activates on `LinAlgError`, which currently propagates as a crash. Behavior changes from "crash the run" to "use nearest-mode edge handling" for the affected smoothing iteration.

No `.cnr` / `.cns` / `.cnn` / SEG / VCF format change.

## Verification

- `pytest test/` → 400 passed, 45 subtests passed
- `ruff check` / `ruff format --check` / `mypy cnvlib/segmentation/__init__.py cnvlib/smoothing.py` → clean

## Out of scope

The `kaiser` smoother's `_fit_edges` (`cnvlib/smoothing.py:262`) also calls `np.polyfit` directly and is theoretically vulnerable to the same `LinAlgError`. It's not on the #508 traceback so I've left it alone — fix-the-reported-bug discipline. If `kaiser` ever hits it, that's a separate PR.

Fixes #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)