### PR TITLE
diagram: --gene label filter, directional thresholds, graceful reversed intervals

### DIFF
--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -1504,6 +1504,23 @@ def _cmd_diagram(args: argparse.Namespace) -> None:
             "the '-s' option, or both. You did neither."
         )
 
+    # Directional thresholds (--threshold-low/--threshold-high) are mutually
+    # exclusive with the symmetric -t/--threshold. -t defaults to None so an
+    # explicit value can be distinguished from the documented 0.5 default.
+    threshold = args.threshold if args.threshold is not None else 0.5
+    if args.threshold_low is not None or args.threshold_high is not None:
+        if args.threshold is not None:
+            raise ValueError(
+                "-t/--threshold (symmetric) is mutually exclusive with the "
+                "directional --threshold-low/--threshold-high options."
+            )
+        # Directional bounds drive labeling; the symmetric `threshold` is unused.
+        threshold_low = args.threshold_low
+        threshold_high = args.threshold_high
+    else:
+        threshold_low = threshold_high = None
+    gene_names = _split_gene_names(args.gene)
+
     cnarr = read_cna(args.filename) if args.filename else None
     segarr = read_cna(args.segment) if args.segment else None
     if args.adjust_xy:
@@ -1521,14 +1538,25 @@ def _cmd_diagram(args: argparse.Namespace) -> None:
     outfname = diagram.create_diagram(
         cnarr,  # type: ignore[arg-type]
         segarr,  # type: ignore[arg-type]
-        args.threshold,
+        threshold,
         args.min_probes,
         args.output,
         args.chromosome,
         args.title,
         args.show_labels,
+        threshold_low=threshold_low,
+        threshold_high=threshold_high,
+        gene_names=gene_names,
     )
     logging.info("Wrote %s", outfname)
+
+
+def _split_gene_names(gene: str | None) -> list[str] | None:
+    """Split the --gene value (comma-separated) into a list of gene names."""
+    if not gene:
+        return None
+    names = [name.strip() for name in gene.split(",") if name.strip()]
+    return names or None
 
 
 P_diagram = AP_subparsers.add_parser("diagram", help=_cmd_diagram.__doc__)
