### PR TITLE
docs: remove internal beads issue-ID tags from source comments

### DIFF
--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -54,7 +54,7 @@ class VariantArray(GenomicArray):
             logging.warning("VCF has no allele frequencies for BAF calculation")
             # Length must match `ranges` (one value per bin), like the normal
             # into_ranges path -- not the variant rows (self.data.index), which
-            # made a shorter/longer Series and crashed callers. (cnvkit-ugh)
+            # made a shorter/longer Series and crashed callers.
             return pd.Series(np.repeat(np.nan, len(ranges)))
 
         def summarize(vals):

--- a/test/test_segmentation.py
+++ b/test/test_segmentation.py
@@ -94,9 +94,9 @@ class SegmentationTests(unittest.TestCase):
         )
         self.assertGreater(len(segments), n_chroms)
         self.assertTrue((segments.start < segments.end).all())
-        # haar segmentation with variants unions depth+BAF breakpoints
-        # (cnvkit-ugh); see test_haar_vcf_detects_copy_neutral_loh for the LOH
-        # behavior. Here just confirm it runs and yields valid segments.
+        # haar segmentation with variants unions depth+BAF breakpoints;
+        # see test_haar_vcf_detects_copy_neutral_loh for the LOH behavior.
+        # Here just confirm it runs and yields valid segments.
         varr = tabio.read("formats/na12878_na12882_mix.vcf", "vcf")
         segments = segmentation.do_segmentation(cnarr, "haar", variants=varr)
         self.assertGreater(len(segments), n_chroms)
@@ -183,7 +183,7 @@ class SegmentationTests(unittest.TestCase):
         self.assertEqual(rstr, "")
 
     def test_threshold_zero_not_overridden(self):
-        """threshold=0.0 is honored, not treated as 'unset' (scq.4).
+        """threshold=0.0 is honored, not treated as 'unset'.
 
         'if not threshold' replaced the valid value 0.0 with the method default;
         'if threshold is None' keeps it.
@@ -197,7 +197,7 @@ class SegmentationTests(unittest.TestCase):
 
     def test_haar_vcf_detects_copy_neutral_loh(self):
         """`-m haar --vcf` unions depth+BAF breakpoints -> catches copy-neutral
-        LOH (flat depth, BAF shift), and adds a 'baf' column (cnvkit-ugh)."""
+        LOH (flat depth, BAF shift), and adds a 'baf' column."""
         n = 120
         rng = np.random.default_rng(0)
         cnarr = cnary.CopyNumArray(
@@ -244,7 +244,7 @@ class SegmentationTests(unittest.TestCase):
 
     def test_haar_vcf_without_allele_info_falls_back(self):
         """`-m haar --vcf` on a VCF lacking AF and AD/DP must not crash; it
-        falls back to depth-only segmentation (cnvkit-ugh)."""
+        falls back to depth-only segmentation."""
         n = 30
         cnarr = cnary.CopyNumArray(
             pd.DataFrame(


### PR DESCRIPTION
## Summary

Beads issue IDs (e.g. `cnvkit-ugh`, `scq.4`) are an internal tracking device that carries no meaning to external readers, so they should not appear in persisted artifacts. PR #1118 stripped these tags from `cnvlib/segmentation/haar.py` and `test/test_haar.py`; this PR removes the remaining five occurrences.

| File | Tag removed |
|------|-------------|
| `cnvlib/vary.py:57` | `cnvkit-ugh` |
| `test/test_segmentation.py:98` | `cnvkit-ugh` |
| `test/test_segmentation.py:186` | `scq.4` |
| `test/test_segmentation.py:200` | `cnvkit-ugh` |
| `test/test_segmentation.py:247` | `cnvkit-ugh` |

## Notes

- Comment/docstring-only edits — no numerical or output-format changes, so no clinical-pipeline impact.
- The `test_segmentation.py:98` case required minor grammar re-flow because the tag sat at the start of a comment continuation; the others were trailing parentheticals removed cleanly.

## Verification

```
grep -rnE 'cnvkit-[a-z0-9]{3}|scq\.[0-9]+' --include='*.py' --include='*.rst' cnvlib/ skgenome/ test/ doc/
```

returns only two legitimate false positives — `cnvkit-filt.` (a tempfile prefix in `coverage.py`) and `cnvkit-from-picard/` (an example output directory in the docs), neither of which is a bead ID.

`test/test_segmentation.py` passes (14 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)