### PR TITLE
scatter: surface LOH and somatic SNV evidence as colored overlays (#290)

### DIFF
--- a/cnvlib/cmdutil.py
+++ b/cnvlib/cmdutil.py
@@ -46,6 +46,31 @@ def read_ga(
     return tabio.read(infile, into=GA, sample_id=sample_id, meta=meta)  # type: ignore[return-value]
 
 
+def _resolve_zygosity_freq(
+    germline_varr: VariantArray, zygosity_freq: float | None, *, warn: bool
+) -> float | None:
+    """Apply the Mutect2 all-zero-normal workaround heuristic.
+
+    When the VCF's normal-sample genotypes are all 0/0 or missing (Mutect2
+    quirk), infer zygosity from allele frequency by setting ``zygosity_freq``
+    to 0.25. Caller must pass the germline subset only (e.g. ``varr`` from a
+    ``skip_somatic=True`` read), so that the all-zero check reflects the
+    germline rows and is not masked by interleaved somatic calls.
+    """
+    if (
+        zygosity_freq is None
+        and "n_zygosity" in germline_varr
+        and not germline_varr["n_zygosity"].any()
+    ):
+        if warn:
+            logging.warning(
+                "VCF normal sample's genotypes are all 0/0 or missing; "
+                "inferring genotypes from allele frequency instead"
+            )
+        return 0.25
+    return zygosity_freq
+
+
 def load_het_snps(
     vcf_fname: str,
     sample_id: str | None = None,
@@ -64,13 +89,7 @@ def load_het_snps(
         min_depth=min_variant_depth,
         skip_somatic=True,
     )
-    if zygosity_freq is None and "n_zygosity" in varr and not varr["n_zygosity"].any():
-        # Mutect2 sets all normal genotypes to 0/0 -- work around it
-        logging.warning(
-            "VCF normal sample's genotypes are all 0/0 or missing; "
-            "inferring genotypes from allele frequency instead"
-        )
-        zygosity_freq = 0.25
+    zygosity_freq = _resolve_zygosity_freq(varr, zygosity_freq, warn=True)  # type: ignore[arg-type]
     if zygosity_freq is not None:
         varr = varr.zygosity_from_freq(zygosity_freq, 1 - zygosity_freq)  # type: ignore[attr-defined]
     if "n_zygosity" in varr:
@@ -121,6 +140,106 @@ def load_het_snps(
     varr.meta["chrx_snp_total"] = n_chrx_total
     varr.meta["chrx_het_count"] = n_chrx_het
     return varr  # type: ignore[no-any-return]
+
+
+def _partition_snp_extras(
+    varr: VariantArray,
+    *,
+    include_loh: bool,
+    include_somatic: bool,
+) -> tuple[VariantArray | None, VariantArray | None]:
+    """Split a VariantArray into LOH-evidence and somatic-SNV subsets.
+
+    ``varr`` should be the full record set as returned by ``tabio.read`` with
+    ``skip_somatic=False`` (post-zygosity_freq inference if applicable). The
+    function does not modify ``varr``.
+
+    LOH evidence = tumor-homozygous loci excluding any somatic call. When a
+    matched normal column (``n_zygosity``) is present, additionally restrict
+    to normal-heterozygous loci (the stricter, T/N-aware definition). In
+    tumor-only flows the column is absent and any tumor-homozygous locus
+    qualifies; this is the same convention as the 2017 #290 request, which
+    treated tumor-homozygous SNVs as LOH evidence in tumor-only mode.
+
+    Somatic = the union of (a) the VCF ``SOMATIC`` flag and (b) T/N-inferred
+    somatic loci (tumor-het with normal-homref), matching the loci that
+    ``load_het_snps`` excludes when building the heterozygous subset.
+    """
+    if not (include_loh or include_somatic):
+        return None, None
+    vcf_somatic = varr["somatic"]
+    if "n_zygosity" in varr:
+        tn_somatic = (varr["zygosity"] != 0.0) & (varr["n_zygosity"] == 0.0)
+        all_somatic = vcf_somatic | tn_somatic
+    else:
+        all_somatic = vcf_somatic
+    loh: VariantArray | None = None
+    if include_loh:
+        non_somatic = varr[~all_somatic]
+        tumor_hom = (non_somatic["zygosity"] == 0.0) | (non_somatic["zygosity"] == 1.0)
+        if "n_zygosity" in non_somatic:
+            loh_mask = tumor_hom & (non_somatic["n_zygosity"] == 0.5)
+        else:
+            loh_mask = tumor_hom
+        loh = non_somatic[loh_mask]
+    somatic: VariantArray | None = None
+    if include_somatic:
+        somatic = varr[all_somatic]
+    return loh, somatic
+
+
+def load_snp_subsets(
+    vcf_fname: str,
+    sample_id: str | None = None,
+    normal_id: str | None = None,
+    min_variant_depth: int = 20,
+    zygosity_freq: float | None = None,
+    *,
+    include_loh: bool = False,
+    include_somatic: bool = False,
+) -> tuple[VariantArray, VariantArray | None, VariantArray | None]:
+    """Load heterozygous SNPs plus optional LOH-evidence and somatic subsets.
+
+    The ``het`` subset is identical to ``load_het_snps``'s return -- same BAF
+    distribution, same chrX-counting in ``.meta``, same warnings. The extras
+    are surfaced for display only (e.g. scatter plot ``--show-snvs`` modes,
+    #290) and are excluded from segment-overlay calculations to preserve the
+    BAF math that the het subset drives.
+
+    When both ``include_*`` flags are False, only ``het`` is loaded -- the
+    second VCF read is skipped. The extras are ``None`` in that case.
+    """
+    het = load_het_snps(
+        vcf_fname, sample_id, normal_id, min_variant_depth, zygosity_freq
+    )
+    if not (include_loh or include_somatic):
+        return het, None, None
+    # Re-read the VCF without skip_somatic to recover the SOMATIC-flagged
+    # loci. The chrX-counting and BAF-distribution warnings already fired
+    # during the load_het_snps call, so do not re-emit them here.
+    varr_all = tabio.read(
+        vcf_fname,
+        "vcf",
+        sample_id=sample_id,
+        normal_id=normal_id,
+        min_depth=min_variant_depth,
+        skip_somatic=False,
+    )
+    # Resolve the Mutect2 workaround against the germline subset only --
+    # interleaved somatic rows can mask the all-zero-normal heuristic that
+    # load_het_snps sees, which would leave germline rows with raw all-zero
+    # zygosity here while load_het_snps applied the workaround. Restricting
+    # to ~somatic mirrors load_het_snps's skip_somatic=True input.
+    germline = varr_all[~varr_all["somatic"]]  # type: ignore[index]
+    zygosity_freq = _resolve_zygosity_freq(germline, zygosity_freq, warn=False)  # type: ignore[arg-type]
+    if zygosity_freq is not None:
+        varr_all = varr_all.zygosity_from_freq(zygosity_freq, 1 - zygosity_freq)  # type: ignore[attr-defined]
+    loh, somatic = _partition_snp_extras(
+        varr_all,  # type: ignore[arg-type]
+        include_loh=include_loh,
+        include_somatic=include_somatic,
+    )
+    return het, loh, somatic
 
 
 def _warn_if_baf_input_suspicious(alt_freqs: pd.Series | None) -> None:

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -47,6 +47,7 @@ from . import (
     batch,
     bintest,
     call,
+    cmdutil,
     core,
     coverage,
     diagram,
@@ -1595,13 +1596,33 @@ def _cmd_scatter(args: argparse.Namespace) -> None:
     """Plot probe log2 coverages and segmentation calls together."""
     cnarr = read_cna(args.filename, sample_id=args.sample_id) if args.filename else None
     segarr = read_cna(args.segment, sample_id=args.sample_id) if args.segment else None
-    varr = load_het_snps(
-        args.vcf,
-        args.sample_id,
-        args.normal_id,
-        args.min_variant_depth,
-        args.zygosity_freq,
-    )
+    # --show-snvs selects which SNV subsets to surface. The default ``het``
+    # path goes through load_het_snps so the result is byte-identical to
+    # historical scatter behavior. The other modes load LOH-evidence
+    # (tumor-homozygous) and/or somatic loci as separate overlays (#290).
+    show_snvs = args.show_snvs
+    loh_varr = None
+    som_varr = None
+    if args.vcf and show_snvs != "het":
+        include_loh = show_snvs in ("with-loh", "all")
+        include_somatic = show_snvs in ("with-somatic", "all")
+        varr, loh_varr, som_varr = cmdutil.load_snp_subsets(
+            args.vcf,
+            args.sample_id,
+            args.normal_id,
+            args.min_variant_depth,
+            args.zygosity_freq,
+            include_loh=include_loh,
+            include_somatic=include_somatic,
+        )
+    else:
+        varr = load_het_snps(
+            args.vcf,
+            args.sample_id,
+            args.normal_id,
+            args.min_variant_depth,
+            args.zygosity_freq,
+        )
     scatter_opts = {
         k: v
         for k, v in (
@@ -1613,6 +1634,8 @@ def _cmd_scatter(args: argparse.Namespace) -> None:
             ("fig_size", args.fig_size),
             ("antitarget_marker", args.antitarget_marker),
             ("segment_color", args.segment_color),
+            ("loh_variants", loh_varr),
+            ("somatic_variants", som_varr),
         )
         if v is not None
     }
@@ -1754,6 +1777,17 @@ P_scatter_vcf.add_argument(
     "--sample-id",
     help="""Name of the sample in the VCF to use for b-allele frequency extraction and
             as the default plot title.""",
+)
+P_scatter_vcf.add_argument(
+    "--show-snvs",
+    choices=("het", "with-loh", "with-somatic", "all"),
+    default="het",
+    help="""Which SNV subsets to plot in the VAF panel. ``het`` (default) shows only
+            heterozygous germline SNPs, as in earlier releases.
+            ``with-loh`` overlays tumor-homozygous loci as LOH evidence;
+            ``with-somatic`` overlays SOMATIC-flagged loci;
+            ``all`` overlays both. The segment-overlay (mean-VAF) trend still
+            uses only the het subset, so the BAF math is unchanged.""",
 )
 add_snp_vcf_args(P_scatter_vcf, short_min_depth=True)
 

--- a/cnvlib/plots.py
+++ b/cnvlib/plots.py
@@ -131,7 +131,7 @@ def translate_segments_to_bins(segments, bins):
         bins.sample_id,
     )
     # Must re-align segments to .cnr bins
-    _x, segments, _v = update_binwise_positions(bins, segments)
+    _x, segments, _v, _extras = update_binwise_positions(bins, segments)
     return segments
 
 
@@ -160,7 +160,9 @@ def update_binwise_positions_simple(cnarr):
     )
 
 
-def update_binwise_positions(cnarr, segments=None, variants=None):
+def update_binwise_positions(
+    cnarr, segments=None, variants=None, *, extra_variants=None
+):
     """Convert start/end positions from genomic to bin-wise coordinates.
 
     Instead of chromosomal basepairs, the positions indicate enumerated bins.
@@ -170,15 +172,26 @@ def update_binwise_positions(cnarr, segments=None, variants=None):
     `variants` are grouped into `cnarr` bins as well -- if multiple `variants`
     rows fall within a single bin, equally-spaced fractional positions are used.
 
-    Returns copies of the 3 input objects with revised `start` and `end` arrays.
+    ``extra_variants`` is an optional list of additional VariantArray (or None)
+    instances to translate against the same bin enumeration as ``variants``
+    -- used by the scatter plot's ``--show-snvs`` overlays (#290) so the LOH
+    and somatic markers stay aligned with the het dots under ``--by-bin``.
+
+    Returns a 4-tuple ``(cnarr, segments, variants, extras)`` where ``extras``
+    is the list of translated extra arrays in input order (empty list if no
+    extras were passed).
     """
     cnarr = cnarr.copy()
     if segments:
         segments = segments.copy()
         seg_chroms = set(segments.chromosome.unique())
-    if variants:
-        variants = variants.copy()
-        var_chroms = set(variants.chromosome.unique())
+    # Bundle the primary `variants` and any extras so the per-chrom loop
+    # iterates them uniformly. Copy each so the caller's arrays are unmodified.
+    var_arrs = [variants, *(list(extra_variants) if extra_variants else [])]
+    var_arrs = [v.copy() if v is not None else None for v in var_arrs]
+    var_chroms_per = [
+        set(v.chromosome.unique()) if v is not None else None for v in var_arrs
+    ]
 
     # ENH: look into pandas groupby innards to get group indices
     for chrom in cnarr.chromosome.unique():
@@ -196,11 +209,13 @@ def update_binwise_positions(cnarr, segments=None, variants=None):
             segments.data.loc[c_seg_idx, "start"] = seg_starts
             segments.data.loc[c_seg_idx, "end"] = seg_ends
 
-        if variants and chrom in var_chroms:
+        for varr, vchroms in zip(var_arrs, var_chroms_per, strict=True):
+            if varr is None or vchroms is None or chrom not in vchroms:
+                continue
             # Match variant positions to enumerated bins, and
             # add fractional increments to multiple variants within 1 bin
-            c_varr_idx = (variants.chromosome == chrom).values
-            c_varr_df = variants.data[c_varr_idx]
+            c_varr_idx = (varr.chromosome == chrom).values
+            c_varr_df = varr.data[c_varr_idx]
             # Get binwise start indices of the variants
             v_starts = np.searchsorted(c_bins.start.values, c_varr_df.start.values)
             # Overwrite runs of repeats with fractional increments,
@@ -208,15 +223,15 @@ def update_binwise_positions(cnarr, segments=None, variants=None):
             for idx, size in list(get_repeat_slices(v_starts)):
                 v_starts[idx] += np.arange(size) / size
             variant_sizes = c_varr_df.end - c_varr_df.start
-            variants.data.loc[c_varr_idx, "start"] = v_starts
-            variants.data.loc[c_varr_idx, "end"] = v_starts + variant_sizes
+            varr.data.loc[c_varr_idx, "start"] = v_starts
+            varr.data.loc[c_varr_idx, "end"] = v_starts + variant_sizes
 
         c_starts = np.arange(len(c_bins))  # c_idx.sum())
         c_ends = np.arange(1, len(c_bins) + 1)
         cnarr.data.loc[c_idx, "start"] = c_starts
         cnarr.data.loc[c_idx, "end"] = c_ends
 
-    return cnarr, segments, variants
+    return cnarr, segments, var_arrs[0], var_arrs[1:]
 
 
 def get_repeat_slices(values):

--- a/cnvlib/scatter.py
+++ b/cnvlib/scatter.py
@@ -26,6 +26,17 @@ HIGHLIGHT_COLOR = "gold"
 POINT_COLOR = "#606060"
 SEG_COLOR = "darkorange"
 TREND_COLOR = "#A0A0A0"
+# Distinct colors and markers for ``--show-snvs`` overlays drawn on top of
+# the het SNP scatter. Colors picked from Wong's colorblind-friendly palette
+# so they remain discriminable from each other, from the gray het dots, and
+# from the darkorange segment overlay (Wong 2011, Nature Methods 8:441).
+# Markers are also distinct so the overlays read in grayscale prints. LOH
+# gets the higher-contrast reddish-purple + 'x' to ensure the typically rare
+# and low-VAF LOH dots are not visually buried by the bulk het scatter. (#290)
+LOH_SNV_COLOR = "#CC79A7"  # reddish purple
+LOH_SNV_MARKER = "x"
+SOMATIC_SNV_COLOR = "#0072B2"  # blue
+SOMATIC_SNV_MARKER = "+"
 
 # Floor for the auto-scaled y-axis lower limit, so a single deep homozygous
 # deletion (log2 far below 0) can't compress the rest of the plot into a sliver.
@@ -61,6 +72,8 @@ def do_scatter(
     antitarget_marker: str | None = None,
     segment_color: str = SEG_COLOR,
     title: str | None = None,
+    loh_variants: CopyNumArray | None = None,
+    somatic_variants: CopyNumArray | None = None,
 ) -> Figure:
     """Plot probe log2 coverages and segmentation calls together.
 
@@ -95,6 +108,14 @@ def do_scatter(
         Color for segment lines. Default is SEG_COLOR.
     title : str, optional
         Plot title.
+    loh_variants : VariantArray, optional
+        Tumor-homozygous loci to overlay as LOH evidence in the VAF panel
+        (#290). Plotted with a distinct color; excluded from the BAF
+        segment-overlay trend so the trend reflects only the het subset.
+    somatic_variants : VariantArray, optional
+        Somatic-SNV loci (VCF SOMATIC flag or T/N-inferred) to overlay in
+        the VAF panel with a distinct color (#290). Also excluded from the
+        BAF segment-overlay trend.
 
     Returns
     -------
@@ -105,8 +126,16 @@ def do_scatter(
         bp_per_bin = sum(c.end.iat[-1] for _, c in cnarr.by_chromosome()) / len(cnarr)
         window_width /= bp_per_bin
         show_range_bins = plots.translate_region_to_bins(show_range, cnarr)
-        cnarr, segments, variants = plots.update_binwise_positions(
-            cnarr, segments, variants
+        (
+            cnarr,
+            segments,
+            variants,
+            (
+                loh_variants,
+                somatic_variants,
+            ),
+        ) = plots.update_binwise_positions(
+            cnarr, segments, variants, extra_variants=[loh_variants, somatic_variants]
         )
         global MB
         orig_mb = MB
@@ -114,7 +143,16 @@ def do_scatter(
 
     if not show_gene and not show_range:
         fig = genome_scatter(
-            cnarr, segments, variants, do_trend, y_min, y_max, title, segment_color
+            cnarr,
+            segments,
+            variants,
+            do_trend,
+            y_min,
+            y_max,
+            title,
+            segment_color,
+            loh_variants=loh_variants,
+            somatic_variants=somatic_variants,
         )
     else:
         if by_bin:
@@ -133,6 +171,8 @@ def do_scatter(
             y_max,
             title,
             segment_color,
+            loh_variants=loh_variants,
+            somatic_variants=somatic_variants,
         )
 
     if by_bin:
@@ -156,6 +196,8 @@ def genome_scatter(
     y_max: float | None = None,
     title: str | None = None,
     segment_color: str = SEG_COLOR,
+    loh_variants: CopyNumArray | None = None,
+    somatic_variants: CopyNumArray | None = None,
 ) -> Figure:
     """Plot all chromosomes, concatenated on one plot."""
     if (cnarr or segments) and variants:
@@ -167,7 +209,14 @@ def genome_scatter(
         axis2.tick_params(labelbottom=False)
         chrom_sizes = plots.chromosome_sizes(cnarr or segments)  # type: ignore[arg-type]
         axis2 = snv_on_genome(
-            axis2, variants, chrom_sizes, segments, do_trend, segment_color
+            axis2,
+            variants,
+            chrom_sizes,
+            segments,
+            do_trend,
+            segment_color,
+            loh_variants=loh_variants,
+            somatic_variants=somatic_variants,
         )
     else:
         _fig, axis = pyplot.subplots()
@@ -191,7 +240,14 @@ def genome_scatter(
             for chrom, subarr in variants.by_chromosome()  # type: ignore[union-attr]
         )
         axis = snv_on_genome(
-            axis, variants, chrom_sizes, segments, do_trend, segment_color
+            axis,
+            variants,
+            chrom_sizes,
+            segments,
+            do_trend,
+            segment_color,
+            loh_variants=loh_variants,
+            somatic_variants=somatic_variants,
         )
     return axis.get_figure()  # type: ignore[return-value]
 
@@ -307,14 +363,30 @@ def cnv_on_genome(
     return axis
 
 
-def snv_on_genome(axis, variants, chrom_sizes, segments, do_trend, segment_color):
-    """Plot a scatter-plot of SNP chromosomal positions and shifts."""
+def snv_on_genome(
+    axis,
+    variants,
+    chrom_sizes,
+    segments,
+    do_trend,
+    segment_color,
+    loh_variants=None,
+    somatic_variants=None,
+):
+    """Plot a scatter-plot of SNP chromosomal positions and shifts.
+
+    Optional ``loh_variants`` and ``somatic_variants`` are overlaid in
+    distinct colors and excluded from the segment-overlay trend so the trend
+    continues to reflect only the het subset (#290).
+    """
     axis.set_ylim(0.0, 1.0)
     axis.set_ylabel("VAF")
     x_starts = plots.plot_chromosome_dividers(axis, chrom_sizes)
 
     # Calculate the coordinates of plot components
     chrom_snvs = dict(variants.by_chromosome())
+    chrom_loh = dict(loh_variants.by_chromosome()) if loh_variants else {}
+    chrom_som = dict(somatic_variants.by_chromosome()) if somatic_variants else {}
     if segments:
         chrom_segs = dict(segments.by_chromosome())
     elif do_trend:
@@ -338,7 +410,36 @@ def snv_on_genome(axis, variants, chrom_sizes, segments, do_trend, segment_color
             alpha=0.2,
             marker=".",
         )
-        # Trend bars: always calculated, only shown on request
+        # Overlay LOH-evidence and somatic markers on top of the het dots.
+        # Distinct color AND marker shape (set in module-level constants) so
+        # the overlays read in grayscale prints as well as in color. Higher
+        # alpha than het dots so they remain visible through dense het
+        # regions. Legend handles (``label=``) are attached only on the
+        # first per-chromosome draw to avoid N duplicate legend entries; the
+        # axis-level legend call at the end of the loop emits the legend.
+        if chrom in chrom_loh:
+            loh_snvs = chrom_loh[chrom]
+            axis.scatter(
+                loh_snvs["start"].values + x_offset,
+                loh_snvs["alt_freq"].values,
+                color=LOH_SNV_COLOR,
+                alpha=0.7,
+                marker=LOH_SNV_MARKER,
+                label=_overlay_label_once(axis, "LOH"),
+            )
+        if chrom in chrom_som:
+            som_snvs = chrom_som[chrom]
+            axis.scatter(
+                som_snvs["start"].values + x_offset,
+                som_snvs["alt_freq"].values,
+                color=SOMATIC_SNV_COLOR,
+                alpha=0.7,
+                marker=SOMATIC_SNV_MARKER,
+                label=_overlay_label_once(axis, "somatic"),
+            )
+        # Trend bars: always calculated, only shown on request.
+        # NB: trend uses only the het subset (snvs), never the overlays --
+        # the BAF math that drives the segment overlay must be unchanged.
         if chrom in chrom_segs:
             # Draw average VAF within each segment
             segs = chrom_segs[chrom]
@@ -363,7 +464,37 @@ def snv_on_genome(axis, variants, chrom_sizes, segments, do_trend, segment_color
                     solid_capstyle="round",
                     snap=False,
                 )
+    if loh_variants is not None or somatic_variants is not None:
+        # Legend lives outside the plot (anchored to the right edge of the
+        # VAF panel) so it doesn't occlude the dot field. Marker keys are
+        # de-duplicated by _overlay_label_once. ``bbox_inches="tight"`` at
+        # savefig captures the legend even though it sits past the axes.
+        axis.legend(
+            loc="upper left",
+            bbox_to_anchor=(1.01, 1.0),
+            borderaxespad=0,
+            fontsize="small",
+            frameon=False,
+        )
     return axis
+
+
+def _overlay_label_once(axis: Axes, label: str) -> str | None:
+    """Return ``label`` the first time it's seen for this axis, else None.
+
+    Prevents matplotlib's legend from accumulating N duplicate entries when
+    the same overlay kind is plotted once per chromosome in genome view.
+    Uses the axis itself as the dedupe scope so different subplots get
+    independent legends.
+    """
+    seen = getattr(axis, "_cnvkit_overlay_labels_seen", None)
+    if seen is None:
+        seen = set()
+        axis._cnvkit_overlay_labels_seen = seen  # type: ignore[attr-defined]
+    if label in seen:
+        return None
+    seen.add(label)
+    return label
 
 
 # === Chromosome-level scatter plots ===
@@ -383,6 +514,8 @@ def chromosome_scatter(
     y_max,
     title,
     segment_color,
+    loh_variants=None,
+    somatic_variants=None,
 ):
     """Plot a specified region on one chromosome.
 
@@ -399,8 +532,24 @@ def chromosome_scatter(
         chr:s-e | +  | given | given
 
     """
-    sel_probes, sel_segs, sel_snvs, window_coords, genes, chrom = select_range_genes(
-        cnarr, segments, variants, show_range, show_gene, window_width
+    (
+        sel_probes,
+        sel_segs,
+        sel_snvs,
+        sel_loh,
+        sel_som,
+        window_coords,
+        genes,
+        chrom,
+    ) = select_range_genes(
+        cnarr,
+        segments,
+        variants,
+        show_range,
+        show_gene,
+        window_width,
+        loh_variants=loh_variants,
+        somatic_variants=somatic_variants,
     )
     # Create plots
     if cnarr or segments:
@@ -412,7 +561,15 @@ def chromosome_scatter(
             axis2 = pyplot.subplot(axgrid[3:], sharex=axis)
             # Plot allele freqs for only the selected region
             snv_on_chromosome(
-                axis2, sel_snvs, sel_segs, genes, do_trend, by_bin, segment_color
+                axis2,
+                sel_snvs,
+                sel_segs,
+                genes,
+                do_trend,
+                by_bin,
+                segment_color,
+                loh_variants=sel_loh,
+                somatic_variants=sel_som,
             )
         else:
             _fig, axis = pyplot.subplots()
@@ -436,7 +593,15 @@ def chromosome_scatter(
         # Only plot SNVs in a single-panel layout
         _fig, axis = pyplot.subplots()
         axis = snv_on_chromosome(
-            axis, sel_snvs, sel_segs, genes, do_trend, by_bin, segment_color
+            axis,
+            sel_snvs,
+            sel_segs,
+            genes,
+            do_trend,
+            by_bin,
+            segment_color,
+            loh_variants=sel_loh,
+            somatic_variants=sel_som,
         )
 
     if title is None:
@@ -445,7 +610,17 @@ def chromosome_scatter(
     return axis.get_figure()
 
 
-def select_range_genes(cnarr, segments, variants, show_range, show_gene, window_width):
+def select_range_genes(
+    cnarr,
+    segments,
+    variants,
+    show_range,
+    show_gene,
+    window_width,
+    *,
+    loh_variants=None,
+    somatic_variants=None,
+):
     """Determine which datapoints to show based on the given options.
 
     Behaviors::
@@ -547,6 +722,10 @@ def select_range_genes(cnarr, segments, variants, show_range, show_gene, window_
         segments.in_range(chrom, *window_coords, mode="trim") if segments else CNA([])
     )
     sel_snvs = variants.in_range(chrom, *window_coords) if variants else None
+    sel_loh = loh_variants.in_range(chrom, *window_coords) if loh_variants else None
+    sel_som = (
+        somatic_variants.in_range(chrom, *window_coords) if somatic_variants else None
+    )
     logging.info(
         "Showing %d probes and %d selected genes in region %s",
         len(sel_probes),
@@ -562,7 +741,16 @@ def select_range_genes(cnarr, segments, variants, show_range, show_gene, window_
             diagnose_missing_chromosome(chrom, cnarr.chromosome.unique()),
         )
 
-    return sel_probes, sel_segs, sel_snvs, window_coords, gene_ranges, chrom
+    return (
+        sel_probes,
+        sel_segs,
+        sel_snvs,
+        sel_loh,
+        sel_som,
+        window_coords,
+        gene_ranges,
+        chrom,
+    )
 
 
 def cnv_on_chromosome(
@@ -681,7 +869,23 @@ def cnv_on_chromosome(
     return axis
 
 
-def snv_on_chromosome(axis, variants, segments, genes, do_trend, by_bin, segment_color):
+def snv_on_chromosome(
+    axis,
+    variants,
+    segments,
+    genes,
+    do_trend,
+    by_bin,
+    segment_color,
+    loh_variants=None,
+    somatic_variants=None,
+):
+    """Draw VAFs for a single-chromosome region.
+
+    Optional ``loh_variants`` and ``somatic_variants`` are overlaid in
+    distinct colors and excluded from the segment-overlay trend so the trend
+    continues to reflect only the het subset (#290).
+    """
     # TODO set x-limits if not already done for probes/segments
     # set_xlim_from(axis, None, segments, variants)
     # setup_chromosome(axis, 0.0, 1.0, "VAF")
@@ -698,8 +902,39 @@ def snv_on_chromosome(axis, variants, segments, genes, do_trend, by_bin, segment
     x_mb = variants["start"].values * MB
     y = variants["alt_freq"].values
     axis.scatter(x_mb, y, color=POINT_COLOR, alpha=0.3)
+    overlay_present = False
+    if loh_variants is not None and len(loh_variants):
+        axis.scatter(
+            loh_variants["start"].values * MB,
+            loh_variants["alt_freq"].values,
+            color=LOH_SNV_COLOR,
+            alpha=0.8,
+            marker=LOH_SNV_MARKER,
+            label="LOH",
+        )
+        overlay_present = True
+    if somatic_variants is not None and len(somatic_variants):
+        axis.scatter(
+            somatic_variants["start"].values * MB,
+            somatic_variants["alt_freq"].values,
+            color=SOMATIC_SNV_COLOR,
+            alpha=0.8,
+            marker=SOMATIC_SNV_MARKER,
+            label="somatic",
+        )
+        overlay_present = True
+    if overlay_present:
+        axis.legend(
+            loc="upper left",
+            bbox_to_anchor=(1.01, 1.0),
+            borderaxespad=0,
+            fontsize="small",
+            frameon=False,
+        )
     if segments or do_trend:
-        # Draw average VAF within each segment
+        # Draw average VAF within each segment.
+        # NB: trend uses only the het subset (variants), never the overlays
+        # -- the BAF math driving the segment overlay must stay unchanged.
         sex_labels = _sex_labels(segments) if segments else (None, None)
         for seg, v_freq in get_segment_vafs(variants, segments):
             if seg:

--- a/doc/plots.rst
+++ b/doc/plots.rst
@@ -5,8 +5,8 @@ The :ref:`scatter` and :ref:`heatmap` plots can be used in two ways:
 
 1. Open the plot in an interactive window with zoom and other features. This
    is also compatible with Jupyter/IPython notebooks to render the plots inline.
-2. Generate a static image plot with the ``--output``/``-o`` option. 
-   
+2. Generate a static image plot with the ``--output``/``-o`` option.
+
     - While PDF is a good choice to generate publication-quality figures that
       can be easily edited in Inkscape or Adobe Illustrator, other formats will
       work, indicated by the output filename extension -- e.g. "-o myplot.png"
@@ -104,7 +104,7 @@ Chromosome-level views are controlled with the ``--chromosome``/``-c`` and
 - A region label with chromosome name and 1-based start and end coordinates
   (e.g. ``-c chr5:1000000-4000000``) plots the specified region, with the start
   and end coordinates as the x-axis limits. All genes in this region (that are
-  labeled in the input .cnr file) are highlighted and labeled. 
+  labeled in the input .cnr file) are highlighted and labeled.
 
     - If the start or end coordinate is left off (e.g. ``-c chr5:-4000000`` or
       ``-c chr7:140000000-``), the region is extended to the end of the
@@ -118,7 +118,7 @@ Chromosome-level views are controlled with the ``--chromosome``/``-c`` and
       and labeled. To not show any genes, specify an empty string: ``-g ''``
     - Special behavior occurs if there are no genes in the selected region:
       Instead, the selection itself is treated as a "gene", highlighted and
-      labeled with the string "Selection", with padding controlled by ``-w``. 
+      labeled with the string "Selection", with padding controlled by ``-w``.
       This behavior can be blocked by specifying an empty list of genes: ``-g
       ''`` -- then the specified region will be plotted as usual, with nothing
       highlighted and no padding.
@@ -179,6 +179,37 @@ Better results can be had by giving CNVkit more information:
   more amenable to LOH detection.
 
 
+Highlighting LOH evidence and somatic mutations
+```````````````````````````````````````````````
+
+By default, the VAF panel shows only heterozygous germline SNPs and the
+mean-VAF trend within each segment, which is the appropriate signal for
+detecting allelic imbalance. Two related variant classes are filtered out of
+this view because including them in the BAF segment-mean would bias it:
+
+- **Tumor-homozygous loci at germline-heterozygous positions** are evidence of
+  loss of heterozygosity (LOH), the canonical second-hit mechanism for
+  tumor-suppressor inactivation in genes such as ``TP53``, ``RB1``, ``PTEN``,
+  and the ``BRCA1``/``BRCA2`` family.
+- **Somatic SNVs** (VCF ``SOMATIC`` flag, or T/N-inferred when matched normal
+  data are present) can be useful visual context alongside copy-number calls,
+  for example to assess tumor mutation burden over deleted segments.
+
+The ``--show-snvs`` flag overlays these subsets in the VAF panel with
+distinct colors while leaving the segment-mean trend driven solely by the
+het subset (so the underlying BAF math is unchanged)::
+
+    cnvkit.py scatter Sample.cnr -s Sample.cns -v Sample.vcf --show-snvs with-loh
+    cnvkit.py scatter Sample.cnr -s Sample.cns -v Sample.vcf --show-snvs with-somatic
+    cnvkit.py scatter Sample.cnr -s Sample.cns -v Sample.vcf --show-snvs all
+
+When a matched normal sample is available, LOH evidence is restricted to loci
+that are heterozygous in the normal and homozygous in the tumor -- the
+stricter T/N-aware definition. In tumor-only flows the selector falls back to
+any tumor-homozygous locus, with the caveat that true germline-homozygous
+positions are then indistinguishable from LOH-induced homozygosity.
+
+
 .. _diagram:
 
 ``diagram``
@@ -232,7 +263,7 @@ alterations at least that exteme.
 To reduce the number of false-positive calls in the .cns file (see
 :doc:`calling`), consider:
 
-- Making the initial segmentation more stringent with `segment -t` or a larger
+- Making the initial segmentation more stringent with ``segment -t`` or a larger
   bin size
 - Filtering segments by confidence interval via :ref:`segmetrics --ci
   <segmetrics>` and :ref:`call --filter ci <call>`
@@ -300,7 +331,7 @@ The plots generated with the :ref:`scatter` and :ref:`heatmap` commands use the
 Python plotting library matplotlib.
 
 To quickly adjust the displayed area of the genome in a plot, run either
-plotting command without the `-o` option to generate an interactive plot in a
+plotting command without the ``-o`` option to generate an interactive plot in a
 new window. You can then resize that plot up to the full size of your screen,
 use the plot window's selection mode to select a smaller area of the genome, and
 use the plot window's save button to save the plot in your preferred format.
@@ -316,7 +347,7 @@ file::
     axes.labelsize      : small
 
 For more control, in the Python intepreter (or a script, or a Jupyter notebook),
-import the :doc:`cnvlib` module and call the `do_scatter` or `do_heatmap`
+import the :doc:`cnvlib` module and call the ``do_scatter`` or ``do_heatmap``
 function to create a plot. Then you can use matplotlib.pyplot to get the current
 axis and modify the plot elements, change font sizes, or anything else you
 like::

--- a/test/test_call.py
+++ b/test/test_call.py
@@ -768,6 +768,152 @@ class LoadHetSnpsTests(unittest.TestCase):
         self.assertLessEqual(varr.meta["chrx_het_count"], varr.meta["chrx_snp_total"])
 
 
+class LoadSnpSubsetsTests(unittest.TestCase):
+    """Tests for cmdutil.load_snp_subsets and _partition_snp_extras.
+
+    The partition surfaces LOH-evidence (tumor-homozygous loci) and somatic
+    SNVs separately from the heterozygous germline subset that drives BAF and
+    segment-overlay computation. Used by the scatter plot's ``--show-snvs``
+    modes (#290) to visualize previously-hidden variant evidence.
+    """
+
+    _VCF_TN = "formats/na12878_na12882_mix.vcf"
+    _TUMOR_ID = "NA12882"
+    _NORMAL_ID = "NA12878"
+
+    def test_default_returns_none_extras(self):
+        """Both include flags False -> behaves like load_het_snps for the het
+        subset, and emits None for both extras (zero-cost default path)."""
+        het, loh, somatic = cmdutil.load_snp_subsets(
+            self._VCF_TN, self._TUMOR_ID, self._NORMAL_ID, 15, None
+        )
+        ref_het = cmdutil.load_het_snps(
+            self._VCF_TN, self._TUMOR_ID, self._NORMAL_ID, 15, None
+        )
+        self.assertEqual(len(het), len(ref_het))
+        self.assertIsNone(loh)
+        self.assertIsNone(somatic)
+
+    def test_with_loh_matched_normal(self):
+        """With matched normal, LOH = (normal-het & tumor-hom & not somatic).
+
+        load_het_snps filters by *normal* zygosity when matched normal is
+        present, so a normal-het + tumor-hom locus is already in ``het`` (and
+        already drives the BAF trend correctly). LOH thus forms a *subset* of
+        ``het`` in matched-normal mode -- the visual layer overlays distinct
+        markers without changing the BAF math. Somatic remains disjoint from
+        het (load_het_snps drops somatic loci at read time).
+        """
+        het, loh, somatic = cmdutil.load_snp_subsets(
+            self._VCF_TN,
+            self._TUMOR_ID,
+            self._NORMAL_ID,
+            15,
+            None,
+            include_loh=True,
+            include_somatic=True,
+        )
+        self.assertIsNotNone(loh)
+        self.assertIsNotNone(somatic)
+        # LOH-evidence must be tumor-homozygous (zygosity in {0, 1}) and,
+        # when matched normal is present, normal-heterozygous (n_zyg == 0.5).
+        loh_zyg = loh["zygosity"]  # type: ignore[index]
+        self.assertTrue(((loh_zyg == 0.0) | (loh_zyg == 1.0)).all())
+        self.assertIn("n_zygosity", loh)  # type: ignore[operator]
+        self.assertTrue((loh["n_zygosity"] == 0.5).all())  # type: ignore[index]
+        # Somatic loci must carry the somatic flag (or be inferred via T/N).
+        self.assertGreater(len(somatic), 0)
+        # Identify each record uniquely by (chr, start, ref, alt) -- the VCF
+        # contains multiallelic sites decomposed into separate biallelic rows,
+        # so (chr, start) alone is not unique.
+        het_keys = {(r.chromosome, r.start, r.ref, r.alt) for r in het}
+        loh_keys = {(r.chromosome, r.start, r.ref, r.alt) for r in loh}  # type: ignore[union-attr]
+        som_keys = {(r.chromosome, r.start, r.ref, r.alt) for r in somatic}  # type: ignore[union-attr]
+        # loh is a strict subset of het: every LOH locus already drives the
+        # BAF trend; we just want to draw a distinct marker on top.
+        self.assertTrue(loh_keys.issubset(het_keys))
+        # Somatic is disjoint from both other subsets.
+        self.assertEqual(het_keys & som_keys, set())
+        self.assertEqual(loh_keys & som_keys, set())
+
+    def test_with_somatic_only(self):
+        """include_somatic=True surfaces the SOMATIC-flagged loci that
+        load_het_snps drops at read time via skip_somatic=True."""
+        _het, loh, somatic = cmdutil.load_snp_subsets(
+            self._VCF_TN,
+            self._TUMOR_ID,
+            self._NORMAL_ID,
+            15,
+            None,
+            include_loh=False,
+            include_somatic=True,
+        )
+        self.assertIsNone(loh)
+        self.assertIsNotNone(somatic)
+        self.assertGreater(len(somatic), 0)
+
+    def test_partition_tumor_only_loh_fallback(self):
+        """In tumor-only flows (no n_zygosity column), the LOH selector falls
+        back to tumor-homozygous regardless of normal genotype. Unit-tested
+        on _partition_snp_extras to avoid needing a tumor-only VCF fixture."""
+        # Build a synthetic VariantArray: 2 het, 2 tumor-hom, 1 somatic-flagged.
+        # No n_zygosity column (tumor-only flow).
+        varr = vary.VariantArray.from_rows(
+            [
+                ("chr1", 100, 101, "A", "G", False, 0.5),
+                ("chr1", 200, 201, "A", "G", False, 0.5),
+                ("chr1", 300, 301, "A", "G", False, 1.0),
+                ("chr1", 400, 401, "A", "G", False, 0.0),
+                ("chr1", 500, 501, "A", "G", True, 0.5),
+            ],
+            columns=[
+                "chromosome",
+                "start",
+                "end",
+                "ref",
+                "alt",
+                "somatic",
+                "zygosity",
+            ],
+        )
+        loh, somatic = cmdutil._partition_snp_extras(
+            varr, include_loh=True, include_somatic=True
+        )
+        self.assertEqual(len(loh), 2)  # type: ignore[arg-type]
+        self.assertEqual(len(somatic), 1)  # type: ignore[arg-type]
+        # The LOH subset captures both zygosity==0 and zygosity==1 rows.
+        loh_zyg = sorted(loh["zygosity"].tolist())  # type: ignore[index]
+        self.assertEqual(loh_zyg, [0.0, 1.0])
+
+    def test_partition_disjoint_when_both_requested(self):
+        """When both include flags are True the function must not double-count:
+        a somatic-flagged tumor-hom locus belongs to ``somatic``, not LOH."""
+        varr = vary.VariantArray.from_rows(
+            [
+                # A non-somatic tumor-hom locus -> LOH
+                ("chr1", 100, 101, "A", "G", False, 1.0),
+                # A somatic tumor-hom locus -> somatic only, NOT LOH
+                ("chr1", 200, 201, "A", "G", True, 1.0),
+            ],
+            columns=[
+                "chromosome",
+                "start",
+                "end",
+                "ref",
+                "alt",
+                "somatic",
+                "zygosity",
+            ],
+        )
+        loh, somatic = cmdutil._partition_snp_extras(
+            varr, include_loh=True, include_somatic=True
+        )
+        self.assertEqual(len(loh), 1)  # type: ignore[arg-type]
+        self.assertEqual(loh.start.iat[0], 100)  # type: ignore[union-attr]
+        self.assertEqual(len(somatic), 1)  # type: ignore[arg-type]
+        self.assertEqual(somatic.start.iat[0], 200)  # type: ignore[union-attr]
+
+
 class VerifySampleSexHetConfirmerTests(unittest.TestCase):
     """Integration tests for the chrX-het-density confirmer plumbing inside
     ``cmdutil.verify_sample_sex`` (#341).

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -226,7 +226,7 @@ class ExportTests(unittest.TestCase):
         self.assertGreater(len(set(fold_changes)), 1)  # not a stuck/degenerate value
 
     def test_export_vcf_loh_allele_specific_fields(self):
-        """VCF export surfaces allele-specific CN and BAF for LOH evidence (gh#892).
+        """VCF export surfaces allele-specific CN and BAF for LOH evidence (#892).
 
         Two clinically meaningful regimes must round-trip through ``export vcf``:
 

--- a/test/test_plots.py
+++ b/test/test_plots.py
@@ -110,6 +110,109 @@ class PlotTests(unittest.TestCase):
         pyplot.close(_fig)
         self.assertAlmostEqual(y_lo, -15.0)
 
+    def test_scatter_show_snvs_extras(self):
+        """`scatter` overlays LOH and somatic markers on the VAF panel and
+        leaves the segment-VAF trend driven solely by the het subset (#290).
+
+        The structural-correctness invariant: introducing the overlays must
+        NOT pull the segment-mean VAF toward the homozygous-allele extremes,
+        because clinical interpretation of segment VAFs depends on the trend
+        being the mean of the het BAFs only. We verify by monkey-patching
+        ``get_segment_vafs`` to capture its first positional argument (the
+        VariantArray driving the trend) and asserting it's the het subset
+        with no LOH rows mixed in -- the test catches a regression where
+        ``snv_on_chromosome`` accidentally concatenates LOH into the trend.
+        """
+        # lazy: defer matplotlib import to keep headless test collection fast
+        from matplotlib import pyplot  # noqa: PLC0415
+
+        het = vary.VariantArray.from_rows(
+            [
+                ("chr1", 100, 101, "A", "G", False, 0.5, 0.5, 100, 50),
+                ("chr1", 200, 201, "A", "G", False, 0.5, 0.55, 100, 55),
+                ("chr1", 300, 301, "A", "G", False, 0.5, 0.45, 100, 45),
+            ],
+            columns=[
+                "chromosome",
+                "start",
+                "end",
+                "ref",
+                "alt",
+                "somatic",
+                "zygosity",
+                "alt_freq",
+                "depth",
+                "alt_count",
+            ],
+        )
+        loh = vary.VariantArray.from_rows(
+            [
+                ("chr1", 150, 151, "A", "G", False, 1.0, 0.95, 100, 95),
+                ("chr1", 250, 251, "A", "G", False, 0.0, 0.05, 100, 5),
+            ],
+            columns=[
+                "chromosome",
+                "start",
+                "end",
+                "ref",
+                "alt",
+                "somatic",
+                "zygosity",
+                "alt_freq",
+                "depth",
+                "alt_count",
+            ],
+        )
+        seg = cnary.CopyNumArray.from_rows(
+            [("chr1", 50, 400, "A", -0.5)],
+            columns=["chromosome", "start", "end", "gene", "log2"],
+        )
+        # Monkey-patch get_segment_vafs to capture the variants array it sees.
+        captured = []
+        orig_get_segment_vafs = scatter.get_segment_vafs
+
+        def recording_get_segment_vafs(variants, segments):
+            captured.append(variants)
+            return orig_get_segment_vafs(variants, segments)
+
+        scatter.get_segment_vafs = recording_get_segment_vafs
+        try:
+            _fig, ax = pyplot.subplots()
+            scatter.snv_on_chromosome(
+                ax,
+                het,
+                seg,
+                [],
+                do_trend=True,
+                by_bin=False,
+                segment_color="darkorange",
+                loh_variants=loh,
+            )
+            pyplot.close(_fig)
+        finally:
+            scatter.get_segment_vafs = orig_get_segment_vafs
+
+        # snv_on_chromosome must drive the trend from the het subset only.
+        self.assertEqual(len(captured), 1)
+        trend_input = captured[0]
+        self.assertEqual(len(trend_input), len(het))
+        # The LOH rows' VAF extremes (0.95, 0.05) must NOT be among the
+        # values the trend was computed from. If they were, the test caught
+        # a regression where the overlay leaked into the BAF math.
+        for loh_freq in loh["alt_freq"].tolist():
+            self.assertNotIn(loh_freq, trend_input["alt_freq"].tolist())
+        # And as a sanity check on the test's premise: a "broken" trend
+        # input that concatenates LOH would produce a clearly different
+        # segment mean.
+        broken_input = het.concat([loh])
+        broken_trend = [
+            v_freq for _seg, v_freq in orig_get_segment_vafs(broken_input, seg)
+        ]
+        correct_trend = [
+            v_freq for _seg, v_freq in orig_get_segment_vafs(trend_input, seg)
+        ]
+        self.assertNotEqual(broken_trend, correct_trend)
+
     def test_heatmap(self):
         """The 'heatmap' command."""
         cnarrs = [cnvlib.read("formats/amplicon.cnr")]


### PR DESCRIPTION
## Summary

- Adds `cnvkit.py scatter --show-snvs {het,with-loh,with-somatic,all}` to overlay tumor-homozygous (LOH-evidence) and somatic SNV loci in the VAF panel with distinct colors and markers, with an external legend identifying each kind. The default `het` mode is unchanged.
- The segment-mean VAF trend is always computed from the het subset only, so the BAF math that drives clinical segment-overlay interpretation is unchanged.
- Closes #290 (open since 2017): "plotting somatic or tumor-homozygous variants in another color."

Visualization-only feature. No change to `.cnr`, `.cns`, `.cnn`, SEG, or VCF outputs.

## Design notes

- **LOH definition.** When matched normal genotypes are available, LOH evidence = normal-heterozygous AND tumor-homozygous, excluding any somatic call. In tumor-only flows the selector falls back to tumor-homozygous (with the documented caveat that true germline-homozygous positions are indistinguishable from LOH-induced homozygosity).
- **Marker style.** Wong colorblind-safe palette: reddish-purple `x` for LOH (typically rare and at VAF extremes; needed visual pop), blue `+` for somatic (typically widespread at low VAF). Distinct shapes so the overlays read in grayscale prints.
- **API shape.** New `cmdutil.load_snp_subsets(...)` returns `(het, loh_or_None, somatic_or_None)`; the het result is identical to `load_het_snps`, so the 8 existing `load_het_snps` callers are unchanged. The Mutect2 all-zero-normal `zygosity_freq` workaround is factored into `_resolve_zygosity_freq` and shared between the two loaders.
- **Plumbing.** Six functions in `cnvlib/scatter.py` thread optional `loh_variants` / `somatic_variants` parameters from `do_scatter` down to the per-chromosome plot calls. `cnvlib/plots.py::update_binwise_positions` accepts optional `extra_variants` and now always returns a 4-tuple.

## Code review

Three parallel `feature-dev:code-reviewer` agents reviewed before push (simplicity/DRY, bugs/correctness, project conventions). Findings addressed:

- `update_binwise_positions` reshaped to always return a 4-tuple (no variable-arity return).
- `_resolve_zygosity_freq` helper extracted to deduplicate the Mutect2 workaround between `load_het_snps` and `load_snp_subsets`, AND applied against the germline subset of the extras read to close the partial-`n_zygosity` edge case where interleaved somatic rows could mask the all-zero-normal heuristic.
- `test_scatter_show_snvs_extras` rewritten to monkey-patch `get_segment_vafs` and capture its actual input (the previous version recomputed the trend with the same expression twice and was a tautology that would not have caught a future regression where the overlays leaked into the BAF math).
- Bare `#290` everywhere (no `gh#` prefix in code prose).
- Defensive `getattr(args, "show_snvs", "het")` simplified to `args.show_snvs`.
- `# noqa: PLC0415` carries the required one-line rationale.

## Commits

1. `test: drop gh# prefix from test_export docstring (#892)` — drive-by repair of a leak from PR #1099.
2. `scatter: surface LOH and somatic SNV evidence as colored overlays (#290)` — the feature plus tests and docs.

## Test plan

- [x] `pytest test/` — 420 passed, 45 subtests passed (was 414 before; +6 new tests in this branch).
- [x] `ruff check cnvlib/ test/` — clean.
- [x] `mypy cnvlib/scatter.py cnvlib/cmdutil.py cnvlib/plots.py cnvlib/commands.py` — clean.
- [x] End-to-end smoke test renders to PNG with the expected visual: het dots gray, LOH dots reddish-purple `x` at VAF extremes, somatic dots blue `+`, external legend.
- [x] Reviewer to confirm the visual is acceptable (legend placement, color/marker choices) on a real local sample.

Fixes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)