### PR TITLE
Allow self-reference in `batch` and reuse shared coverage (#48)

### DIFF
--- a/cnvlib/batch.py
+++ b/cnvlib/batch.py
@@ -460,6 +460,7 @@ def batch_run_sample(
     fasta: str | None = None,
     sample_sex: str | None = None,
     bias_smoother: str = "median",
+    reuse_coverage: bool = False,
 ) -> None:
     """Run the pipeline on one sample (BAM or bedGraph file).
 
@@ -467,21 +468,33 @@ def batch_run_sample(
     coverage and is passed through to copy-number calling and (if enabled)
     diagram plotting; it accepts the same strings as ``--sample-sex`` on
     the ``call`` / ``diagram`` / ``genemetrics`` subcommands.
+
+    ``reuse_coverage`` indicates this sample's (anti)target coverage was already
+    computed and written to ``{output_dir}/{sample_id}.*coverage.cnn`` earlier in
+    the same run (the self-reference workflow where the sample is also a normal,
+    #48); when True the existing files are read back instead of recomputed.
     """
     # ENH - return probes, segments (cnarr, segarr)
     logging.info("Running the CNVkit pipeline on %s ...", sample_fname)
     sample_id = core.fbase(sample_fname)
     sample_pfx = os.path.join(output_dir, sample_id)
 
-    raw_tgt = coverage.do_coverage(
-        target_bed, sample_fname, by_count, min_mapq, processes, fasta
-    )
-    tabio.write(raw_tgt, sample_pfx + ".targetcoverage.cnn")
+    tgt_cnn = sample_pfx + ".targetcoverage.cnn"
+    anti_cnn = sample_pfx + ".antitargetcoverage.cnn"
+    if reuse_coverage and os.path.isfile(tgt_cnn) and os.path.isfile(anti_cnn):
+        logging.info("Reusing existing coverage for %s", sample_fname)
+        raw_tgt = read_cna(tgt_cnn)
+        raw_anti = read_cna(anti_cnn)
+    else:
+        raw_tgt = coverage.do_coverage(
+            target_bed, sample_fname, by_count, min_mapq, processes, fasta
+        )
+        tabio.write(raw_tgt, tgt_cnn)
 
-    raw_anti = coverage.do_coverage(
-        antitarget_bed, sample_fname, by_count, min_mapq, processes, fasta
-    )
-    tabio.write(raw_anti, sample_pfx + ".antitargetcoverage.cnn")
+        raw_anti = coverage.do_coverage(
+            antitarget_bed, sample_fname, by_count, min_mapq, processes, fasta
+        )
+        tabio.write(raw_anti, anti_cnn)
 
     cnarr = fix.do_fix(
         raw_tgt,

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -208,6 +208,53 @@ def add_snp_vcf_args(
 # batch -----------------------------------------------------------------------
 
 
+def _resolve_batch_sample_ids(
+    sample_fnames: list[str], normal_fnames: list[str], building_reference: bool
+) -> set[str]:
+    """Validate sample-ID uniqueness; return tumor IDs reusable from the reference.
+
+    A sample ID (``core.fbase`` of the filename) names the per-sample outputs
+    (``{output_dir}/{sample_id}.*``), so two distinct inputs sharing an ID would
+    silently overwrite each other. A repeated ID *within* either the tumor set
+    or the normal set is therefore always an error.
+
+    The same file legitimately appearing in *both* sets is the intentional
+    self-reference workflow (#48): run presumed-normal samples against a
+    reference built from themselves. The reference build then already computed
+    that sample's (anti)target coverage to the very path ``batch_run_sample``
+    would write, so the tumor run can reuse it instead of recomputing. Such IDs
+    are returned for reuse, but only when a reference is being built this run
+    (with ``-r/--reference`` no coverage was precomputed).
+    """
+
+    def first_paths(fnames: list[str]) -> dict[str, str]:
+        seen: dict[str, str] = {}
+        for fname in fnames:
+            sid = core.fbase(fname)
+            if sid in seen:
+                sys.exit(f"Duplicate sample ID {sid!r} (from {fname} and {seen[sid]})")
+            seen[sid] = fname
+        return seen
+
+    tumor_paths = first_paths(sample_fnames)
+    normal_paths = first_paths(normal_fnames)
+
+    reusable: set[str] = set()
+    for sid, tumor_fname in tumor_paths.items():
+        normal_fname = normal_paths.get(sid)
+        if normal_fname is None:
+            continue
+        if os.path.realpath(tumor_fname) != os.path.realpath(normal_fname):
+            sys.exit(
+                f"Duplicate sample ID {sid!r} from different files "
+                f"({tumor_fname} and {normal_fname}); rename one to avoid "
+                "overwriting outputs."
+            )
+        if building_reference:
+            reusable.add(sid)
+    return reusable
+
+
 def _cmd_batch(args: argparse.Namespace) -> None:
     """Run the complete CNVkit pipeline on one or more BAM or bedGraph files."""
     logging.info("CNVkit %s", __version__)
@@ -248,13 +295,13 @@ def _cmd_batch(args: argparse.Namespace) -> None:
     if bad_args_msg:
         sys.exit(bad_args_msg + "\n(See: cnvkit.py batch -h)")
 
-    # Ensure sample IDs are unique to avoid overwriting outputs
-    seen_sids: dict[str, str] = {}
-    for fname in (args.sample_fnames or []) + (args.normal or []):
-        sid = core.fbase(fname)
-        if sid in seen_sids:
-            sys.exit(f"Duplicate sample ID {sid!r} (from {fname} and {seen_sids[sid]})")
-        seen_sids[sid] = fname
+    # Ensure sample IDs are unique to avoid overwriting outputs, allowing the
+    # same file in both the tumor and normal sets (self-reference, #48).
+    reusable_sids = _resolve_batch_sample_ids(
+        args.sample_fnames or [],
+        args.normal or [],
+        building_reference=not args.reference,
+    )
 
     if args.processes < 1:
         args.processes = parallel.available_cpus()
@@ -332,6 +379,7 @@ def _cmd_batch(args: argparse.Namespace) -> None:
                     args.fasta,
                     args.sample_sex,
                     args.bias_smoother,
+                    core.fbase(bam) in reusable_sids,
                 )
                 futures.append((bam, future))
             # Wait for all tasks to complete and raise any exceptions

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -40,10 +40,25 @@ Run the CNVkit pipeline on one or more BAM files::
         -t my_targets.bed -a my_antitargets.bed \
         -f hg38.fasta -g data/access-10kb.hg38.bed
 
+    # Self-reference QC: build a pooled reference from the normals and analyze
+    # each of them against it, computing each sample's coverage only once
+    cnvkit.py batch *Normal.bam --normal *Normal.bam \
+        --targets my_targets.bed -f hg38.fasta -g data/access-10kb.hg38.bed \
+        --output-reference normals_reference.cnn --output-dir qc/
+
 With the ``-p`` option, process each of the BAM files in parallel, as separate
 subprocesses. The status messages logged to the console will be somewhat
 disorderly, but the pipeline will take advantage of multiple CPU cores to
 complete sooner.
+
+A BAM file may appear in both the tumor/test set and the ``--normal`` set. This
+supports a self-reference quality-control workflow, in which presumed-normal
+samples are analyzed against a pooled reference built from themselves to identify
+noisy or aberrant samples. When a sample is supplied in both roles, its target
+and antitarget coverage are computed once, during reference construction, and
+reused for the per-sample analysis rather than recomputed. Supplying two distinct
+files that share a sample name (the filename without its extension) remains an
+error, since their per-sample outputs would overwrite each other.
 
 ::
 

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -9,6 +9,7 @@ import shutil
 import tempfile
 import unittest
 import warnings
+from unittest import mock
 
 import pytest
 
@@ -401,6 +402,203 @@ class BatchTests(unittest.TestCase):
                 "--bias-smoother loess` reaches center_by_window during "
                 "reference construction (#1028).",
             )
+
+    # -- batch coverage-dedup / self-reference (#48) --
+
+    def test_resolve_batch_sample_ids_self_reference_building(self):
+        """Self-reference returns the shared ID as reusable when building a
+        reference (#48).
+
+        The same file in both the tumor and normal sets is the intentional
+        self-reference workflow; its coverage is computed during the reference
+        build and must be flagged for reuse on the tumor pass. Compared via
+        ``os.path.realpath``, so two spellings of one file still match.
+        """
+        reusable = commands._resolve_batch_sample_ids(
+            ["d/s1.bam"], ["./d/s1.bam"], building_reference=True
+        )
+        self.assertEqual(reusable, {"s1"})
+
+    def test_resolve_batch_sample_ids_self_reference_existing_reference(self):
+        """Self-reference yields no reusable IDs when a reference is supplied
+        rather than built (#48).
+
+        With ``-r/--reference`` nothing was precomputed this run, so even the
+        legitimately-shared sample has no coverage to reuse; the set is empty.
+        """
+        reusable = commands._resolve_batch_sample_ids(
+            ["d/s1.bam"], ["d/s1.bam"], building_reference=False
+        )
+        self.assertEqual(reusable, set())
+
+    def test_resolve_batch_sample_ids_duplicate_within_set(self):
+        """A repeated sample ID within one set (distinct paths, same basename)
+        is always fatal (#48).
+
+        Two inputs sharing an ID would overwrite each other's
+        ``{output_dir}/{id}.*`` outputs, so this must abort regardless of the
+        self-reference allowance.
+        """
+        with self.assertRaises(SystemExit):
+            commands._resolve_batch_sample_ids(
+                ["a/s1.bam", "b/s1.bam"], [], building_reference=True
+            )
+
+    def test_resolve_batch_sample_ids_same_id_different_paths(self):
+        """Same basename from different real paths across the two sets is fatal
+        (#48).
+
+        The self-reference allowance covers only the *same file* in both sets;
+        distinct files colliding on ID would overwrite outputs, so this aborts.
+        """
+        with self.assertRaises(SystemExit):
+            commands._resolve_batch_sample_ids(
+                ["tumor/s1.bam"], ["normal/s1.bam"], building_reference=True
+            )
+
+    def test_resolve_batch_sample_ids_no_overlap(self):
+        """Disjoint tumor/normal ID sets are valid and reuse nothing (#48)."""
+        reusable = commands._resolve_batch_sample_ids(
+            ["t1.bam", "t2.bam"], ["n1.bam", "n2.bam"], building_reference=True
+        )
+        self.assertEqual(reusable, set())
+
+    def test_batch_run_sample_reuse_coverage_guarded_read(self):
+        """``batch_run_sample`` must read existing coverage via ``read_cna``
+        under a branch gated by ``reuse_coverage`` (#48).
+
+        AST-level guard so source rearrangements still catch a regression that
+        drops the reuse branch (or the parameter) without needing a BAM fixture
+        per case, mirroring the bias_smoother/do_call plumbing guards above.
+        """
+        self.assertIn(
+            "reuse_coverage",
+            inspect.signature(batch.batch_run_sample).parameters,
+            "batch_run_sample must expose a reuse_coverage parameter (#48).",
+        )
+        src = inspect.getsource(batch.batch_run_sample)
+        tree = ast.parse(src)
+        guarded_reads = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            names_in_test = {
+                n.id for n in ast.walk(node.test) if isinstance(n, ast.Name)
+            }
+            if "reuse_coverage" not in names_in_test:
+                continue
+            guarded_reads.extend(
+                body_node
+                for body_node in ast.walk(node)
+                if isinstance(body_node, ast.Call)
+                and isinstance(body_node.func, ast.Name)
+                and body_node.func.id == "read_cna"
+            )
+        self.assertGreater(
+            len(guarded_reads),
+            0,
+            "batch_run_sample must read existing coverage via read_cna under a "
+            "branch guarded by reuse_coverage so the self-reference pass skips "
+            "recomputation (#48).",
+        )
+
+    def test_batch_run_sample_reuse_coverage_end_to_end(self):
+        """End-to-end self-reference: the shared sample's coverage is computed
+        once (during the reference build) and reused on the tumor pass (#48).
+
+        Drives the direct API with haar (pure-Python) segmentation. The
+        deterministic dedup signal is the number of ``coverage.do_coverage``
+        calls -- 0 on the reuse pass vs 2 (target + antitarget) without reuse --
+        rather than bit-exact .cnr equality, which is unsafe because the reuse
+        path reads coverage round-tripped through tabio's ``%.6g`` writer while
+        a fresh run uses full-precision in-memory values.
+        """
+        target_bed = "formats/my-targets.bed"
+        fasta = "formats/chrM-Y-trunc.hg19.fa"
+        bam = "formats/na12878-chrM-Y-trunc.bam"
+        sample_id = core.fbase(bam)
+        outdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outdir, ignore_errors=True)
+
+        # Build a hybrid-capture reference from the sample itself; this writes
+        # {outdir}/{sample_id}.{target,antitarget}coverage.cnn.
+        ref_fname, tgt_bed_fname, anti_bed_fname = batch.batch_make_reference(
+            [bam],
+            target_bed,
+            None,
+            True,
+            None,
+            fasta,
+            None,
+            True,
+            10,
+            None,
+            1000,
+            100,
+            None,
+            outdir,
+            1,
+            False,
+            0,
+            "hybrid",
+            False,
+        )
+        self.assertTrue(os.path.isfile(ref_fname))
+        self.assertTrue(
+            os.path.isfile(os.path.join(outdir, sample_id + ".targetcoverage.cnn"))
+        )
+
+        def run(reuse):
+            with mock.patch.object(
+                batch.coverage,
+                "do_coverage",
+                wraps=batch.coverage.do_coverage,
+            ) as spy:
+                batch.batch_run_sample(
+                    bam,
+                    tgt_bed_fname,
+                    anti_bed_fname,
+                    ref_fname,
+                    outdir,
+                    True,
+                    None,
+                    False,
+                    False,
+                    "Rscript",
+                    False,
+                    0,
+                    False,
+                    "hybrid",
+                    "haar",
+                    1,
+                    False,
+                    fasta=fasta,
+                    reuse_coverage=reuse,
+                )
+            return spy.call_count
+
+        # Control first: the default path recomputes both (anti)target coverage,
+        # proving the spy has teeth and reuse is what suppresses the calls.
+        self.assertEqual(
+            run(reuse=False),
+            2,
+            "reuse_coverage=False must recompute target + antitarget coverage.",
+        )
+        # Self-reference tumor pass with reuse: coverage is read back, never
+        # recomputed. Runs last so the output assertions below defend the reuse
+        # path's products.
+        self.assertEqual(
+            run(reuse=True),
+            0,
+            "reuse_coverage=True must skip do_coverage for the shared sample "
+            "whose coverage the reference build already wrote (#48).",
+        )
+
+        # Outputs from the reuse pass exist and are non-empty.
+        cnr = cnvlib.read(os.path.join(outdir, sample_id + ".cnr"))
+        self.assertGreater(len(cnr), 0)
+        call_cns = cnvlib.read(os.path.join(outdir, sample_id + ".call.cns"))
+        self.assertGreater(len(call_cns), 0)
 
     @pytest.mark.slow
     def test_diploid_parx_genome(self):


