### PR TITLE
Auto-select CSI BAM index for long-chromosome genomes

### DIFF
--- a/cnvlib/samutil.py
+++ b/cnvlib/samutil.py
@@ -66,13 +66,33 @@ def bam_total_reads(bam_fname: str, fasta: str | None = None) -> int64:
     return table.mapped.sum()  # type: ignore[no-any-return]
 
 
+# BAI's binning scheme cannot address coordinates beyond 2**29 bp, so a
+# reference contig longer than this requires a CSI index instead.
+_BAI_MAX_CONTIG_LENGTH = 1 << 29  # 536_870_912
+
+
+def _bam_needs_csi(bam_fname: str, pysam: Any) -> bool:
+    """Return True if any reference contig is too long for a BAI index.
+
+    Long-chromosome genomes (e.g. wheat, barley) have contigs exceeding the BAI
+    coordinate limit of 2**29 bp and must use a CSI index. Reads only the BAM
+    header, so no index is required.
+    """
+    with pysam.AlignmentFile(bam_fname, "rb") as bam:
+        return any(length > _BAI_MAX_CONTIG_LENGTH for length in bam.lengths)
+
+
 def ensure_bam_index(bam_fname: str) -> str:
-    """Ensure a BAM file is indexed, to enable fast traversal & lookup.
+    """Ensure a BAM/CRAM file is indexed, to enable fast traversal & lookup.
 
-    For MySample.bam, samtools will look for an index in these files, in order:
+    For MySample.bam, samtools looks for an index in these files, in order:
 