@@ -1552,8 +1580,32 @@ P_diagram.add_argument(
     "-t",
     "--threshold",
     type=float,
-    default=0.5,
-    help="""Copy number change threshold to label genes. [Default: %(default)s]""",
+    default=None,
+    help="""Symmetric copy number change threshold to label genes: label when
+            abs(log2) is at or above this value. [Default: 0.5]""",
+)
+P_diagram.add_argument(
+    "--threshold-high",
+    type=float,
+    metavar="LOG2",
+    help="""Label only gain segments with log2 ratio at or above this value.
+            Directional; mutually exclusive with -t/--threshold.""",
+)
+P_diagram.add_argument(
+    "--threshold-low",
+    type=float,
+    metavar="LOG2",
+    help="""Label only loss segments with log2 ratio at or below this value
+            (typically negative). Directional; mutually exclusive with
+            -t/--threshold.""",
+)
+P_diagram.add_argument(
+    "--gene",
+    metavar="GENE",
+    help="""Name of gene or genes (comma-separated) to label, among those passing
+            the threshold. Restricts diagram's default behavior of labeling every
+            gene that meets the threshold. (Note: -g is the deprecated alias for
+            --sample-sex, so --gene has no short form here, unlike scatter.)""",
 )
 P_diagram.add_argument(
     "-m",

--- a/cnvlib/diagram.py
+++ b/cnvlib/diagram.py
@@ -45,8 +45,22 @@ def create_diagram(
     show_range: str | None = None,
     title: str | None = None,
     show_labels: bool = True,
+    *,
+    threshold_low: float | None = None,
+    threshold_high: float | None = None,
+    gene_names: list[str] | None = None,
 ) -> str:
-    """Create the diagram."""
+    """Create the diagram.
+
+    Gene labels are drawn for segments whose log2 ratio passes a threshold.
+    By default the symmetric ``threshold`` is used (label when
+    ``abs(log2) >= threshold``). Passing ``threshold_high`` and/or
+    ``threshold_low`` switches to directional thresholds: label gains at or
+    above ``threshold_high`` and losses at or below ``threshold_low``; a side
+    left as ``None`` disables labeling in that direction. ``gene_names``, if
+    given, restricts labels to those genes (among the ones passing the
+    threshold), dropping co-binned neighbors.
+    """
     if cnarr and segarr:
         do_both = True  # Draw segments on left, probes on right.
         cnarr_is_seg = False  # Are probes actually the segmented values?
@@ -71,7 +85,18 @@ def create_diagram(
             cnarr = cnarr.in_range(chrom=chrom, start=None, end=None)
         if segarr:
             segarr = segarr.in_range(chrom=chrom, start=None, end=None)
-    gene_labels = _get_gene_labels(cnarr, segarr, cnarr_is_seg, threshold, min_probes)
+    # The symmetric -t/--threshold maps to the pair (-threshold, +threshold),
+    # for which "log2 >= high or log2 <= low" is exactly "abs(log2) >= threshold"
+    # -- so the default output is unchanged. Directional flags override one or
+    # both sides; a None side disables labeling in that direction.
+    low: float | None
+    high: float | None
+    if threshold_low is None and threshold_high is None:
+        low, high = -threshold, threshold
+    else:
+        low, high = threshold_low, threshold_high
+    gene_labels = _get_gene_labels(cnarr, segarr, cnarr_is_seg, low, high, min_probes)
+    requested = set(gene_names) if gene_names else None
 
     # NB: If multiple segments cover the same gene (gene contains breakpoints),
     # all those segments are marked as "hits".  We'll uniquify them.
@@ -85,21 +110,19 @@ def create_diagram(
     if not cnarr_is_seg:
         cnarr = cnarr.squash_genes()
     for row in cnarr:
-        if (
-            row.start - 1 >= 0 and row.end <= chrom_sizes[row.chromosome]
-        ):  # Sanity check
+        span = _feature_span(row.start, row.end, chrom_sizes[row.chromosome])
+        if span is not None:
+            lo, hi = span
             if show_labels and row.gene in gene_labels and row.gene not in seen_genes:
                 seen_genes.add(row.gene)
-                feat_name = row.gene
-                if "," in feat_name:
-                    # TODO - line-wrap multi-gene labels (reportlab won't do \n)
-                    feat_name = feat_name.replace(",", ", ")
+                # TODO - line-wrap multi-gene labels (reportlab won't do \n)
+                feat_name = _gene_feature_label(row.gene, requested)
             else:
                 feat_name = None
             features[row.chromosome].append(
                 (
-                    row.start - 1,
-                    row.end,
+                    lo,
+                    hi,
                     strand,
                     feat_name,
                     colors.Color(*plots.cvg2rgb(row.log2, not cnarr_is_seg)),
@@ -109,13 +132,13 @@ def create_diagram(
         # Draw segments in the left half of each chromosome (strand -1)
         for chrom, segrows in segarr.by_chromosome():
             for srow in segrows:
-                if (
-                    srow.start - 1 >= 0 and srow.end <= chrom_sizes[chrom]
-                ):  # Sanity check
+                span = _feature_span(srow.start, srow.end, chrom_sizes[chrom])
+                if span is not None:
+                    lo, hi = span
                     features[chrom].append(
                         (
-                            srow.start - 1,
-                            srow.end,
+                            lo,
+                            hi,
                             -1,
                             None,
                             colors.Color(*plots.cvg2rgb(srow.log2, False)),
@@ -137,27 +160,94 @@ def _get_gene_labels(
     cnarr: CopyNumArray,
     segarr: CopyNumArray,
     cnarr_is_seg: bool,
-    threshold: float,
+    threshold_low: float | None,
+    threshold_high: float | None,
     min_probes: int,
 ) -> list[Any]:
-    """Label genes where copy ratio value exceeds threshold."""
+    """Label genes whose copy ratio passes a directional threshold.
+
+    A gene qualifies when its log2 value is at or above ``threshold_high``
+    (a gain) or at or below ``threshold_low`` (a loss). Either bound may be
+    ``None`` to disable labeling in that direction.
+    """
     if cnarr_is_seg:
-        # Only segments (.cns)
-        sel = cnarr.data[
-            (cnarr.data.log2.abs() >= threshold)
-            & ~cnarr.data.gene.isin(params.IGNORE_GENE_NAMES)
-        ]
+        # Only segments (.cns): build the directional mask directly.
+        mask = cnarr.data["log2"].map(
+            lambda v: _passes(v, threshold_low, threshold_high)
+        )
+        sel = cnarr.data[mask & ~cnarr.data.gene.isin(params.IGNORE_GENE_NAMES)]
         rows = sel.itertuples(index=False)
         probes_attr = "probes"
     elif segarr:
-        # Both segments and bin-level ratios
-        rows = reports.gene_metrics_by_segment(cnarr, segarr, threshold)
+        # Both segments and bin-level ratios. gene_metrics_by_segment filters on
+        # abs(log2) >= t, so feed it the least-restrictive magnitude covering
+        # both bounds and refine the direction afterward.
+        rows = (
+            row
+            for row in reports.gene_metrics_by_segment(
+                cnarr, segarr, _min_magnitude(threshold_low, threshold_high)
+            )
+            if _passes(row.log2, threshold_low, threshold_high)
+        )
         probes_attr = "segment_probes"
     else:
         # Only bin-level ratios (.cnr)
-        rows = reports.gene_metrics_by_gene(cnarr, threshold)
+        rows = (
+            row
+            for row in reports.gene_metrics_by_gene(
+                cnarr, _min_magnitude(threshold_low, threshold_high)
+            )
+            if _passes(row.log2, threshold_low, threshold_high)
+        )
         probes_attr = "probes"
     return [row.gene for row in rows if getattr(row, probes_attr) >= min_probes]
+
+
+def _passes(
+    log2: float, threshold_low: float | None, threshold_high: float | None
+) -> bool:
+    """True if ``log2`` is a gain (>= high) or loss (<= low); None disables a side."""
+    return (threshold_high is not None and log2 >= threshold_high) or (
+        threshold_low is not None and log2 <= threshold_low
+    )
+
+
+def _min_magnitude(threshold_low: float | None, threshold_high: float | None) -> float:
+    """Least-restrictive symmetric cutoff covering both directional bounds."""
+    mags = [abs(t) for t in (threshold_low, threshold_high) if t is not None]
+    return min(mags) if mags else 0.0
+
+
+def _feature_span(start: int, end: int, chrom_size: int) -> tuple[int, int] | None:
+    """0-based half-open span ``[lo, hi)`` for a feature, or None if out of range.
+
+    Normalizes reverse-oriented intervals: reverse-direction PCR primers are
+    sometimes stored with ``start > end`` in the input BED, so the interval is
+    taken to span ``[min, max]`` regardless of column order. Biopython's
+    chromosome renderer asserts ``0 <= start <= end <= length``, so an
+    un-normalized reversed interval would otherwise crash the diagram.
+    """
+    lo = min(start, end) - 1
+    hi = max(start, end)
+    if lo >= 0 and hi <= chrom_size:
+        return lo, hi
+    return None
+
+
+def _gene_feature_label(gene: str, requested: set[str] | None) -> str | None:
+    """Build the on-plot label for a qualifying segment or gene.
+
+    Without ``requested`` (no --gene), expand the bin's comma-joined gene
+    string for display, preserving legacy output. With ``requested``, show only
+    the requested genes -- dropping co-binned neighbors the user did not ask for
+    and collapsing duplicate names.
+    """
+    if requested is None:
+        return gene.replace(",", ", ")
+    names = list(
+        dict.fromkeys(n.strip() for n in gene.split(",") if n.strip() in requested)
+    )
+    return ", ".join(names) if names else None
 
 
 def build_chrom_diagram(

--- a/cnvlib/plots.py
+++ b/cnvlib/plots.py
@@ -94,7 +94,11 @@ def chromosome_sizes(
     """Create an ordered mapping of chromosome names to sizes."""
     chrom_sizes = collections.OrderedDict()
     for chrom, rows in probes.by_chromosome():
-        chrom_sizes[chrom] = rows["end"].max()
+        # Use the rightmost coordinate from either column so reverse-oriented
+        # intervals (start > end, e.g. reverse-direction PCR primers) still set
+        # the chromosome's extent. For well-formed intervals end.max() already
+        # dominates, so this is a no-op there.
+        chrom_sizes[chrom] = max(rows["end"].max(), rows["start"].max())
         if to_mb:
             chrom_sizes[chrom] *= MB
     return chrom_sizes

--- a/doc/plots.rst
+++ b/doc/plots.rst
@@ -257,8 +257,33 @@ extremely cluttered with hundreds or thousands of genes labeled.
 You can reduce the number of labels by using a higher threshold (``diagram -t``)
 to limit labeling to deep deletions and high-level amplifications. The
 :ref:`genemetrics` command can help you determine the log2 value of genes of
-interest, and then a ``-t`` value slightly below that will disply only
-alterations at least that exteme.
+interest, and then a ``-t`` value slightly below that will display only
+alterations at least that extreme.
+
+The ``-t``/``--threshold`` option is symmetric: it labels any gene whose
+absolute log2 ratio meets the threshold. To label only gains or only losses,
+use the directional options instead:
+
+- ``--threshold-high`` labels only gain segments at or above the given log2
+  ratio (e.g. ``--threshold-high 0.5`` shows amplifications only).
+- ``--threshold-low`` labels only loss segments at or below the given log2
+  ratio, which is normally negative (e.g. ``--threshold-low -0.5`` shows
+  deletions only). Setting it very low, such as ``--threshold-low -25``,
+  suppresses loss labels entirely.
+
+Both directional options may be given together to apply asymmetric cutoffs to
+gains and losses. The directional options are mutually exclusive with the
+symmetric ``-t``/``--threshold``.
+
+To label a specific set of genes rather than every gene that meets the
+threshold, pass their names (comma-separated) to ``--gene``::
+
+    cnvkit.py diagram -s Sample.cns --gene MYC,ERBB2,KRAS
+
+Only the named genes are labeled, among those that pass the threshold; other
+genes co-binned with a requested gene are not shown. (Unlike :ref:`scatter`,
+``diagram`` has no ``-g`` short form for this option, because ``-g`` is the
+deprecated alias for ``--sample-sex``.)
 
 To reduce the number of false-positive calls in the .cns file (see
 :doc:`calling`), consider:

--- a/test/test_plots.py
+++ b/test/test_plots.py
@@ -74,7 +74,7 @@ class PlotTests(unittest.TestCase):
 
     def test_scatter_genome_y_floor(self):
         """Genome-wide autoscale floors y_min so a single deep homozygous
-        deletion can't compress the whole plot (gh#385)."""
+        deletion can't compress the whole plot (#385)."""
         # lazy: defer matplotlib import to keep headless test collection fast
         from matplotlib import pyplot  # noqa: PLC0415
 
@@ -229,7 +229,7 @@ class GeneCoordsTests(unittest.TestCase):
     """Tests for plots.gene_coords_by_name gene-label selection."""
 
     def test_gene_coords_by_name(self):
-        """`-g` labels only requested genes, not co-binned neighbors (gh#458).
+        """`-g` labels only requested genes, not co-binned neighbors (#458).
 
         A bin whose `gene` column packs several names (e.g. "ERBB2,MIR4728")
         must not surface the unrequested neighbor (MIR4728) when only ERBB2

--- a/test/test_plots.py
+++ b/test/test_plots.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Tests for plotting commands: scatter, heatmap, diagram."""
 
+import ast
+import inspect
 import logging
 import os
 import shutil
@@ -255,3 +257,187 @@ class GeneCoordsTests(unittest.TestCase):
         ]:
             names_seen.update(label.split(","))
         self.assertEqual(names_seen, {"ERBB2", "MIR4728"})
+
+
+class DiagramGeneLabelTests(unittest.TestCase):
+    """`diagram` --gene and directional --threshold-low/-high (#248)."""
+
+    @staticmethod
+    def _segments():
+        """A .cns with one clear gain, one clear loss, and a co-binned label."""
+        seg = cnary.CopyNumArray.from_rows(
+            [
+                ["chr1", 100, 200, "GAINER", 1.0],
+                ["chr2", 100, 200, "LOSER", -1.0],
+                ["chr3", 100, 200, "FLAT", 0.1],
+                ["chr17", 100, 200, "NF1,ERBB2,ERBB2,MIR4728", 0.8],
+            ],
+            columns=["chromosome", "start", "end", "gene", "log2"],
+        )
+        seg.data["probes"] = [5, 5, 5, 5]
+        return seg
+
+    def test_symmetric_threshold_unchanged(self):
+        """Default symmetric threshold labels both gains and losses."""
+        seg = self._segments()
+        labels = diagram._get_gene_labels(seg, None, True, -0.5, 0.5, 3)
+        self.assertIn("GAINER", labels)
+        self.assertIn("LOSER", labels)
+        self.assertNotIn("FLAT", labels)
+
+    def test_threshold_high_labels_only_gains(self):
+        """--threshold-high (loss side disabled) labels only gains."""
+        seg = self._segments()
+        labels = diagram._get_gene_labels(seg, None, True, None, 0.5, 3)
+        self.assertIn("GAINER", labels)
+        self.assertNotIn("LOSER", labels)
+
+    def test_threshold_low_labels_only_losses(self):
+        """--threshold-low (gain side disabled) labels only losses."""
+        seg = self._segments()
+        labels = diagram._get_gene_labels(seg, None, True, -0.5, None, 3)
+        self.assertIn("LOSER", labels)
+        self.assertNotIn("GAINER", labels)
+
+    def test_threshold_low_suppresses_deletions(self):
+        """A very low loss cutoff (e.g. -25) suppresses all loss labels while a
+        gain cutoff still surfaces gains (maintainer's 2018 example)."""
+        seg = self._segments()
+        labels = diagram._get_gene_labels(seg, None, True, -25.0, 0.5, 3)
+        self.assertIn("GAINER", labels)
+        self.assertNotIn("LOSER", labels)
+
+    def test_min_probes_filters(self):
+        """Below-min-probes segments are not labeled regardless of threshold."""
+        seg = self._segments()
+        seg.data["probes"] = [1, 1, 1, 1]
+        labels = diagram._get_gene_labels(seg, None, True, -0.5, 0.5, 3)
+        self.assertEqual(labels, [])
+
+    def test_gene_feature_label_default(self):
+        """Without -g, the comma-joined gene string is expanded verbatim."""
+        self.assertEqual(
+            diagram._gene_feature_label("NF1,ERBB2,ERBB2,MIR4728", None),
+            "NF1, ERBB2, ERBB2, MIR4728",
+        )
+        self.assertEqual(diagram._gene_feature_label("GAINER", None), "GAINER")
+
+    def test_gene_feature_label_restricts_to_requested(self):
+        """-g shows only requested genes, dropping co-binned neighbors and dups."""
+        # ERBB2 requested: NF1/MIR4728 neighbors dropped; duplicate ERBB2 collapsed
+        self.assertEqual(
+            diagram._gene_feature_label("NF1,ERBB2,ERBB2,MIR4728", {"ERBB2"}),
+            "ERBB2",
+        )
+        # Multiple requested genes sharing the bin all appear, in order
+        self.assertEqual(
+            diagram._gene_feature_label("NF1,ERBB2,MIR4728", {"ERBB2", "MIR4728"}),
+            "ERBB2, MIR4728",
+        )
+        # A segment with no requested gene yields no label
+        self.assertIsNone(diagram._gene_feature_label("STARD3", {"ERBB2"}))
+        # Whitespace around comma-separated names is tolerated when matching
+        self.assertEqual(
+            diagram._gene_feature_label("NF1, ERBB2", {"ERBB2"}),
+            "ERBB2",
+        )
+
+    def test_create_diagram_smoke_with_flags(self):
+        """End-to-end: the new flags drive create_diagram and write a PDF."""
+        seg = self._segments()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, "diagram.pdf")
+            result = diagram.create_diagram(
+                None,
+                seg,
+                0.5,
+                3,
+                out,
+                title="Test sample",
+                threshold_high=0.5,
+                gene_names=["ERBB2"],
+            )
+            self.assertTrue(os.path.exists(result))
+
+    def test_cmd_diagram_threshold_mutually_exclusive(self):
+        """Explicit -t with a directional threshold is rejected up front."""
+        args = commands.parse_args(
+            ["diagram", "formats/amplicon.cns", "-t", "0.5", "--threshold-low", "-0.5"]
+        )
+        with self.assertRaises(ValueError):
+            args.func(args)
+
+    def test_cmd_diagram_plumbs_new_args_to_create_diagram(self):
+        """`_cmd_diagram` forwards gene_names and directional thresholds.
+
+        AST-walk plumbing check (no fixtures): assert the create_diagram call
+        site passes the new keyword arguments, so a dropped kwarg fails fast.
+        """
+        tree = ast.parse(inspect.getsource(commands._cmd_diagram))
+        kwargs_seen = set()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "create_diagram"
+            ):
+                kwargs_seen = {kw.arg for kw in node.keywords}
+        self.assertLessEqual(
+            {"threshold_low", "threshold_high", "gene_names"}, kwargs_seen
+        )
+
+
+class DiagramCoordinateTests(unittest.TestCase):
+    """diagram renders reverse-oriented intervals (start > end) gracefully.
+
+    Reverse-direction PCR primers are sometimes saved in the input BED with
+    start > end; CNVkit should treat the interval as spanning [min, max] rather
+    than crashing Biopython's renderer, which asserts start <= end <= length.
+    """
+
+    def test_feature_span_normalizes_orientation(self):
+        # Forward interval: 1-based start -> 0-based half-open, unchanged
+        self.assertEqual(diagram._feature_span(100, 200, 300), (99, 200))
+        # Reversed interval (start > end): normalized to [min-1, max)
+        self.assertEqual(diagram._feature_span(400, 300, 400), (299, 400))
+        # Out of range (beyond chromosome) is rejected
+        self.assertIsNone(diagram._feature_span(100, 500, 300))
+        # start == 0 -> lo == -1 is rejected, preserving prior lower-bound guard
+        self.assertIsNone(diagram._feature_span(0, 50, 300))
+
+    def test_chromosome_sizes_counts_reversed_intervals(self):
+        seg = cnary.CopyNumArray.from_rows(
+            [
+                ["chr1", 100, 200, "FWD", 0.0],
+                ["chr1", 400, 300, "REV", 0.0],  # reversed: rightmost pos is 400
+            ],
+            columns=["chromosome", "start", "end", "gene", "log2"],
+        )
+        sizes = plots.chromosome_sizes(seg)
+        self.assertEqual(sizes["chr1"], 400)
+
+    def test_create_diagram_renders_reversed_interval(self):
+        seg = cnary.CopyNumArray.from_rows(
+            [
+                ["chr1", 100, 200, "FWD", 1.0],
+                ["chr1", 400, 300, "REV", 1.0],  # reverse-primer style
+            ],
+            columns=["chromosome", "start", "end", "gene", "log2"],
+        )
+        seg.data["probes"] = [5, 5]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, "diagram.pdf")
+            # Must not raise the Biopython start<=end<=length assertion
+            result = diagram.create_diagram(None, seg, 0.5, 3, out, title="t")
+            self.assertTrue(os.path.exists(result))
+
+    def test_create_diagram_amplicon_fixture(self):
+        """Regression: the amplicon fixture has several reverse-oriented
+        segments (e.g. chr2 212578209-212576985) that previously crashed the
+        renderer. It must now produce a diagram."""
+        cnarr = cnvlib.read("formats/amplicon.cnr")
+        segarr = cnvlib.read("formats/amplicon.cns")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, "diagram.pdf")
+            result = diagram.create_diagram(cnarr, segarr, 0.5, 3, out)
+            self.assertTrue(os.path.exists(result))


### PR DESCRIPTION
## Summary

Extends `cnvkit.py diagram` with finer control over gene labeling, plus a robustness fix for reverse-oriented input intervals.

- **`--gene MYC,ERBB2`** — label only the named genes among those passing the threshold, dropping co-binned neighbors. This is the original request in #248. Mirrors `scatter`'s `--gene` (singular; `-g` stays the deprecated `--sample-sex` alias on `diagram`, so there is no short form).
- **`--threshold-low` / `--threshold-high`** — directional log2 cutoffs, mutually exclusive with the symmetric `-t/--threshold`. Label gains at or above `--threshold-high` and losses at or below `--threshold-low`; omitting a side suppresses labels in that direction. For example, `--threshold-high 0.5` labels gains only, and `--threshold-low -25` drops deletion labels while gains still surface.
- **Graceful reverse-oriented intervals** — intervals stored with `start > end` (e.g. reverse-direction PCR primers saved that way in the input BED) are now taken to span `[min, max]` rather than crashing Biopython's chromosome renderer, which asserts `0 <= start <= end <= length`.

## Output stability

The symmetric threshold maps internally to the directional pair `(-t, +t)`, for which `log2 >= high or log2 <= low` is exactly `abs(log2) >= threshold`. Default `diagram` invocations therefore produce unchanged output; the new behavior is opt-in via the new flags. No `.cnr`/`.cns`/`.cnn`/SEG/VCF formats are touched.

## Tests

14 new tests in `test/test_plots.py` covering symmetric-default equivalence, each directional mode, the `-t`/directional mutual-exclusion guard, `--gene` filtering (including whitespace tolerance and co-binned-neighbor dropping), reverse-interval coordinate normalization, and an end-to-end render. An AST-walk plumbing test pins the new kwargs through `_cmd_diagram` → `create_diagram`. Full plots suite passes; ruff and mypy clean.

## Docs

`doc/plots.rst` "Reducing cluttered gene labels" documents the new flags.

Fixes #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)