### PR TITLE
rna: document --normal cohort-design caveats; warn on small normal set

### DIFF
--- a/cnvlib/import_rna.py
+++ b/cnvlib/import_rna.py
@@ -79,6 +79,23 @@ def do_import_rna(
 
     logging.info("Aligning gene info to sample gene counts")
     normal_ids = [os.path.basename(f).split(".")[0] for f in normal_fnames]
+    if 0 < len(normal_ids) < 3:
+        # The normal-anchoring step in normalize_read_depths divides each gene's
+        # row by the median across normal samples. With fewer than three normals
+        # that median is a high-variance per-gene estimator, and in the single-
+        # normal case it reduces to a self-divide that drives the normal
+        # sample's own log2 .cnr to ~0 everywhere by construction. See
+        # doc/rna.rst "Considerations" for the recommended cohort design.
+        logging.warning(
+            "import-rna --normal: %d normal sample(s) provided. "
+            "With fewer than 3 normals, the per-gene normal-median used as the "
+            "anchor is a noisy estimator, and with exactly 1 normal the "
+            "anchored value is a tautological self-divide -- the normal "
+            "sample's .cnr will be ~0 everywhere by construction and cannot "
+            "be used for QC of that normal. Provide >=3 normals for robust "
+            "anchoring; see doc/rna.rst.",
+            len(normal_ids),
+        )
     gene_info, sample_counts, sample_data_log2 = rna.align_gene_info_to_samples(
         gene_info, sample_counts, tx_lengths, normal_ids
     )

--- a/doc/rna.rst
+++ b/doc/rna.rst
@@ -84,3 +84,51 @@ Considerations
   per-gene and per-sample copy number and expression levels, typically retrieved
   from cBioPortal for TCGA cancer-specific cohorts.
 
+
+Using ``--normal`` to anchor against control samples
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``-n``/``--normal`` option accepts one or more count files representing
+process-matched control (non-neoplastic) samples. When provided, the
+normalization pipeline first applies a cohort-wide median polish to remove
+per-sample sequencing-depth differences and per-gene scale differences, then
+divides each gene's row by the median of the normal samples' values. Tumor
+sample ``.cnr`` files are then expressed as log2 ratios against that
+normal-anchored baseline.
+
+This recentering has several important consequences that affect cohort design:
+
+- **A single normal yields a non-informative ``.cnr`` for that sample.** With
+  one normal, the per-gene "normal median" is just that sample's own value, so
+  the anchoring step is a self-divide and the normal's output is approximately
+  zero at every gene by construction. The normal's ``.cnr`` cannot be used to
+  detect mislabelling, contamination, or copy-number events affecting the
+  normal sample itself. ``import-rna`` emits a ``logging.warning`` in this
+  case.
+- **Two normals are still fragile.** A median over two values reduces to the
+  arithmetic mean and remains a high-variance per-gene estimator. The output
+  for each normal then represents that sample's deviation from the other
+  normal, not a deviation from a stable biological baseline. ``import-rna``
+  also warns in this case.
+- **Three or more normals are recommended.** With ``n_normal >= 3``, the
+  per-gene median is a robust estimator and individual normal ``.cnr`` files
+  retain interpretable residuals (deviation from peer normals) usable for QC.
+- **Cohort composition affects intermediate values.** The cohort-wide polish
+  step uses the median across all samples in the cohort, so running the same
+  ``--normal X`` on two different tumor cohorts produces different intermediate
+  reference values. The final tumor log2 ratios are largely insensitive to
+  this for typical cohorts, but extreme cohort imbalance (for example, a small
+  number of tumors with shared, large-scale alterations) can perturb calls.
+- **Control samples must themselves be free of the alterations under study.**
+  Adjacent-tissue normals in solid-tumor settings frequently carry
+  tumor-derived expression patterns (stromal contamination, field effects).
+  When the normal cohort shares the same alterations as the tumors, the
+  normal-anchored divide cancels real tumor signal and reduces the dynamic
+  range of the resulting calls. Pure tissue-matched controls from independent
+  donors are preferred when available.
+
+If a suitable normal cohort is not available, run ``import-rna`` without
+``--normal``. The output ``.cnr`` files will then be expressed as log2 ratios
+against the cohort median, which carries its own assumption (that most genes
+in most samples are copy-neutral) that may also be violated in heavily altered
+cohorts.

--- a/test/test_rna.py
+++ b/test/test_rna.py
@@ -2,6 +2,8 @@
 """Unit tests for RNA import functionality (cnvlib.rna)."""
 
 import logging
+import os
+import tempfile
 import unittest
 import warnings
 
@@ -301,6 +303,127 @@ class ImportRnaIntegrationTests(unittest.TestCase):
     def test_do_import_rna_unknown_format_raises(self):
         with self.assertRaises(RuntimeError):
             import_rna.do_import_rna(self.COUNT_FILES[:1], "bogus", self.GENE_RESOURCE)
+
+
+class NormalizeReadDepthsNormalAnchorTests(unittest.TestCase):
+    """Pin the current --normal anchoring invariants surfaced in cnvkit-ccy.
+
+    These tests document what ``normalize_read_depths`` does *today* with
+    ``normal_ids`` set, as a regression baseline for any future redesign
+    (tracked in cnvkit-9wj). They exercise the suspected bug from GH #352
+    and confirm it does not reproduce at the unit level: the issue lies in
+    the design (small-normal-cohort information loss) rather than a numerical
+    error in the implementation.
+    """
+
+    @staticmethod
+    def _make_cohort(
+        n_tumor, n_normal, n_genes, altered_mask, tumor_alt_factor=2.0, seed=0
+    ):
+        rng = np.random.default_rng(seed)
+        baseline = rng.lognormal(mean=4.0, sigma=1.0, size=n_genes)
+        cols = {}
+        normal_ids = []
+        for i in range(n_normal):
+            sid = f"normal{i}"
+            normal_ids.append(sid)
+            cols[sid] = baseline * rng.lognormal(0, 0.05, n_genes)
+        for i in range(n_tumor):
+            v = baseline.copy()
+            v[altered_mask] *= tumor_alt_factor
+            cols[f"tumor{i}"] = v * rng.lognormal(0, 0.05, n_genes)
+        return (pd.DataFrame(cols, index=[f"g{i}" for i in range(n_genes)]), normal_ids)
+
+    def test_single_normal_is_self_divide(self):
+        """One normal => that normal's log2 is ~0 at every gene by construction.
+
+        With one normal sample, the per-gene "median of normals" reduces to
+        that single column, so the anchor divide is a self-divide. The normal
+        sample's resulting log2 row collapses to ``safe_log2(1.0)`` = a small
+        positive offset from the NULL_LOG2_COVERAGE shift, with vanishing
+        per-gene variance. This is the design behavior to pin until the
+        cnvkit-9wj redesign lands.
+        """
+        n_genes = 200
+        altered = np.zeros(n_genes, dtype=bool)
+        altered[:50] = True
+        depths, normal_ids = self._make_cohort(10, 1, n_genes, altered, seed=1)
+        log2 = rna.normalize_read_depths(depths.copy(), normal_ids)
+
+        normal_log2 = log2[normal_ids[0]]
+        # All values are within numerical noise of the safe_log2 floor offset.
+        expected_offset = np.log2(1.0 + 2**rna.NULL_LOG2_COVERAGE)
+        self.assertLess(abs(normal_log2.median() - expected_offset), 1e-3)
+        self.assertLess(normal_log2.std(), 1e-3)
+        # And the chrX-altered region in tumors is recovered at ~+1.0 (2x gain)
+        tumor_cols = [c for c in log2.columns if c.startswith("tumor")]
+        tumor_alt_med = log2[tumor_cols].loc[altered].median().median()
+        self.assertGreater(tumor_alt_med, 0.8)
+        self.assertLess(tumor_alt_med, 1.2)
+
+    def test_multi_normal_carries_residual_qc_signal(self):
+        """With >= 3 normals, individual normals' .cnr files retain non-zero spread.
+
+        This documents the design rationale for the >=3-normals recommendation:
+        the median-of-normals anchor leaves each normal with residual deviation
+        from peer normals (interpretable as QC signal), rather than collapsing
+        to a tautological zero.
+        """
+        n_genes = 200
+        altered = np.zeros(n_genes, dtype=bool)
+        altered[:50] = True
+        depths, normal_ids = self._make_cohort(10, 3, n_genes, altered, seed=2)
+        log2 = rna.normalize_read_depths(depths.copy(), normal_ids)
+
+        # Each normal retains a non-degenerate spread across genes; not flat-zero.
+        for nid in normal_ids:
+            self.assertGreater(log2[nid].std(), 1e-3)
+
+    def test_import_rna_warns_for_few_normals(self):
+        """do_import_rna emits a warning for 0 < n_normals < 3."""
+        with tempfile.TemporaryDirectory() as tmp:
+            gene_res = os.path.join(tmp, "genes.tsv")
+            rng = np.random.default_rng(7)
+            n_genes = 80
+            gene_ids = [f"ENSG{i:05d}.1" for i in range(n_genes)]
+            with open(gene_res, "w") as fh:
+                fh.write("# fixture\n")
+                fh.write(
+                    "Gene stable ID\tGC\tChr\tStart\tEnd\tName\tNCBI\tTxLen\tTSL\n"
+                )
+                for i, g in enumerate(gene_ids):
+                    fh.write(
+                        f"{g}\t{int(rng.integers(30, 65))}\t1\t"
+                        f"{100000 + i * 5000}\t{102000 + i * 5000}\t"
+                        f"G{i}\t{1000 + i}\t1500\ttsl1\n"
+                    )
+            baseline = rng.lognormal(mean=5.0, sigma=1.0, size=n_genes)
+            fnames = []
+            normal_fnames = []
+            # 1 normal + 5 tumors -> should warn
+            for tag, is_normal in [("normal-0", True)] + [
+                (f"tumor-{i}", False) for i in range(5)
+            ]:
+                vals = baseline * rng.lognormal(0, 0.1, n_genes)
+                f = os.path.join(tmp, f"{tag}.counts.txt")
+                with open(f, "w") as fh:
+                    for g, v in zip(gene_ids, vals, strict=True):
+                        fh.write(f"{g}\t{int(v)}\n")
+                fnames.append(f)
+                if is_normal:
+                    normal_fnames.append(f)
+
+            with self.assertLogs(level="WARNING") as cm:
+                _, cnrs = import_rna.do_import_rna(
+                    fnames,
+                    "counts",
+                    gene_res,
+                    normal_fnames=normal_fnames,
+                )
+                list(cnrs)  # exhaust generator so all logging fires
+            joined = "\n".join(cm.output)
+            self.assertIn("import-rna --normal", joined)
+            self.assertIn("3 normals", joined)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Verify-FIRST investigation of GH #352 (bead cnvkit-ccy): the symptom (normal sample not centered on heatmap; dynamic-range compression) does NOT reproduce against the current code at either the `normalize_read_depths` unit level or the full `do_import_rna` pipeline.
- The current `--normal` math composes to `tumor / normal` per gene; with a single normal it reduces to a tautological self-divide that drives the normal's own `.cnr` to `log2 ~ 0` at every gene by construction.
- Mathematically self-consistent, but a real cohort-design weakness: single-normal cohorts give no QC signal on the normal sample itself, and `n_normals < 3` uses a noisy per-gene median as the anchor.
- Adds a runtime warning + a doc section explaining the design, the single-normal degeneracy, the recommendation to use ≥3 normals, and the contaminated-normals failure mode (likely root cause of the original 2018 dynamic-range complaint).
- Pins the current invariants in `test/test_rna.py` as a regression baseline for the deeper redesign (DESeq2-style size factors + LOO) tracked separately in bead cnvkit-9wj.

**Clinical impact:** no changes to numerical output of `.cnr` files. The warning is purely informational; existing pipelines are unaffected.

## Test plan

- [x] `pytest test/test_rna.py` — 14/14 pass, including 3 new tests:
  - `test_single_normal_is_self_divide` (pins the current invariant)
  - `test_multi_normal_carries_residual_qc_signal` (documents the ≥3-normals rationale)
  - `test_import_rna_warns_for_few_normals` (asserts the warning fires)
- [x] Full test suite — 412/412 pass
- [x] `ruff check` — clean on changed files
- [x] `mypy cnvlib/import_rna.py` — clean
- [x] Pre-commit hooks — pass

## References

- Bead cnvkit-ccy (verify-FIRST disposition, this PR)
- Bead cnvkit-9wj (follow-up: deeper redesign — DESeq2-style size factors + LOO anchoring for normals' own `.cnr` files)
- GH #352 (2018 user report; to be closed with a pointer to `doc/rna.rst` and this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)