-    - MySample.bam.bai
-    - MySample.bai
+    - MySample.bam.bai / MySample.bam.csi
+    - MySample.bai / MySample.csi
+
+    A CSI index is built automatically when any reference contig is longer than
+    the BAI coordinate limit (2**29 bp), as in long-chromosome genomes such as
+    wheat or barley.
     """
     try:
         import pysam  # noqa: PLC0415  # lazy: keep targeted ImportError message
@@ -83,28 +103,52 @@ def ensure_bam_index(bam_fname: str) -> str:
     if PurePath(bam_fname).suffix == ".cram":
         if os.path.isfile(bam_fname + ".crai"):
             # MySample.cram.crai
-            bai_fname = bam_fname + ".crai"
+            index_fname = bam_fname + ".crai"
         else:
             # MySample.crai
-            bai_fname = bam_fname[:-1] + "i"
-        if not is_newer_than(bai_fname, bam_fname):
+            index_fname = bam_fname[:-1] + "i"
+        if not is_newer_than(index_fname, bam_fname):
             logging.info("Indexing CRAM file %s", bam_fname)
             pysam.index(bam_fname)  # type: ignore[attr-defined]
-            bai_fname = bam_fname + ".crai"
-        assert os.path.isfile(bai_fname), "Failed to generate cram index " + bai_fname
+            index_fname = bam_fname + ".crai"
+        assert os.path.isfile(index_fname), (
+            "Failed to generate cram index " + index_fname
+        )
+    elif _bam_needs_csi(bam_fname, pysam):
+        # Long-chromosome genome: a contig exceeds the BAI 2**29 bp coordinate
+        # limit, so a CSI index is required instead of BAI.
+        if os.path.isfile(bam_fname + ".csi"):
+            # MySample.bam.csi
+            index_fname = bam_fname + ".csi"
+        else:
+            # MySample.csi
+            index_fname = bam_fname[:-3] + "csi"
+        if not is_newer_than(index_fname, bam_fname):
+            logging.info("Indexing BAM file %s (CSI; long contigs)", bam_fname)
+            pysam.index("-c", bam_fname)  # type: ignore[attr-defined]
+            index_fname = bam_fname + ".csi"
+            # A stale .bai cannot index this BAM and would shadow the new .csi.
+            for stale_bai in (bam_fname + ".bai", bam_fname[:-1] + "i"):
+                if os.path.isfile(stale_bai):
+                    os.remove(stale_bai)
+        assert os.path.isfile(index_fname), (
+            "Failed to generate bam csi index " + index_fname
+        )
     else:
         if os.path.isfile(bam_fname + ".bai"):
             # MySample.bam.bai
-            bai_fname = bam_fname + ".bai"
+            index_fname = bam_fname + ".bai"
         else:
             # MySample.bai
-            bai_fname = bam_fname[:-1] + "i"
-        if not is_newer_than(bai_fname, bam_fname):
+            index_fname = bam_fname[:-1] + "i"
+        if not is_newer_than(index_fname, bam_fname):
             logging.info("Indexing BAM file %s", bam_fname)
             pysam.index(bam_fname)  # type: ignore[attr-defined]
-            bai_fname = bam_fname + ".bai"
-        assert os.path.isfile(bai_fname), "Failed to generate bam index " + bai_fname
-    return bai_fname
+            index_fname = bam_fname + ".bai"
+        assert os.path.isfile(index_fname), (
+            "Failed to generate bam index " + index_fname
+        )
+    return index_fname
 
 
 def ensure_bam_sorted(

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -395,6 +395,16 @@ beforehand, CNVkit will automatically do it for you.
     to update the timestamp on the index files after all files have been
     downloaded.
 
+.. note::
+    **Long-chromosome genomes are indexed automatically with CSI.** The BAI
+    index format cannot address chromosomes longer than about 537 Mb, which
+    excludes some plant and amphibian
+    genomes such as wheat, barley, and salamander. When CNVkit indexes such a
+    BAM it builds a CSI index (``.csi``) rather than BAI, and an existing
+    ``.csi`` file is detected and reused just like ``.bai``. No extra options
+    or manual indexing are required (equivalent to running ``samtools index
+    -c`` yourself).
+
 
 .. _reference:
 

--- a/test/test_samutil.py
+++ b/test/test_samutil.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""Tests for cnvlib.samutil, focused on BAM index (BAI vs. CSI) selection."""
+
+import logging
+import os
+import tempfile
+import unittest
+
+import pysam
+
+from cnvlib import samutil
+from cnvlib.samutil import _BAI_MAX_CONTIG_LENGTH as BAI_LIMIT
+
+logging.basicConfig(level=logging.ERROR, format="%(message)s")
+
+
+def write_sorted_bam(path, contig_length, read_start):
+    """Write a coordinate-sorted single-read BAM with one contig.
+
+    The contig is declared `contig_length` bp long (only the header carries the
+    length; no reference sequence is stored), and one mapped read is placed at
+    `read_start`. Placing a read near the end of a >2**29 contig is what makes a
+    BAI index actually impossible, so this exercises the real failure mode.
+    """
+    header = {
+        "HD": {"VN": "1.6", "SO": "coordinate"},
+        "SQ": [{"SN": "chrBig", "LN": contig_length}],
+    }
+    with pysam.AlignmentFile(path, "wb", header=header) as out:
+        read = pysam.AlignedSegment(out.header)
+        read.query_name = "read1"
+        read.query_sequence = "ACGT" * 10
+        read.flag = 0
+        read.reference_id = 0
+        read.reference_start = read_start
+        read.mapping_quality = 60
+        read.cigarstring = "40M"
+        read.query_qualities = pysam.qualitystring_to_array("I" * 40)
+        out.write(read)
+
+
+class IndexSelectionTests(unittest.TestCase):
+    """ensure_bam_index picks BAI for short contigs and CSI for long ones."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.bam = os.path.join(self.tmpdir, "sample.bam")
+
+    def tearDown(self):
+        for name in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, name))
+        os.rmdir(self.tmpdir)
+
+    def test_short_contig_builds_bai(self):
+        """A normal (sub-2**29) contig is indexed as BAI, unchanged behavior."""
+        write_sorted_bam(self.bam, contig_length=100_000, read_start=1000)
+        self.assertFalse(samutil._bam_needs_csi(self.bam, pysam))
+        index_fname = samutil.ensure_bam_index(self.bam)
+        self.assertEqual(index_fname, self.bam + ".bai")
+        self.assertTrue(os.path.isfile(index_fname))
+        self.assertFalse(os.path.isfile(self.bam + ".csi"))
+
+    def test_long_contig_builds_usable_csi(self):
+        """A >2**29 contig is auto-indexed as CSI and remains queryable."""
+        write_sorted_bam(self.bam, contig_length=600_000_000, read_start=599_000_000)
+        self.assertTrue(samutil._bam_needs_csi(self.bam, pysam))
+        index_fname = samutil.ensure_bam_index(self.bam)
+        self.assertEqual(index_fname, self.bam + ".csi")
+        self.assertTrue(os.path.isfile(index_fname))
+        self.assertFalse(os.path.isfile(self.bam + ".bai"))
+        # The CSI index must actually work for downstream pysam operations.
+        with pysam.AlignmentFile(self.bam, "rb") as af:
+            self.assertEqual(sum(1 for _ in af.fetch("chrBig")), 1)
+        idxstats = pysam.idxstats(self.bam)
+        self.assertIn("chrBig\t600000000\t1\t0", idxstats)
+
+    def test_contig_exactly_at_limit_uses_bai(self):
+        """A contig of length exactly 2**29 still fits BAI (strict-> threshold)."""
+        write_sorted_bam(self.bam, contig_length=BAI_LIMIT, read_start=BAI_LIMIT - 1000)
+        self.assertFalse(samutil._bam_needs_csi(self.bam, pysam))
+        index_fname = samutil.ensure_bam_index(self.bam)
+        self.assertEqual(index_fname, self.bam + ".bai")
+        self.assertTrue(os.path.isfile(index_fname))
+
+    def test_existing_fresh_csi_is_reused(self):
+        """A CSI index newer than the BAM is reused without rebuilding."""
+        write_sorted_bam(self.bam, contig_length=600_000_000, read_start=599_000_000)
+        pysam.index("-c", self.bam)
+        csi = self.bam + ".csi"
+        # The freshly built CSI is newer than the BAM, so it must be reused as-is;
+        # an unwanted rebuild would rewrite the file and change its mtime.
+        before_ns = os.stat(csi).st_mtime_ns
+        index_fname = samutil.ensure_bam_index(self.bam)
+        self.assertEqual(index_fname, csi)
+        self.assertEqual(os.stat(csi).st_mtime_ns, before_ns)
+
+    def test_stale_bai_removed_when_csi_built(self):
+        """A leftover .bai is deleted after a CSI index is built for the BAM."""
+        write_sorted_bam(self.bam, contig_length=600_000_000, read_start=599_000_000)
+        # A leftover .bai from a prior alignment; the CSI rebuild must remove it.
+        stale_bai = self.bam + ".bai"
+        with open(stale_bai, "wb") as handle:
+            handle.write(b"BAI\x01")
+        index_fname = samutil.ensure_bam_index(self.bam)
+        self.assertEqual(index_fname, self.bam + ".csi")
+        self.assertFalse(os.path.isfile(stale_bai))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #817.

`ensure_bam_index` previously built and recognized only BAI indexes. The
BAI format cannot address reference contigs longer than 2**29 bp (about
537 Mb), so BAM files from long-chromosome genomes — wheat, barley
(chr2H ~665 Mb), salamander — failed to index entirely:

```
[E::hts_idx_check_range] Region X..Y cannot be stored in a bai index. Try using a csi index
```

CNVkit now reads the BAM header and, when any reference contig exceeds the
BAI limit, builds a CSI index (`samtools index -c`) automatically. Typical
human references (hg19/hg38, longest contig ~250 Mb) are unaffected: they
still get a `.bai`, byte-for-byte as before. An existing `.csi` is
discovered and reused just like `.bai`, and a stale `.bai` is removed after
a CSI is built so it cannot shadow the new index.

## Tests

New `test/test_samutil.py`:

- short contig → BAI is built and returned;
- contig > 2**29 → a CSI index is built, returned, and usable (`fetch` and
  `idxstats` work through a read positioned beyond the BAI coordinate limit);
- contig of exactly 2**29 → BAI (verifies the strict threshold);
- a fresh `.csi` is reused without rebuilding;
- a leftover `.bai` is removed once a CSI is built.

Existing `coverage` and `batch` tests pass unchanged, confirming the BAI
path is unregressed.

## Clinical impact

None. No change to numerical output or output file formats (`.cnr`,
`.cns`, `.cnn`, SEG, VCF) for existing workflows; the BAI code path is
unchanged. This only enables genomes that previously could not be indexed
at all.