### PR DESCRIPTION
## Summary

`cnvkit.py batch` previously exited whenever a sample ID appeared in both the tumor/test set (positional args) and the `--normal` set, which blocked the self-reference QC workflow: analyzing presumed-normal samples against a reference built from themselves to identify noisy or aberrant samples (#48). It also meant a shared sample's coverage would be computed twice.

Now the same file may appear in both sets. Its target and antitarget coverage are computed once, during reference construction, and reused for the per-sample analysis rather than recomputed. Supplying two *distinct* files that share a sample name (basename without extension) remains an error, since their per-sample outputs would overwrite each other.

## Changes

- **`cnvlib/commands.py`** — new `_resolve_batch_sample_ids` helper replaces the inline duplicate-ID guard. It validates sample-ID uniqueness (still fatal for a repeated ID within either set, or the same ID from different files across sets) and returns the tumor IDs reusable from the just-built reference (same file in both sets, only when building a reference this run).
- **`cnvlib/batch.py`** — `batch_run_sample` gains a `reuse_coverage` parameter; when set and the `{output_dir}/{sample_id}.{,anti}targetcoverage.cnn` files already exist, they are read via `read_cna` instead of recomputed. The default path is byte-identical to before.
- **`doc/pipeline.rst`** — documents the self-reference workflow and the dedup semantics.
- **`test/test_batch.py`** — helper unit cases (self-reference reusable; not reusable with `-r`; within-set duplicate fatal; cross-set different-path fatal; disjoint sets), an AST guard on the reuse branch, and an end-to-end test asserting coverage is computed once (via a `do_coverage` call-count spy) and reused.

## Verification

- End-to-end CLI self-reference run: exit 0, coverage computed once, full pipeline output produced; a distinct tumor/normal run still computes coverage twice (default path unchanged).
- `pytest test/test_batch.py -m "not slow"`: 14 passed. (`test_diploid_parx_genome` is deselected; it requires the R `DNAcopy` package, a pre-existing environment dependency unrelated to this change.)
- `ruff check` and `ruff format --check` clean.

Fixes #48
