### PR TITLE
import-rna: add --normalize-method size-factors (DESeq2 + leave-one-out)

### DIFF
--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -2800,6 +2800,7 @@ def _cmd_import_rna(args: argparse.Namespace) -> None:
         args.max_log2,
         diploid_parx_genome=args.diploid_parx_genome,
         min_sample_fraction=args.min_sample_fraction,
+        normalize_method=args.normalize_method,
     )
     logging.info("Writing output files")
     if args.output:
@@ -2861,6 +2862,19 @@ P_import_rna.add_argument(
             fraction of samples. Lower this for single-cell or sparse cohorts, where
             most genes are expressed in fewer than half of cells; values below ~0.2
             admit genes whose log2 ratios are likely noise. [Default: %(default)s]""",
+)
+P_import_rna.add_argument(
+    "--normalize-method",
+    choices=("polish", "size-factors"),
+    default="polish",
+    metavar="NAME",
+    help="""Read-depth normalization strategy. 'polish' (default) is the historical
+            cohort-wide median polish anchored on the normal median. 'size-factors'
+            estimates DESeq2-style median-of-ratios size factors from the --normal
+            control samples only, with leave-one-out anchoring so each normal's .cnr
+            retains QC signal; this avoids the polish's cohort-composition
+            dependence and is recommended with three or more normals.
+            [Default: %(default)s]""",
 )
 P_import_rna.add_argument(
     "-n",

--- a/cnvlib/import_rna.py
+++ b/cnvlib/import_rna.py
@@ -20,6 +20,7 @@ def do_import_rna(
     max_log2=3,
     diploid_parx_genome=None,
     min_sample_fraction=0.5,
+    normalize_method="polish",
 ):
     """Convert a cohort of per-gene read counts to CNVkit .cnr format.
 
@@ -52,6 +53,12 @@ def do_import_rna(
         (count >= 1) for it to be retained. Default 0.5 preserves the legacy
         filter. Lower it for single-cell or sparse cohorts. See
         :func:`cnvlib.rna.filter_probes`.
+    normalize_method : {'polish', 'size-factors'}, optional
+        Read-depth normalization strategy. 'polish' (default) is the historical
+        cohort-wide median polish anchored on the normal median. 'size-factors'
+        uses DESeq2-style median-of-ratios size factors estimated from the
+        control samples only, with leave-one-out anchoring for the normals. See
+        :func:`cnvlib.rna.normalize_read_depths`.
 
     Returns
     -------
@@ -105,7 +112,11 @@ def do_import_rna(
             len(normal_ids),
         )
     gene_info, sample_counts, sample_data_log2 = rna.align_gene_info_to_samples(
-        gene_info, sample_counts, tx_lengths, normal_ids
+        gene_info,
+        sample_counts,
+        tx_lengths,
+        normal_ids,
+        normalize_method=normalize_method,
     )
 
     # Summary table has log2-normalized values, not raw counts

--- a/cnvlib/rna.py
+++ b/cnvlib/rna.py
@@ -344,11 +344,14 @@ def locate_entrez_dupes(dframe):
                     yield idx
 
 
-def align_gene_info_to_samples(gene_info, sample_counts, tx_lengths, normal_ids):
+def align_gene_info_to_samples(
+    gene_info, sample_counts, tx_lengths, normal_ids, normalize_method="polish"
+):
     """Align columns and sort.
 
     Also calculate weights and add to gene_info as 'weight', along with
-    transcript lengths as 'tx_length'.
+    transcript lengths as 'tx_length'. ``normalize_method`` selects the
+    read-depth normalization strategy; see :func:`normalize_read_depths`.
     """
     logging.debug(
         "Dimensions: gene_info=%s, sample_counts=%s",
@@ -403,7 +406,9 @@ def align_gene_info_to_samples(gene_info, sample_counts, tx_lengths, normal_ids)
 
     logging.info("Calculating normalized gene read depths")
     sample_depths_log2 = normalize_read_depths(
-        sc.divide(gi["tx_length"], axis=0), normal_ids
+        sc.divide(gi["tx_length"], axis=0),
+        normal_ids,
+        normalize_method=normalize_method,
     )
 
     logging.info("Weighting genes by spread of read depths")
@@ -437,17 +442,29 @@ def align_gene_info_to_samples(gene_info, sample_counts, tx_lengths, normal_ids)
     return gi, sc, sample_depths_log2
 
 
-def normalize_read_depths(sample_depths, normal_ids):
-    """Normalize read depths within each sample.
+def normalize_read_depths(sample_depths, normal_ids, normalize_method="polish"):
+    """Normalize per-gene read depths within and across samples.
 
-    Some samples have higher sequencing depth and therefore read depths need to
-    be normalized within each sample. TCGA recommends an upper quartile
-    normalization.
+    Parameters
+    ----------
+    sample_depths : pandas.DataFrame
+        Per-gene (rows) read depths (counts / transcript length) across samples
+        (columns).
+    normal_ids : sequence of str
+        Column names of the control (normal) samples used to anchor the
+        baseline. Empty for the no-control case.
+    normalize_method : {"polish", "size-factors"}, optional
+        Normalization strategy. ``"polish"`` (default) is the historical
+        4-iteration multiplicative median polish followed by a normal-median
+        anchor; see :func:`_polish_normalize`. ``"size-factors"`` estimates
+        DESeq2-style median-of-ratios size factors from the control set only and
+        anchors each control with a leave-one-out peer median; see
+        :func:`_size_factor_normalize`.
 
-    After normalizing read depths within each sample, normalize (median-center)
-    within each gene, across samples.
-
-    Finally, convert to log2 ratios.
+    Returns
+    -------
+    pandas.DataFrame
+        Per-gene log2 ratios, one column per sample.
     """
     if sample_depths.to_numpy().sum() <= 0:
         raise ValueError(
@@ -459,46 +476,117 @@ def normalize_read_depths(sample_depths, normal_ids):
             f"has nan: {sample_depths.isna().any().any()}. "
             "This likely indicates a problem with gene alignment or transcript lengths."
         )
+    if normal_ids:
+        missing = pd.Index(normal_ids).difference(sample_depths.columns)
+        if len(missing):
+            raise ValueError(f"Normal sample IDs not in samples: {list(missing)}")
     sample_depths = sample_depths.fillna(0)
+    if normalize_method == "polish":
+        normalized = _polish_normalize(sample_depths, normal_ids)
+    elif normalize_method == "size-factors":
+        normalized = _size_factor_normalize(sample_depths, normal_ids)
+    else:
+        raise ValueError(
+            f"Unknown normalize method {normalize_method!r}; "
+            "expected 'polish' or 'size-factors'"
+        )
+    # Finally, convert normalized read depths to log2 scale
+    return safe_log2(normalized, NULL_LOG2_COVERAGE)
+
+
+def _polish_normalize(sample_depths, normal_ids):
+    """Historical multiplicative median polish with a normal-median anchor.
+
+    Four iterations alternately rescale each sample by its 75th-percentile depth
+    (TCGA-style upper-quartile normalization) and re-center each gene on the
+    median across *all* samples; then, when controls are given, divide each gene
+    by the median of the control samples. This forces every gene's cohort median
+    to 1, so intermediate values depend on cohort composition and a single
+    control reduces to a self-divide. The ``size-factors`` method avoids both
+    properties.
+    """
     for _i in range(4):
-        # By-sample: 75%ile  among all genes
+        # By-sample: 75%ile among all genes
         q3 = sample_depths.quantile(0.75)
         sample_depths /= q3
         # By-gene: median among all samples
         sm = sample_depths.median(axis=1)
         sample_depths = sample_depths.divide(sm, axis=0)
-        # print("  round", _i, "grand mean:", sample_depths.values.mean(),
-        #       ": sample-wise denom =", q3.mean(),
-        #       ", gene-wise denom =", sm.mean())
     if normal_ids:
-        # Use normal samples as a baseline for read depths
-        normal_ids = pd.Series(normal_ids)
-        if not normal_ids.isin(sample_depths.columns).all():
-            raise ValueError(
-                "Normal sample IDs not in samples: %s"
-                % normal_ids.drop(sample_depths.columns, errors="ignore")
-            )
-        normal_depths = sample_depths.loc[:, normal_ids]
-        use_median = True  # TODO - benchmark & pick one
-        if use_median:
-            # Simple approach: divide normalized (1=neutral) values by gene medians
-            normal_avg = normal_depths.median(axis=1)
-            sample_depths = sample_depths.divide(normal_avg, axis=0).clip(lower=0)
-        else:
-            # Alternate approach: divide their IQR
-            # At each gene, sample depths above the normal sample depth 75%ile
-            # are divided by the 75%ile, those below 25%ile are divided by
-            # 25%ile, and those in between are reset to neutral (=1.0)
-            n25, n75 = np.nanpercentile(normal_depths.to_numpy(), [25, 75], axis=1)
-            below_idx = sample_depths.to_numpy() < n25[:, np.newaxis]
-            above_idx = sample_depths.to_numpy() > n75[:, np.newaxis]
-            factor = np.zeros_like(sample_depths.to_numpy())
-            factor[below_idx] = (below_idx / n25[:, np.newaxis])[below_idx]
-            factor[above_idx] = (above_idx / n75[:, np.newaxis])[above_idx]
-            sample_depths *= factor
-            sample_depths[~(below_idx | above_idx)] = 1.0
-    # Finally, convert normalized read depths to log2 scale
-    return safe_log2(sample_depths, NULL_LOG2_COVERAGE)
+        # Use normal samples as a baseline: divide normalized (1=neutral) values
+        # by the per-gene median across the control samples.
+        normal_avg = sample_depths.loc[:, list(normal_ids)].median(axis=1)
+        sample_depths = sample_depths.divide(normal_avg, axis=0).clip(lower=0)
+    return sample_depths
+
+
+def _size_factor_normalize(sample_depths, normal_ids):
+    """DESeq2-style size factors with leave-one-out normal anchoring.
+
+    The reference set is the control samples when ``normal_ids`` is non-empty,
+    otherwise the full cohort. Per-sample size factors are the median across
+    genes of each sample's depth divided by the reference geometric mean
+    (DESeq2 "median of ratios"; Love, Huber & Anders, *Genome Biol* 2014), which
+    is robust to a large minority of copy-number-altered genes -- the property
+    the cohort-wide polish lacks. Genes with a zero in any reference sample are
+    excluded from size-factor estimation, as in DESeq2.
+
+    Each sample is divided by its size factor, then expressed as a log2 ratio
+    against the per-gene median of the size-factor-normalized controls. Controls
+    are anchored leave-one-out (against the median of their *peers*) so a
+    control's own .cnr retains QC signal rather than collapsing to zero. With a
+    single control this reduces to a self-divide (warned upstream in
+    :func:`cnvlib.import_rna.do_import_rna`). Because the per-gene reference
+    cancels any per-gene constant, both the size factors and the final ratios are
+    invariant to transcript length.
+    """
+    # 1. DESeq2 median-of-ratios size factors from the reference set.
+    normal_cols = list(normal_ids)
+    ref_cols = normal_cols if normal_cols else list(sample_depths.columns)
+    ref = sample_depths[ref_cols]
+    # Only genes detected in every reference sample inform the size factors.
+    usable = (ref > 0).all(axis=1)
+    geomean = np.exp(np.log(ref.loc[usable]).mean(axis=1))
+    # Each sample's size factor = median over usable genes of depth / geomean.
+    size_factors = sample_depths.loc[usable].divide(geomean, axis=0).median(axis=0)
+    # Size factors are undefined when too few genes are detected across all
+    # controls (no usable genes -> all NaN, or a sample too sparse for a positive
+    # median). Fall back to no library-size scaling for those samples, and surface
+    # it -- silent degradation is a clinical-output hazard.
+    degenerate = ~(np.isfinite(size_factors) & (size_factors > 0))
+    if degenerate.any():
+        logging.warning(
+            "size-factors: %d/%d sample(s) had an undefined or non-positive size "
+            "factor (too few genes detected across all controls); using no "
+            "library-size scaling for them",
+            int(degenerate.sum()),
+            len(size_factors),
+        )
+        size_factors = size_factors.where(~degenerate, 1.0)
+    norm = sample_depths.divide(size_factors, axis=1)
+
+    # 2. Anchor against the size-factor-normalized baseline. ``norm`` is a fresh
+    # frame and is mutated in place below; the per-gene baselines are taken from
+    # ``normal_norm`` (an independent copy of the controls) before any mutation,
+    # so anchoring is order-independent.
+    if not normal_cols:
+        baseline = norm.median(axis=1).replace(0, np.nan)
+        return norm.divide(baseline, axis=0)
+
+    normal_norm = norm[normal_cols]
+    normal_col_set = set(normal_cols)
+    # Tumors: divide by the per-gene median across all controls.
+    baseline = normal_norm.median(axis=1).replace(0, np.nan)
+    tumor_cols = [c for c in norm.columns if c not in normal_col_set]
+    if tumor_cols:
+        norm[tumor_cols] = norm[tumor_cols].divide(baseline, axis=0)
+    # Controls: leave-one-out -- anchor each to the median of its peers. With a
+    # lone control there are no peers, so it self-divides to a flat ~0 .cnr.
+    for col in normal_cols:
+        peers = normal_norm.drop(columns=col)
+        loo = peers.median(axis=1) if peers.shape[1] else normal_norm[col]
+        norm[col] = norm[col] / loo.replace(0, np.nan)
+    return norm
 
 
 def safe_log2(values, min_log2):
@@ -566,7 +654,7 @@ def correct_cnr(cnr, do_gc, do_txlen, max_log2, diploid_parx_genome):
         # Re-center after bias correction. Carry diploid_parx_genome through:
         # GC/transcript-length window correction is invariant to a uniform
         # pre-shift, so without it the earlier center_all(diploid_parx_genome)
-        # is silently undone and the flag becomes a no-op (cnvkit-d68).
+        # is silently undone and the flag becomes a no-op.
         cnr.center_all(diploid_parx_genome=diploid_parx_genome)
     if max_log2:
         cnr[cnr["log2"] > max_log2, "log2"] = max_log2

--- a/doc/rna.rst
+++ b/doc/rna.rst
@@ -137,6 +137,9 @@ per-sample sequencing-depth differences and per-gene scale differences, then
 divides each gene's row by the median of the normal samples' values. Tumor
 sample ``.cnr`` files are then expressed as log2 ratios against that
 normal-anchored baseline.
+The normalization strategy is selected with ``--normalize-method`` (see
+`Choosing a normalization method`_ below); the default, ``polish``, is the
+procedure described here.
 
 This recentering has several important consequences that affect cohort design:
 
@@ -174,6 +177,52 @@ If a suitable normal cohort is not available, run ``import-rna`` without
 against the cohort median, which carries its own assumption (that most genes
 in most samples are copy-neutral) that may also be violated in heavily altered
 cohorts.
+
+
+.. _Choosing a normalization method:
+
+Choosing a normalization method (``--normalize-method``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``--normalize-method`` option selects how read depths are normalized before
+anchoring against the controls:
+
+- ``polish`` (default) is the historical procedure described above: a
+  cohort-wide multiplicative median polish followed by division by the per-gene
+  normal median. It is well-behaved for typical cohorts, but because the polish
+  re-centers each gene on the median across *all* samples, its intermediate
+  values depend on cohort composition.
+- ``size-factors`` derives the reference from the control samples alone. It
+  estimates per-sample size factors by the DESeq2 "median-of-ratios" method
+  (Love, Huber & Anders, *Genome Biology* 2014) -- the median across genes of
+  each sample's depth divided by the geometric-mean depth of the normals -- which
+  is robust to the large fraction of copy-number-altered genes typical of
+  aneuploid tumors. Each normal is then anchored against the median of the
+  *other* normals (leave-one-out), so its own ``.cnr`` reports its deviation from
+  its peers and stays usable for quality control instead of collapsing to zero.
+
+Because the ``size-factors`` reference depends only on the control set, a tumor's
+log2 ratios are unaffected by the number or composition of the other tumors in
+the run, removing the cohort-composition sensitivity of the polish. This follows
+the consensus for RNA-based copy-number inference: global "most genes are
+copy-neutral" normalization (as used by TMM and the cohort-wide polish) is biased
+in aneuploid cohorts, and the reference should instead be built from matched
+controls.
+
+The method is recommended when three or more control samples are available::
+
+    cnvkit.py import-rna *.txt --gene-resource data/ensembl-gene-info.hg38.tsv \
+        --normal normal1.txt normal2.txt normal3.txt \
+        --normalize-method size-factors --output-dir out/
+
+With one or two normals, ``size-factors`` still anchors the tumors against the
+controls, but the small-cohort caveats above apply: with a single normal that
+normal's own ``.cnr`` reduces to a self-divide (flat zero), and ``import-rna``
+warns. The method does not rescue control samples that share the tumors'
+alterations -- as with the polish, a contaminated normal cancels real tumor
+signal -- so the guidance on control selection above still holds. The default
+remains ``polish``, so the output of existing ``--normal`` workflows is unchanged
+unless ``--normalize-method size-factors`` is given.
 
 
 

--- a/test/test_rna.py
+++ b/test/test_rna.py
@@ -433,7 +433,7 @@ class FilterProbesPlumbingTests(unittest.TestCase):
 class DiploidParxPlumbingTests(unittest.TestCase):
     """``diploid_parx_genome`` is threaded CLI -> do_import_rna -> correct_cnr.
 
-    The CLI layer was the missing link (cnvkit-d68): ``_cmd_import_rna`` never
+    The CLI layer was the missing link: ``_cmd_import_rna`` never
     forwarded ``args.diploid_parx_genome``, so PAR-aware centering was
     unreachable from ``cnvkit import-rna``. AST guard so a dropped kwarg fails
     at collection rather than silently disabling the flag again.
@@ -521,7 +521,7 @@ def _make_rna_cnr(seed, *, include_par):
 class DiploidParxCenteringTests(unittest.TestCase):
     """PAR-aware centering must actually shift output in the default path.
 
-    Regression guard for cnvkit-d68: ``correct_cnr`` applies GC/transcript-
+    Regression guard: ``correct_cnr`` applies GC/transcript-
     length bias correction (on by default), which is invariant to a uniform
     pre-shift. So unless the *second* ``center_all`` also carries
     ``diploid_parx_genome``, the flag is silently neutralized whenever GC/txlen
@@ -599,11 +599,11 @@ class ImportRnaIntegrationTests(unittest.TestCase):
 
 
 class NormalizeReadDepthsNormalAnchorTests(unittest.TestCase):
-    """Pin the current --normal anchoring invariants surfaced in cnvkit-ccy.
+    """Pin the current --normal anchoring invariants.
 
     These tests document what ``normalize_read_depths`` does *today* with
-    ``normal_ids`` set, as a regression baseline for any future redesign
-    (tracked in cnvkit-9wj). They exercise the suspected bug from GH #352
+    ``normal_ids`` set, as a regression baseline for any future redesign.
+    They exercise the suspected bug from #352
     and confirm it does not reproduce at the unit level: the issue lies in
     the design (small-normal-cohort information loss) rather than a numerical
     error in the implementation.
@@ -634,8 +634,8 @@ class NormalizeReadDepthsNormalAnchorTests(unittest.TestCase):
         that single column, so the anchor divide is a self-divide. The normal
         sample's resulting log2 row collapses to ``safe_log2(1.0)`` = a small
         positive offset from the NULL_LOG2_COVERAGE shift, with vanishing
-        per-gene variance. This is the design behavior to pin until the
-        cnvkit-9wj redesign lands.
+        per-gene variance. This pins the polish's single-normal degeneracy as a
+        regression baseline.
         """
         n_genes = 200
         altered = np.zeros(n_genes, dtype=bool)
@@ -717,6 +717,223 @@ class NormalizeReadDepthsNormalAnchorTests(unittest.TestCase):
             joined = "\n".join(cm.output)
             self.assertIn("import-rna --normal", joined)
             self.assertIn("3 normals", joined)
+
+
+class SizeFactorNormalizeTests(unittest.TestCase):
+    """``--normalize-method size-factors`` behavior.
+
+    DESeq2-style median-of-ratios size factors from the control set only, with
+    leave-one-out anchoring for the normals. The headline property is
+    independence from cohort composition, which the polish lacks.
+    """
+
+    @staticmethod
+    def _cohort(
+        n_normal,
+        n_tumor,
+        n_genes=300,
+        alt_frac=0.2,
+        tumor_alt=2.0,
+        contaminate=False,
+        seed=0,
+    ):
+        rng = np.random.default_rng(seed)
+        baseline = rng.lognormal(4.0, 1.0, n_genes)
+        altered = np.zeros(n_genes, dtype=bool)
+        altered[: int(n_genes * alt_frac)] = True
+        cols, normal_ids = {}, []
+        for i in range(n_normal):
+            lib = rng.lognormal(0, 0.4)  # per-sample library-depth difference
+            v = baseline.copy()
+            if contaminate:
+                v[altered] *= tumor_alt
+            cols[f"normal{i}"] = v * rng.lognormal(0, 0.05, n_genes) * lib
+            normal_ids.append(f"normal{i}")
+        for i in range(n_tumor):
+            lib = rng.lognormal(0, 0.4)
+            v = baseline.copy()
+            v[altered] *= tumor_alt
+            cols[f"tumor{i}"] = v * rng.lognormal(0, 0.05, n_genes) * lib
+        df = pd.DataFrame(cols, index=[f"g{i}" for i in range(n_genes)])
+        return df, normal_ids, altered
+
+    @staticmethod
+    def _separation(log2, altered):
+        """Median (altered - neutral) log2 over tumor columns; the recovered gain.
+
+        Taken as a difference so it is invariant to any constant per-sample
+        offset (which downstream ``correct_cnr`` centering removes anyway).
+        """
+        tcols = [c for c in log2.columns if c.startswith("tumor")]
+        gain = log2[tcols].loc[altered].median().median()
+        neutral = log2[tcols].loc[~altered].median().median()
+        return gain - neutral
+
+    def test_recovers_tumor_gain(self):
+        """A 2x tumor gain becomes ~+1 log2 after normal anchoring.
+
+        This pins the per-gene anchoring/ratio step: the gain is read as a
+        within-tumor altered-minus-neutral difference, which is invariant to the
+        per-sample size factor. Size-factor *estimation* is exercised separately
+        by ``test_invariant_to_library_depth`` and
+        ``test_invariant_to_cohort_composition``.
+        """
+        depths, nids, altered = self._cohort(5, 10, seed=1)
+        log2 = rna.normalize_read_depths(depths, nids, normalize_method="size-factors")
+        sep = self._separation(log2, altered)
+        self.assertGreater(sep, 0.8)
+        self.assertLess(sep, 1.2)
+
+    def test_multi_normal_loo_carries_qc_signal(self):
+        """With >=3 normals, leave-one-out leaves each normal a non-flat .cnr."""
+        depths, nids, _altered = self._cohort(3, 8, seed=2)
+        log2 = rna.normalize_read_depths(depths, nids, normalize_method="size-factors")
+        for nid in nids:
+            self.assertGreater(log2[nid].std(), 1e-3)
+
+    def test_single_normal_self_divides_but_tumors_recover(self):
+        """One normal => its own .cnr collapses (self-divide); tumors still gain."""
+        depths, nids, altered = self._cohort(1, 10, seed=3)
+        log2 = rna.normalize_read_depths(depths, nids, normalize_method="size-factors")
+        self.assertLess(log2[nids[0]].std(), 1e-3)
+        self.assertGreater(self._separation(log2, altered), 0.8)
+
+    def test_invariant_to_cohort_composition(self):
+        """The defining property: a tumor's log2 does not depend on which *other*
+        tumors are in the cohort, because the reference is the normals alone.
+
+        Contrast with the polish, whose cohort-wide median centering shifts when
+        the cohort composition changes.
+        """
+        rng = np.random.default_rng(7)
+        n_genes = 300
+        baseline = rng.lognormal(4.0, 1.0, n_genes)
+        alt_bulk = np.zeros(n_genes, dtype=bool)
+        alt_bulk[150:280] = True  # a large alteration shared by the bulk tumors
+
+        def col(v):
+            return v * rng.lognormal(0, 0.05, n_genes) * rng.lognormal(0, 0.4)
+
+        normals = {f"normal{i}": col(baseline.copy()) for i in range(5)}
+        probe = baseline.copy()
+        probe[:60] *= 2.0
+        probe_col = col(probe)
+        nids = list(normals)
+
+        def build(n_bulk):
+            cols = dict(normals)
+            cols["tumorP"] = probe_col.copy()
+            for j in range(n_bulk):
+                v = baseline.copy()
+                v[alt_bulk] *= 3.0
+                cols[f"bulk{j}"] = col(v)
+            return pd.DataFrame(cols, index=[f"g{i}" for i in range(n_genes)])
+
+        small = rna.normalize_read_depths(
+            build(3), nids, normalize_method="size-factors"
+        )
+        large = rna.normalize_read_depths(
+            build(40), nids, normalize_method="size-factors"
+        )
+        self.assertLess((small["tumorP"] - large["tumorP"]).abs().max(), 1e-9)
+
+    def test_invariant_to_library_depth(self):
+        """A pure per-sample depth rescaling is absorbed by the size factor."""
+        depths, nids, _altered = self._cohort(4, 6, seed=5)
+        base = rna.normalize_read_depths(depths, nids, normalize_method="size-factors")
+        scaled = depths.copy()
+        scaled["tumor0"] = scaled["tumor0"] * 7.5  # deeper library, same biology
+        rescaled = rna.normalize_read_depths(
+            scaled, nids, normalize_method="size-factors"
+        )
+        self.assertLess((base["tumor0"] - rescaled["tumor0"]).abs().max(), 1e-9)
+
+    def test_invalid_method_raises(self):
+        depths, nids, _altered = self._cohort(3, 3, seed=6)
+        with self.assertRaises(ValueError) as cm:
+            rna.normalize_read_depths(depths, nids, normalize_method="bogus")
+        self.assertIn("bogus", str(cm.exception))
+
+    def test_warns_when_size_factors_degenerate(self):
+        """No gene detected in every control => warn and fall back to no scaling.
+
+        Every gene is zeroed in at least one control (round-robin), so no gene is
+        positive across all controls; the median-of-ratios is then undefined and
+        size factors fall back to 1.0. That degradation must be surfaced, not
+        silent, for a clinical-output path.
+        """
+        depths, nids, _altered = self._cohort(4, 4, n_genes=120, seed=8)
+        normal_locs = [depths.columns.get_loc(nid) for nid in nids]
+        for g in range(len(depths)):
+            depths.iloc[g, normal_locs[g % len(nids)]] = 0.0
+        with self.assertLogs(level="WARNING") as cm:
+            log2 = rna.normalize_read_depths(
+                depths, nids, normalize_method="size-factors"
+            )
+        self.assertIn("size factor", "\n".join(cm.output))
+        # Still returns a usable, fully finite result for every sample.
+        self.assertEqual(log2.shape, depths.shape)
+        self.assertFalse(log2.isna().all(axis=0).any())
+
+
+class NormalizeMethodPlumbingTests(unittest.TestCase):
+    """``normalize_method`` is threaded CLI -> do_import_rna -> align -> normalize.
+
+    AST-level guards (no fixtures) so a dropped kwarg fails at collection rather
+    than silently reverting size-factors runs to the polish default.
+    """
+
+    def test_cmd_passes_method_to_do_import_rna(self):
+        calls = _ast_calls_to(commands._cmd_import_rna, "do_import_rna", "import_rna")
+        self.assertGreater(len(calls), 0)
+        for call in calls:
+            self.assertIn(
+                "normalize_method",
+                {kw.arg for kw in call.keywords},
+                "_cmd_import_rna must forward args.normalize_method to do_import_rna",
+            )
+
+    def test_do_import_rna_passes_method_to_align(self):
+        calls = _ast_calls_to(
+            import_rna.do_import_rna, "align_gene_info_to_samples", "rna"
+        )
+        self.assertGreater(len(calls), 0)
+        for call in calls:
+            self.assertIn(
+                "normalize_method",
+                {kw.arg for kw in call.keywords},
+                "do_import_rna must forward normalize_method to "
+                "rna.align_gene_info_to_samples",
+            )
+
+    def test_align_passes_method_to_normalize(self):
+        tree = ast.parse(inspect.getsource(rna.align_gene_info_to_samples))
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "normalize_read_depths"
+        ]
+        self.assertGreater(len(calls), 0)
+        for call in calls:
+            self.assertIn(
+                "normalize_method",
+                {kw.arg for kw in call.keywords},
+                "align_gene_info_to_samples must forward normalize_method to "
+                "normalize_read_depths",
+            )
+
+    def test_signatures_default_to_polish(self):
+        """Default preserved at every layer so existing output is unchanged."""
+        for func, param in (
+            (rna.normalize_read_depths, "normalize_method"),
+            (rna.align_gene_info_to_samples, "normalize_method"),
+            (import_rna.do_import_rna, "normalize_method"),
+        ):
+            self.assertEqual(
+                inspect.signature(func).parameters[param].default, "polish"
+            )
 
 
 class _TempTsvTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds an opt-in read-depth normalization strategy to `cnvkit.py import-rna`:
`--normalize-method {polish,size-factors}`. The default, `polish`, is the
historical cohort-wide median polish and is **unchanged and bit-exact**.

The new `size-factors` method derives the reference from the control samples
alone:

- per-sample **DESeq2 median-of-ratios** size factors estimated from the
  `--normal` controls (robust to the large fraction of copy-number-altered
  genes typical of aneuploid tumors);
- per-gene anchoring to the median of the size-factor-normalized controls;
- **leave-one-out** anchoring for each normal, so a normal's own `.cnr` retains
  QC signal (deviation from its peers) instead of collapsing to zero.

Unlike the polish, the reference depends only on the control set, so a tumor's
log2 ratios no longer shift with the number or composition of the *other*
tumors in the run. This follows the consensus for RNA-based copy-number
inference, where global "most genes are copy-neutral" normalization (TMM, the
polish) is biased in aneuploid cohorts and the reference should be built from
matched controls (DESeq2: Love, Huber & Anders 2014).

## Background

The design weaknesses motivating this were surfaced while investigating the
`import-rna --normal` reports in #352 (the original symptom did not reproduce
against current code; the underlying small-cohort / cohort-composition
weaknesses did).

## Changes

- `cnvlib/rna.py`: `normalize_read_depths` becomes a thin dispatcher; the polish
  is factored into `_polish_normalize` (bit-exact) and the new
  `_size_factor_normalize`. Removes the long-dead `use_median=False` IQR branch.
  Degenerate size factors (too few genes detected across all controls) fall back
  to no library-size scaling and emit a warning rather than degrading silently.
- `cnvlib/import_rna.py`, `cnvlib/commands.py`: thread `normalize_method`
  end-to-end; default `"polish"` keeps existing output bit-exact.
- `test/test_rna.py`: cover gain recovery, multi-normal leave-one-out QC signal,
  single-normal self-divide, cohort-composition and library-depth invariance,
  the degenerate-size-factor warning, and CLI-to-leaf kwarg plumbing
  (42 -> 53 tests).
- `doc/rna.rst`: document the method choice and when to prefer `size-factors`.

## Clinical impact

The **default output is unchanged** (bit-exact verified over multiple synthetic
configs). Only runs that explicitly pass `--normalize-method size-factors`
produce different `.cnr` numerics, which is the intended behavior of the new
method. Migrating the default to `size-factors` (a numerical-output change for
every `--normal` workflow) is deliberately left to a later release cycle after a
period of co-existence.

## Verification

- `ruff check` + `ruff format` clean; `pytest test/test_rna.py` 53 passed.
- End-to-end `cnvkit.py import-rna --normalize-method size-factors` exercised.
- Synthetic benchmark: both methods recover a 2x tumor gain equally; the
  size-factors probe-tumor drift across a 3-vs-40 bulk-tumor cohort is exactly
  0.0 (vs the polish's nonzero leak), confirming the cohort-composition
  invariance.
