### PR TITLE
Run serially when only one CPU is usable (fixes #1103)

### DIFF
--- a/cnvlib/cli/guess_baits.py
+++ b/cnvlib/cli/guess_baits.py
@@ -160,7 +160,6 @@ def scan_targets(access_bed, sample_bams, min_depth, min_gap, min_length, procs)
     bait_chunks = []
     # ENH: context manager to call rm on bed chunks? with to_chunks as pool, ck?
     logging.info("Scanning for enriched regions in:\n  %s", "\n  ".join(sample_bams))
-    #  with futures.ProcessPoolExecutor(procs) as pool:
     with parallel.pick_pool(procs) as pool:
         args_iter = (
             (bed_chunk, sample_bams, min_depth, min_gap, min_length)

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import multiprocessing
 import os
 import sys
 import warnings
@@ -258,7 +257,7 @@ def _cmd_batch(args: argparse.Namespace) -> None:
         seen_sids[sid] = fname
 
     if args.processes < 1:
-        args.processes = multiprocessing.cpu_count()
+        args.processes = parallel.available_cpus()
 
     if not args.reference:
         # Build a copy number reference; update (anti)targets upon request

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -8,7 +8,6 @@ import math
 import os.path
 import tempfile
 import time
-from concurrent import futures
 from io import StringIO
 from typing import TYPE_CHECKING
 
@@ -21,7 +20,7 @@ from skgenome.chromnames import detect_chr_prefix
 
 from . import core, samutil
 from .cnary import CopyNumArray as CNA
-from .parallel import rm, to_chunks
+from .parallel import pick_pool, rm, to_chunks
 from .params import NULL_LOG2_COVERAGE
 
 if TYPE_CHECKING:
@@ -441,7 +440,7 @@ def interval_coverages_count(
             for count, row in _rdc_chunk(bamfile, subregions, min_mapq):
                 yield [count, row]
     else:
-        with futures.ProcessPoolExecutor(procs) as pool:
+        with pick_pool(procs) as pool:
             args_iter = ((bam_fname, subr, min_mapq, fasta) for _c, subr in present)
             for chunk in pool.map(_rdc, args_iter):
                 for count, row in chunk:
@@ -538,7 +537,7 @@ def interval_coverages_pileup(
         table = bedcov(bed_fname, bam_fname, min_mapq, fasta, bam_chroms=bam_chroms)
     else:
         chunks = []
-        with futures.ProcessPoolExecutor(procs) as pool:
+        with pick_pool(procs) as pool:
             args_iter = (
                 (bed_chunk, bam_fname, min_mapq, fasta, bam_chroms)
                 for bed_chunk in to_chunks(bed_fname)

--- a/cnvlib/parallel.py
+++ b/cnvlib/parallel.py
@@ -50,13 +50,48 @@ class SerialFuture:
         return self._result
 
 
+def available_cpus() -> int:
+    """Number of CPUs this process may actually use.
+
+    Honors CPU affinity and cgroup limits (e.g. ``taskset``, container quotas,
+    or the kernel ``nr_cpus=1`` boot parameter) rather than the machine's total
+    core count, so a constrained single-CPU environment is reported as 1.
+    """
+    # Python 3.13+: respects affinity, cgroups, and -X cpu_count / PYTHON_CPU_COUNT.
+    process_cpu_count = getattr(os, "process_cpu_count", None)
+    if process_cpu_count is not None:
+        n = process_cpu_count()
+        if n:
+            return int(n)
+    # Linux/Unix: respects affinity set by taskset / sched_setaffinity.
+    sched_getaffinity = getattr(os, "sched_getaffinity", None)
+    if sched_getaffinity is not None:
+        try:
+            n = len(sched_getaffinity(0))
+        except OSError:
+            n = 0
+        if n:
+            return n
+    return os.cpu_count() or 1
+
+
 @contextmanager
 def pick_pool(nprocs: int) -> Iterator[SerialPool | ProcessPoolExecutor]:
-    if nprocs == 1:
+    """Yield a process pool, or a serial stand-in when parallelism is moot.
+
+    `nprocs` <= 0 means "use all available CPUs". The requested count is clamped
+    to the number of usable CPUs, so asking for more workers than cores never
+    oversubscribes. When the effective count is 1 -- which includes every
+    single-CPU host -- work runs in-process via `SerialPool` instead of forking
+    workers: real multiprocessing offers no speedup there, and on constrained
+    single-CPU build environments forking the pool can deadlock (#1103).
+    """
+    avail = available_cpus()
+    nprocs = avail if nprocs < 1 else min(nprocs, avail)
+    if nprocs <= 1:
         yield SerialPool()
     else:
-        max_workers = nprocs if nprocs >= 1 else None
-        with futures.ProcessPoolExecutor(max_workers=max_workers) as pool:
+        with futures.ProcessPoolExecutor(max_workers=nprocs) as pool:
             yield pool
 
 

--- a/test/test_parallel.py
+++ b/test/test_parallel.py
@@ -2,6 +2,7 @@
 
 import unittest
 from concurrent import futures
+from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -77,6 +78,10 @@ class ParallelTests(unittest.TestCase):
             future.result()
         self.assertEqual(str(ctx.exception), "test exception")
 
+    @unittest.skipIf(
+        parallel.available_cpus() < 2,
+        "real multiprocessing requires more than one usable CPU (#1103)",
+    )
     def test_process_pool_exception_propagation(self):
         """Test that ProcessPoolExecutor properly propagates exceptions from workers."""
         # Test that exceptions from worker processes are propagated
@@ -92,14 +97,16 @@ class ParallelTests(unittest.TestCase):
             )
 
     def test_pick_pool_with_multiple_processes(self):
-        """Test pick_pool correctly creates ProcessPoolExecutor for multiple processes."""
-        # Test with 2 processes
+        """pick_pool(2) yields a real ProcessPoolExecutor when more than one CPU
+        is usable, and a SerialPool on a single-CPU host (#1103)."""
+        expected = (
+            futures.ProcessPoolExecutor
+            if parallel.available_cpus() > 1
+            else parallel.SerialPool
+        )
         with parallel.pick_pool(2) as pool:
-            future = pool.submit(_simple_task, 21)
-            result = future.result()
-            self.assertEqual(
-                result, 42, "ProcessPoolExecutor should execute _simple_task(21) = 42"
-            )
+            self.assertIsInstance(pool, expected)
+            self.assertEqual(pool.submit(_simple_task, 21).result(), 42)
 
     def test_pick_pool_with_single_process(self):
         """Test pick_pool correctly creates SerialPool for single process."""
@@ -119,3 +126,23 @@ class ParallelTests(unittest.TestCase):
             self.assertEqual(
                 result, 42, "SerialPool should execute simple_task(21) = 42"
             )
+
+    def test_pick_pool_single_cpu_never_forks(self):
+        """On a single-CPU host, pick_pool must run in-process rather than fork
+        workers, however many are requested (regression test for #1103)."""
+        with mock.patch.object(parallel, "available_cpus", return_value=1):
+            for nprocs in (2, 8, 0, -1):
+                with parallel.pick_pool(nprocs) as pool:
+                    self.assertIsInstance(
+                        pool,
+                        parallel.SerialPool,
+                        f"pick_pool({nprocs}) must be serial on a single CPU",
+                    )
+                    self.assertEqual(pool.submit(_simple_task, 21).result(), 42)
+
+    def test_pick_pool_clamps_to_available_cpus(self):
+        """pick_pool never starts more workers than there are usable CPUs."""
+        with mock.patch.object(parallel, "available_cpus", return_value=4):
+            with parallel.pick_pool(64) as pool:
+                self.assertIsInstance(pool, futures.ProcessPoolExecutor)
+                self.assertEqual(pool._max_workers, 4)


### PR DESCRIPTION
## Problem

On a single-CPU host, `cnvkit` started real `ProcessPoolExecutor` workers
whenever more than one process was requested (e.g. tests forcing
`processes=2`, or `cnvkit batch/coverage/segment -p N` in a 1-CPU
container). Forking a worker pool on a machine that cannot parallelize is
pointless, and in constrained single-CPU build environments — notably
Debian's `sbuild` with `nproc=1` — it deadlocks *after* the work finishes,
hanging the build until it is killed for inactivity (#1103).

The Debian maintainer narrowed it to six tests, all of which spawn real
workers on one CPU, and worked around it by skipping them when `nproc==1`.

## Fix

- `cnvlib/parallel.py`: add `available_cpus()`, which reports the number of
  *usable* CPUs, honoring affinity and cgroup limits
  (`os.process_cpu_count()` on 3.13+, then `os.sched_getaffinity()`, then
  `os.cpu_count()`). `pick_pool()` now resolves `nprocs <= 0` to that count,
  clamps the request to it, and runs in-process via `SerialPool` whenever the
  effective count is 1. A single-CPU host therefore never forks workers.
- `cnvlib/coverage.py`: route both pool sites through `pick_pool()` (they
  constructed `ProcessPoolExecutor` directly and so bypassed the new logic).
- `cnvlib/commands.py`: the `batch` command resolves `-p`/`--processes` via
  `available_cpus()` instead of `multiprocessing.cpu_count()`, so the logged
  process count and per-sample division match what the pool actually uses on
  constrained hosts.
- `test/test_parallel.py`: the direct stdlib `ProcessPoolExecutor` test is
  skipped when fewer than two CPUs are usable; `test_pick_pool_with_multiple_processes`
  asserts the pool type conditionally; two regression tests cover the new
  behavior via mocking (single CPU falls back to `SerialPool`; the worker
  count is clamped to the usable CPUs).
- Remove a stale commented-out `ProcessPoolExecutor` line in
  `cli/guess_baits.py` revealed alongside the change.

## Behavior note

On multi-CPU hosts, `-p N` with `N` greater than the usable CPU count no
longer oversubscribes; it is capped at the number of usable CPUs. This is
the correct choice for cnvkit's CPU-bound (and R-subprocess-bound) work.

## Verification

- A faithful single-CPU Linux container (Python 3.13, fork start method,
  R + DNAcopy) runs the full suite with **no hang and no leaked worker
  processes**; the previously-deadlocking tests pass or skip as intended.
- Multi-CPU runs still exercise the real `ProcessPoolExecutor` path.
- `ruff` and `mypy` are clean.

Once released, the `nproc==1` workaround in Debian's `debian/rules` can be
removed.

Fixes #1103
