### PR TITLE
fix: optional antitarget + -r/--reference flag for `cnvkit.py fix` (#894)

### DIFF
--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -1062,6 +1062,33 @@ def _cmd_fix(args: argparse.Namespace) -> None:
     Adjust raw coverage data according to the given reference, correct potential
     biases and re-center.
     """
+    # Resolve the reference from -r/--reference (preferred) or the legacy
+    # positional. The positional is deprecated and will be removed in CNVkit 1.0.
+    if args.reference is not None and args.reference_arg is not None:
+        sys.exit(
+            "Specify the reference once: either with -r/--reference or as the "
+            "positional argument, not both.\n(See: cnvkit.py fix -h)"
+        )
+    reference_fname = (
+        args.reference if args.reference is not None else args.reference_arg
+    )
+    if reference_fname is None:
+        sys.exit(
+            "No reference specified. Provide one with -r/--reference, e.g.\n"
+            "    cnvkit.py fix Sample.targetcoverage.cnn -r reference.cnn\n"
+            "(See: cnvkit.py fix -h)"
+        )
+    if args.reference_arg is not None:
+        # DeprecationWarning is silent under CPython's default filters when
+        # raised from a library module, so routine pipeline runs stay quiet; it
+        # surfaces for anyone who opts in (python -W, PYTHONWARNINGS, pytest/CI).
+        warnings.warn(
+            "Passing the reference to `cnvkit.py fix` as a positional argument "
+            "is deprecated and will be removed in CNVkit 1.0; use -r/--reference "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     # Verify that target and antitarget are from the same sample
     tgt_raw = read_cna(args.target, sample_id=args.sample_id)
     if args.antitarget is not None:
@@ -1078,7 +1105,7 @@ def _cmd_fix(args: argparse.Namespace) -> None:
     target_table = fix.do_fix(
         tgt_raw,
         anti_raw,
-        read_cna(args.reference),
+        read_cna(reference_fname),
         args.diploid_parx_genome,
         args.do_gc,
         args.do_edge,
@@ -1099,7 +1126,20 @@ P_fix.add_argument(
     help="Antitarget coverage file (.antitargetcoverage.cnn). "
     "Omit for WGS/amplicon samples with no antitarget bins.",
 )
-P_fix.add_argument("reference", help="Reference coverage (.cnn).")
+P_fix.add_argument(
+    "reference_arg",
+    metavar="reference",
+    nargs="?",
+    default=None,
+    help="Reference coverage (.cnn). Deprecated positional form; prefer "
+    "-r/--reference. Will be removed in CNVkit 1.0.",
+)
+P_fix.add_argument(
+    "-r",
+    "--reference",
+    default=None,
+    help="Reference coverage (.cnn). Preferred over the positional form.",
+)
 P_fix.add_argument(
     "-c",
     "--cluster",

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -1064,7 +1064,12 @@ def _cmd_fix(args: argparse.Namespace) -> None:
     """
     # Verify that target and antitarget are from the same sample
     tgt_raw = read_cna(args.target, sample_id=args.sample_id)
-    anti_raw = read_cna(args.antitarget, sample_id=args.sample_id)
+    if args.antitarget is not None:
+        anti_raw = read_cna(args.antitarget, sample_id=args.sample_id)
+    else:
+        # WGS/amplicon samples may have no antitarget bins; do_fix tolerates an
+        # empty antitarget array (the established blank-CNA idiom, cf. batch.py).
+        anti_raw = _CNA([])
     if len(anti_raw) and tgt_raw.sample_id != anti_raw.sample_id:
         raise ValueError(
             "Sample IDs do not match: "
@@ -1088,7 +1093,11 @@ def _cmd_fix(args: argparse.Namespace) -> None:
 P_fix = AP_subparsers.add_parser("fix", help=_cmd_fix.__doc__)
 P_fix.add_argument("target", help="Target coverage file (.targetcoverage.cnn).")
 P_fix.add_argument(
-    "antitarget", help="Antitarget coverage file (.antitargetcoverage.cnn)."
+    "antitarget",
+    nargs="?",
+    default=None,
+    help="Antitarget coverage file (.antitargetcoverage.cnn). "
+    "Omit for WGS/amplicon samples with no antitarget bins.",
 )
 P_fix.add_argument("reference", help="Reference coverage (.cnn).")
 P_fix.add_argument(

--- a/cnvlib/diagram.py
+++ b/cnvlib/diagram.py
@@ -12,15 +12,17 @@ import math
 import warnings
 from typing import TYPE_CHECKING, Any
 
-# Reportlab on Py3.10 triggers a DeprecationWarning via load_module, which
-# becomes an error (ModuleNotFoundError) unless silenced here.
-warnings.simplefilter("ignore", DeprecationWarning)
-
-from Bio.Graphics import BasicChromosome as BC
-from reportlab.graphics import renderPDF
-from reportlab.lib import colors
-from reportlab.lib.units import inch
-from reportlab.pdfgen import canvas
+# Reportlab triggers a DeprecationWarning via load_module on import, which can
+# become an error under `-W error`. Silence it for just these imports rather
+# than muzzling DeprecationWarning process-wide (which would hide every other
+# deprecation, including CNVkit's own).
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from Bio.Graphics import BasicChromosome as BC
+    from reportlab.graphics import renderPDF
+    from reportlab.lib import colors
+    from reportlab.lib.units import inch
+    from reportlab.pdfgen import canvas
 
 from skgenome.rangelabel import unpack_range
 

--- a/cnvlib/fix.py
+++ b/cnvlib/fix.py
@@ -346,8 +346,19 @@ def match_ref_to_sample(
     # Check for signs that the wrong reference was used
     num_missing = pd.isna(ref_matched.start).sum()
     if num_missing > 0:
+        if num_missing == len(samp_labeled):
+            # No bins in common at all -- almost certainly the wrong file was
+            # given as the reference (e.g. a raw coverage .cnn passed in place of
+            # a built reference), not merely a panel mismatch.
+            raise ValueError(
+                f"Reference shares no bins with {samp_cnarr.sample_id}. "
+                "Is the reference argument actually a reference .cnn built with "
+                "'cnvkit.py reference' (and not a coverage file or the wrong panel)?"
+            )
         raise ValueError(
-            f"Reference is missing {num_missing} bins found in {samp_cnarr.sample_id}"
+            f"Reference is missing {num_missing} of {len(samp_labeled)} bins found "
+            f"in {samp_cnarr.sample_id}; the reference was likely built for a "
+            "different target panel."
         )
     x = ref_cnarr.as_dataframe(
         ref_matched.reset_index(drop=True).set_index(samp_cnarr.data.index)

--- a/doc/nonhybrid.rst
+++ b/doc/nonhybrid.rst
@@ -68,12 +68,10 @@ ignoring off-target regions::
 Equivalently::
 
     cnvkit.py target targets.bed --split -o targets.split.bed
-    # Create a blank file to substitute for antitargets
-    touch MT
     # For each sample
     cnvkit.py coverage Sample.bam targets.split.bed -p 0 -o Sample.targetcoverage.cnn
     cnvkit.py reference *.targetcoverage.cnn --no-edge -o ref-tas.cnn
-    cnvkit.py fix Sample.targetcoverage.cnn MT ref-tas.cnn --no-edge
+    cnvkit.py fix Sample.targetcoverage.cnn ref-tas.cnn --no-edge
 
 This approach does not collect any copy number information between targeted
 regions, so it should only be used if you have in fact prepared your samples

--- a/doc/nonhybrid.rst
+++ b/doc/nonhybrid.rst
@@ -71,7 +71,7 @@ Equivalently::
     # For each sample
     cnvkit.py coverage Sample.bam targets.split.bed -p 0 -o Sample.targetcoverage.cnn
     cnvkit.py reference *.targetcoverage.cnn --no-edge -o ref-tas.cnn
-    cnvkit.py fix Sample.targetcoverage.cnn ref-tas.cnn --no-edge
+    cnvkit.py fix Sample.targetcoverage.cnn -r ref-tas.cnn --no-edge
 
 This approach does not collect any copy number information between targeted
 regions, so it should only be used if you have in fact prepared your samples

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -62,7 +62,7 @@ The pipeline executed by the ``batch`` command is equivalent to::
     cnvkit.py reference *Normal.{,anti}targetcoverage.cnn --fasta hg38.fa -o my_reference.cnn
 
     # For each tumor sample...
-    cnvkit.py fix Sample.targetcoverage.cnn Sample.antitargetcoverage.cnn my_reference.cnn -o Sample.cnr
+    cnvkit.py fix Sample.targetcoverage.cnn Sample.antitargetcoverage.cnn -r my_reference.cnn -o Sample.cnr
     cnvkit.py segment Sample.cnr -o Sample.cns
 
     # Post-processing for each tumor sample...
@@ -557,7 +557,7 @@ the given reference. Output a table of copy number ratios (.cnr).
 
 ::
 
-    cnvkit.py fix Sample.targetcoverage.cnn Sample.antitargetcoverage.cnn Reference.cnn -o Sample.cnr
+    cnvkit.py fix Sample.targetcoverage.cnn Sample.antitargetcoverage.cnn -r Reference.cnn -o Sample.cnr
 
 How it works
 ````````````

--- a/test/clustering.makefile
+++ b/test/clustering.makefile
@@ -13,7 +13,7 @@ $(cnr_of_interest): \
 	$(example_cnn_dir)/TR_%_T.targetcoverage.cnn \
 	$(example_cnn_dir)/TR_%_T.antitargetcoverage.cnn \
 	ref-clustered.cnn
-	cnvkit.py fix $^ --cluster -o $@
+	cnvkit.py fix $< $(word 2,$^) -r ref-clustered.cnn --cluster -o $@
 
 ref-clustered.cnn: $(wildcard $(example_cnn_dir)/TR_*targetcoverage.cnn)
 	cnvkit.py reference $^ --cluster -o $@

--- a/test/test_reference.py
+++ b/test/test_reference.py
@@ -408,41 +408,93 @@ class ReferenceTests(unittest.TestCase):
         self.assertFalse(np.isnan(cnr["log2"]).any())
         self.assertFalse(np.isnan(cnr["weight"]).any())
 
-    def test_fix_antitarget_optional_argparse(self):
-        """'fix' accepts the antitarget coverage as an optional positional (#894).
+    def test_fix_reference_grammar_argparse(self):
+        """`fix` parses the redesigned reference grammar (#894 follow-up).
 
-        WGS/amplicon samples have no antitarget bins, so the CLI must let users
-        run `cnvkit.py fix target.cnn reference.cnn -o out.cnr` with two
-        positionals instead of fabricating a decoy antitarget file. This pins the
-        argparse contract that makes that workflow possible:
-          - 2 positionals  -> target, reference; antitarget defaults to None
-          - 3 positionals  -> target, antitarget, reference (backward compatible)
-          - reference stays mandatory (a lone positional is a usage error)
+        The reference moved from a required positional to a canonical
+        ``-r/--reference`` flag plus a deprecated optional positional
+        (dest ``reference_arg``); the antitarget stays an optional positional.
+        This pins how each invocation maps onto the parsed attributes. Crucially,
+        the forgotten-reference case (``fix target antitarget``) now parses to an
+        *unresolved* reference (both sources None) instead of silently treating
+        the antitarget file as the reference -- the silent-misparse bug this
+        redesign closes. argparse no longer enforces the reference (that moved
+        into ``_cmd_fix``), so none of these forms raise SystemExit.
         """
-        # Two-positional WGS form: antitarget omitted.
-        ns2 = commands.P_fix.parse_args(["tgt.cnn", "ref.cnn", "-o", "out.cnr"])
-        self.assertEqual(ns2.target, "tgt.cnn")
-        self.assertIsNone(ns2.antitarget)
-        self.assertEqual(ns2.reference, "ref.cnn")
-        self.assertEqual(ns2.output, "out.cnr")
-        # Three-positional hybrid-capture form: backward compatibility.
-        ns3 = commands.P_fix.parse_args(["tgt.cnn", "anti.cnn", "ref.cnn"])
-        self.assertEqual(ns3.target, "tgt.cnn")
-        self.assertEqual(ns3.antitarget, "anti.cnn")
-        self.assertEqual(ns3.reference, "ref.cnn")
-        # Reference is still required: a single positional is a usage error.
-        with self.assertRaises(SystemExit):
-            commands.P_fix.parse_args(["tgt.cnn"])
+        # WGS form: target + -r reference, antitarget omitted.
+        ns = commands.P_fix.parse_args(["tgt.cnn", "-r", "ref.cnn"])
+        self.assertEqual(ns.target, "tgt.cnn")
+        self.assertIsNone(ns.antitarget)
+        self.assertIsNone(ns.reference_arg)
+        self.assertEqual(ns.reference, "ref.cnn")
+        # Hybrid-capture form: target + antitarget positional + -r reference.
+        ns = commands.P_fix.parse_args(["tgt.cnn", "anti.cnn", "-r", "ref.cnn"])
+        self.assertEqual(ns.target, "tgt.cnn")
+        self.assertEqual(ns.antitarget, "anti.cnn")
+        self.assertIsNone(ns.reference_arg)
+        self.assertEqual(ns.reference, "ref.cnn")
+        # Deprecated 3-positional form: reference lands in reference_arg, not -r.
+        ns = commands.P_fix.parse_args(["tgt.cnn", "anti.cnn", "ref.cnn"])
+        self.assertEqual(ns.target, "tgt.cnn")
+        self.assertEqual(ns.antitarget, "anti.cnn")
+        self.assertEqual(ns.reference_arg, "ref.cnn")
+        self.assertIsNone(ns.reference)
+        # Forgotten-reference trap: the old grammar took this as target+reference;
+        # the new one parses it as target+antitarget with the reference left
+        # unresolved (both reference sources None), to be rejected by _cmd_fix.
+        ns = commands.P_fix.parse_args(["tgt.cnn", "anti.cnn"])
+        self.assertEqual(ns.target, "tgt.cnn")
+        self.assertEqual(ns.antitarget, "anti.cnn")
+        self.assertIsNone(ns.reference_arg)
+        self.assertIsNone(ns.reference)
+        # Lone target: antitarget and both reference sources unset.
+        ns = commands.P_fix.parse_args(["tgt.cnn"])
+        self.assertEqual(ns.target, "tgt.cnn")
+        self.assertIsNone(ns.antitarget)
+        self.assertIsNone(ns.reference_arg)
+        self.assertIsNone(ns.reference)
+
+    @staticmethod
+    def _fix_namespace(
+        target,
+        *,
+        antitarget_fname=None,
+        reference=None,
+        reference_arg=None,
+        output=None,
+    ):
+        """Build a `fix` argparse.Namespace, varying only the reference inputs.
+
+        do_edge is held False so callers need not assert value equality against
+        do_fix's do_edge=True default; only bin counts and validity are compared.
+        """
+        return argparse.Namespace(
+            target=target,
+            antitarget=antitarget_fname,
+            reference_arg=reference_arg,
+            reference=reference,
+            sample_id=None,
+            diploid_parx_genome=None,
+            do_gc=True,
+            do_edge=False,
+            do_rmask=True,
+            cluster=False,
+            smoothing_window_fraction=None,
+            bias_smoother="median",
+            output=output,
+        )
 
     def test_cmd_fix_without_antitarget(self):
-        """`_cmd_fix` produces a valid .cnr when antitarget is None (#894).
+        """`_cmd_fix` produces a valid .cnr from the WGS `-r` form (#894).
 
-        Drives the full command path a WGS/amplicon user takes (target +
-        reference, no antitarget file). The None branch must synthesize an empty
-        antitarget and still write a usable .cnr -- not crash and not emit NaN
-        log2 (which would break downstream segmentation). Cross-checks that this
-        yields the same number of bins as the explicit blank-antitarget API call,
-        confirming the synthesized empty antitarget is equivalent to passing one.
+        Drives the full command path a WGS/amplicon user takes (target plus
+        ``-r reference``, no antitarget file): reference via the canonical
+        ``reference`` attribute, ``reference_arg`` None, ``antitarget`` None.
+        The None-antitarget branch must synthesize an empty antitarget and still
+        write a usable .cnr -- not crash and not emit NaN log2 (which would break
+        downstream segmentation). Cross-checks that this yields the same number
+        of bins as the explicit blank-antitarget API call, confirming the
+        synthesized empty antitarget is equivalent to passing one.
         """
         ref = cnvlib.read("formats/reference-tr.cnn")
         is_bg = ref["gene"] == "Background"
@@ -454,19 +506,8 @@ class ReferenceTests(unittest.TestCase):
             out_fname = os.path.join(tmpdir, "sample.cnr")
             tabio.write(tgt_bins, tgt_fname)
             tabio.write(ref[~is_bg], ref_fname)
-            namespace = argparse.Namespace(
-                target=tgt_fname,
-                antitarget=None,
-                reference=ref_fname,
-                sample_id=None,
-                diploid_parx_genome=None,
-                do_gc=True,
-                do_edge=False,
-                do_rmask=True,
-                cluster=False,
-                smoothing_window_fraction=None,
-                bias_smoother="median",
-                output=out_fname,
+            namespace = self._fix_namespace(
+                tgt_fname, reference=ref_fname, output=out_fname
             )
             commands._cmd_fix(namespace)
             cnr = cnvlib.read(out_fname)
@@ -484,6 +525,149 @@ class ReferenceTests(unittest.TestCase):
             self.assertEqual(len(cnr), len(api_cnr))
         finally:
             shutil.rmtree(tmpdir)
+
+    def test_cmd_fix_requires_reference(self):
+        """`_cmd_fix` exits when no reference is given by flag or positional (#894).
+
+        The forgotten-reference invocation (`fix target antitarget`) parses with
+        both reference sources None; _cmd_fix must refuse rather than proceed
+        referenceless. A real target file is provided so the exit is the
+        reference check, not file I/O.
+        """
+        ref = cnvlib.read("formats/reference-tr.cnn")
+        is_bg = ref["gene"] == "Background"
+        tgt_bins = ref[~is_bg]
+        tmpdir = tempfile.mkdtemp()
+        try:
+            tgt_fname = os.path.join(tmpdir, "sample.targetcoverage.cnn")
+            tabio.write(tgt_bins, tgt_fname)
+            namespace = self._fix_namespace(
+                tgt_fname, reference=None, reference_arg=None
+            )
+            with self.assertRaisesRegex(SystemExit, "No reference"):
+                commands._cmd_fix(namespace)
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_cmd_fix_reference_specified_twice(self):
+        """`_cmd_fix` exits when the reference is given both ways (#894).
+
+        Supplying -r/--reference *and* the deprecated positional is ambiguous;
+        the command must refuse rather than silently pick one.
+        """
+        ref = cnvlib.read("formats/reference-tr.cnn")
+        is_bg = ref["gene"] == "Background"
+        tgt_bins = ref[~is_bg]
+        tmpdir = tempfile.mkdtemp()
+        try:
+            tgt_fname = os.path.join(tmpdir, "sample.targetcoverage.cnn")
+            ref_fname = os.path.join(tmpdir, "reference.cnn")
+            tabio.write(tgt_bins, tgt_fname)
+            tabio.write(ref[~is_bg], ref_fname)
+            namespace = self._fix_namespace(
+                tgt_fname, reference=ref_fname, reference_arg=ref_fname
+            )
+            with self.assertRaisesRegex(SystemExit, "once"):
+                commands._cmd_fix(namespace)
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_cmd_fix_positional_reference_deprecated(self):
+        """The legacy positional reference still works but warns (#894).
+
+        Passing the reference as the third positional (reference_arg) must emit a
+        DeprecationWarning yet remain fully functional -- the deprecation is
+        non-fatal, so a valid .cnr is still written. Uses the full hybrid fixture
+        (target + antitarget + full reference) so do_fix succeeds.
+        """
+        ref = cnvlib.read("formats/reference-tr.cnn")
+        is_bg = ref["gene"] == "Background"
+        tgt_bins = ref[~is_bg]
+        anti_bins = ref[is_bg]
+        tmpdir = tempfile.mkdtemp()
+        try:
+            tgt_fname = os.path.join(tmpdir, "sample.targetcoverage.cnn")
+            anti_fname = os.path.join(tmpdir, "sample.antitargetcoverage.cnn")
+            ref_fname = os.path.join(tmpdir, "reference.cnn")
+            out_fname = os.path.join(tmpdir, "sample.cnr")
+            tabio.write(tgt_bins, tgt_fname)
+            tabio.write(anti_bins, anti_fname)
+            tabio.write(ref, ref_fname)
+            namespace = self._fix_namespace(
+                tgt_fname,
+                antitarget_fname=anti_fname,
+                reference_arg=ref_fname,
+                output=out_fname,
+            )
+            with self.assertWarns(DeprecationWarning):
+                commands._cmd_fix(namespace)
+            cnr = cnvlib.read(out_fname)
+            self.assertTrue(0 < len(cnr) <= len(ref))
+            self.assertFalse(np.isnan(cnr["log2"]).any())
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_match_ref_to_sample_zero_overlap(self):
+        """Zero shared bins reads as a wrong-file error, not a panel mismatch.
+
+        When the reference and sample share *no* coordinates (e.g. a raw coverage
+        .cnn handed in where a built reference was expected, or the reference
+        omitted so the antitarget file gets misused), match_ref_to_sample must
+        say so explicitly rather than emit a misleading "missing N bins".
+        """
+        samp = cnary.CopyNumArray.from_columns(
+            {
+                "chromosome": ["chr1"] * 4,
+                "start": [0, 100, 200, 300],
+                "end": [100, 200, 300, 400],
+                "gene": list("ABCD"),
+                "log2": [0.0, 0.1, -0.1, 0.2],
+            },
+            {"sample_id": "Sample"},
+        )
+        # Disjoint coordinates: a different chromosome -> no bins in common.
+        ref = cnary.CopyNumArray.from_columns(
+            {
+                "chromosome": ["chr2"] * 4,
+                "start": [0, 100, 200, 300],
+                "end": [100, 200, 300, 400],
+                "gene": list("ABCD"),
+                "log2": [0.0, 0.0, 0.0, 0.0],
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "shares no bins"):
+            fix.match_ref_to_sample(ref, samp)
+
+    def test_match_ref_to_sample_partial_overlap(self):
+        """A reference missing *some* of the sample's bins flags a panel mismatch.
+
+        Partial overlap (the reference covers part but not all of the sample's
+        bins) is the "wrong target panel" case and must be distinguished from the
+        zero-overlap wrong-file case: the message reports how many of how many
+        bins are missing.
+        """
+        samp = cnary.CopyNumArray.from_columns(
+            {
+                "chromosome": ["chr1"] * 4,
+                "start": [0, 100, 200, 300],
+                "end": [100, 200, 300, 400],
+                "gene": list("ABCD"),
+                "log2": [0.0, 0.1, -0.1, 0.2],
+            },
+            {"sample_id": "Sample"},
+        )
+        # Reference covers only the first two of the sample's four bins.
+        ref = cnary.CopyNumArray.from_columns(
+            {
+                "chromosome": ["chr1", "chr1"],
+                "start": [0, 100],
+                "end": [100, 200],
+                "gene": ["A", "B"],
+                "log2": [0.0, 0.0],
+            }
+        )
+        with self.assertRaisesRegex(ValueError, r"missing \d+ of \d+"):
+            fix.match_ref_to_sample(ref, samp)
 
 
 class ClusterTests(unittest.TestCase):

--- a/test/test_reference.py
+++ b/test/test_reference.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Tests for the reference command (and clustering used to build references)."""
 
+import argparse
 import logging
 import os
 import shutil
@@ -406,6 +407,83 @@ class ReferenceTests(unittest.TestCase):
         cnr = commands.do_fix(tgt_bins, anti_bins, ref)
         self.assertFalse(np.isnan(cnr["log2"]).any())
         self.assertFalse(np.isnan(cnr["weight"]).any())
+
+    def test_fix_antitarget_optional_argparse(self):
+        """'fix' accepts the antitarget coverage as an optional positional (#894).
+
+        WGS/amplicon samples have no antitarget bins, so the CLI must let users
+        run `cnvkit.py fix target.cnn reference.cnn -o out.cnr` with two
+        positionals instead of fabricating a decoy antitarget file. This pins the
+        argparse contract that makes that workflow possible:
+          - 2 positionals  -> target, reference; antitarget defaults to None
+          - 3 positionals  -> target, antitarget, reference (backward compatible)
+          - reference stays mandatory (a lone positional is a usage error)
+        """
+        # Two-positional WGS form: antitarget omitted.
+        ns2 = commands.P_fix.parse_args(["tgt.cnn", "ref.cnn", "-o", "out.cnr"])
+        self.assertEqual(ns2.target, "tgt.cnn")
+        self.assertIsNone(ns2.antitarget)
+        self.assertEqual(ns2.reference, "ref.cnn")
+        self.assertEqual(ns2.output, "out.cnr")
+        # Three-positional hybrid-capture form: backward compatibility.
+        ns3 = commands.P_fix.parse_args(["tgt.cnn", "anti.cnn", "ref.cnn"])
+        self.assertEqual(ns3.target, "tgt.cnn")
+        self.assertEqual(ns3.antitarget, "anti.cnn")
+        self.assertEqual(ns3.reference, "ref.cnn")
+        # Reference is still required: a single positional is a usage error.
+        with self.assertRaises(SystemExit):
+            commands.P_fix.parse_args(["tgt.cnn"])
+
+    def test_cmd_fix_without_antitarget(self):
+        """`_cmd_fix` produces a valid .cnr when antitarget is None (#894).
+
+        Drives the full command path a WGS/amplicon user takes (target +
+        reference, no antitarget file). The None branch must synthesize an empty
+        antitarget and still write a usable .cnr -- not crash and not emit NaN
+        log2 (which would break downstream segmentation). Cross-checks that this
+        yields the same number of bins as the explicit blank-antitarget API call,
+        confirming the synthesized empty antitarget is equivalent to passing one.
+        """
+        ref = cnvlib.read("formats/reference-tr.cnn")
+        is_bg = ref["gene"] == "Background"
+        tgt_bins = ref[~is_bg]
+        tmpdir = tempfile.mkdtemp()
+        try:
+            tgt_fname = os.path.join(tmpdir, "sample.targetcoverage.cnn")
+            ref_fname = os.path.join(tmpdir, "reference.cnn")
+            out_fname = os.path.join(tmpdir, "sample.cnr")
+            tabio.write(tgt_bins, tgt_fname)
+            tabio.write(ref[~is_bg], ref_fname)
+            namespace = argparse.Namespace(
+                target=tgt_fname,
+                antitarget=None,
+                reference=ref_fname,
+                sample_id=None,
+                diploid_parx_genome=None,
+                do_gc=True,
+                do_edge=False,
+                do_rmask=True,
+                cluster=False,
+                smoothing_window_fraction=None,
+                bias_smoother="median",
+                output=out_fname,
+            )
+            commands._cmd_fix(namespace)
+            cnr = cnvlib.read(out_fname)
+            # (a) Produced real bins, bounded by the target input.
+            self.assertTrue(0 < len(cnr) <= len(tgt_bins))
+            # (b) No NaN log2 leaked through (would crash downstream segmentation).
+            self.assertFalse(np.isnan(cnr["log2"]).any())
+            # (c) Same bin count as the explicit blank-antitarget API path.
+            #     (Value equality is intentionally not asserted: this namespace
+            #     sets do_edge=False while do_fix defaults to do_edge=True, so
+            #     the corrected log2 values legitimately differ.)
+            api_cnr = commands.do_fix(
+                tgt_bins, cnvlib.cnary.CopyNumArray([]), ref[~is_bg]
+            )
+            self.assertEqual(len(cnr), len(api_cnr))
+        finally:
+            shutil.rmtree(tmpdir)
 
 
 class ClusterTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Lets WGS and targeted-amplicon samples (which have no antitarget bins) run `cnvkit.py fix` without
fabricating a decoy antitarget file, and makes the reference argument explicit and safe to specify.

```
# WGS / amplicon (no antitarget):
cnvkit.py fix Sample.targetcoverage.cnn -r reference.cnn -o Sample.cnr

# Hybrid capture:
cnvkit.py fix Sample.targetcoverage.cnn Sample.antitargetcoverage.cnn -r reference.cnn -o Sample.cnr
```

Fixes #894.

## Background

The antitarget coverage was a required positional, so `cnvkit.py fix target.cnn reference.cnn` failed
(argparse bound `reference.cnn` to the antitarget slot), forcing users to fabricate a decoy empty
antitarget file. Simply making the antitarget optional, however, introduced an ambiguity: with the
reference still positional, `cnvkit.py fix target.cnn antitarget.cnn` (reference accidentally omitted)
was *silently accepted* — the antitarget file was bound to the reference slot — and the user got a
misleading "wrong reference" error downstream.

## What this does

1. **Optional antitarget.** The antitarget positional is now optional; when omitted, `_cmd_fix`
   synthesizes an empty `CopyNumArray`. `fix.do_fix` already tolerates an empty antitarget
   (`if len(anti_cnarr):`), so `.cnr` output is identical to the prior decoy-file workaround.

2. **`-r/--reference` flag.** Adds an explicit `-r/--reference` flag (the spelling already used by
   `batch` and `export theta`) as the preferred way to pass the reference. The positional reference is
   retained for backward compatibility but **deprecated** (removed in CNVkit 1.0) and demoted to an
   optional positional.

3. **No more silent misparse.** With both antitarget and the positional reference optional, the
   forgotten-reference case now leaves the reference unresolved, so `_cmd_fix` rejects it with an
   actionable error ("No reference specified. Provide one with -r/--reference …") instead of a
   misleading downstream failure. Specifying the reference both ways is also rejected.

4. **Quiet, opt-in deprecation.** Using the deprecated positional emits a `DeprecationWarning` — silent
   under CPython's default filters (so routine pipeline runs are unaffected), but revealable by anyone
   who opts in via `python -W`, `PYTHONWARNINGS`, or pytest/CI (where it can be escalated to an error).

5. **Clearer wrong-reference error.** `match_ref_to_sample` now distinguishes *zero* bin overlap
   ("Reference shares no bins … is it actually a reference .cnn?", the likely wrong-file case) from
   *partial* overlap ("missing N of M bins … different target panel").

6. **Latent-bug fix (`diagram.py`).** `diagram.py` called `warnings.simplefilter("ignore",
   DeprecationWarning)` at import, which reset the process-wide filter and silenced *every*
   DeprecationWarning (including numpy/pandas and CNVkit's own) whenever the diagram code was imported —
   which includes `fix`. This is now scoped to just the Bio/Reportlab imports via
   `warnings.catch_warnings()`, restoring normal deprecation visibility for the rest of the process.
   (This is also what makes the deprecation in item 4 revealable.)

7. **Docs + dogfooding.** The documented `fix` examples (`doc/pipeline.rst`, `doc/nonhybrid.rst`) and
   the `test/clustering.makefile` recipe now use the `-r` form.

## Grammar (verified)

| Invocation | Result |
|---|---|
| `fix t -r ref` | WGS/amplicon — antitarget omitted ✓ |
| `fix t a -r ref` | hybrid, explicit ✓ |
| `fix t a ref` | hybrid, deprecated positional — works + `DeprecationWarning` |
| `fix t a` (forgot reference) | clear "No reference specified" error |
| `fix t a ref -r ref` | clear "specify once" error |

Known argparse limitation: with `antitarget` optional and preceding `reference`, an optional flag
interleaved *between* the positionals (e.g. `fix t a -o out ref`) does not parse; place flags before
or after the positional group. All idiomatic invocations are unaffected.

## Testing

- `test/test_reference.py`: rewrote the grammar test and added coverage for the WGS `-r` path, the
  missing-reference error, the specified-twice error, the positional-reference `DeprecationWarning`,
  and the zero- vs partial-overlap `match_ref_to_sample` errors. 11 fix/match_ref tests pass.
- Full `reference`/`commands`/`plots`/`batch` suites pass (one pre-existing failure,
  `test_diploid_parx_genome`, is a missing `DNAcopy` R package in the local env, unrelated).
- `ruff` and all pre-commit hooks pass.
- Reviewed via two rounds of a 3-reviewer pass (simplicity/DRY, correctness, conventions); findings
  consolidated here.
