### PR TITLE
CI: trim test matrix to 3.14 (Linux+macOS) and 3.12-macOS

### DIFF
--- a/.github/workflows/tests-tox.yaml
+++ b/.github/workflows/tests-tox.yaml
@@ -21,8 +21,7 @@ jobs:
       matrix:
         include:
           - {name: '3.14', python: '3.14', os: ubuntu-latest, tox: py314}
-          - {name: '3.13', python: '3.13', os: ubuntu-latest, tox: py313}
-          - {name: '3.12', python: '3.12', os: ubuntu-latest, tox: py312}
+          - {name: '3.14-MacOS', python: '3.14', os: macos-latest, tox: py314}
           - {name: '3.12-MacOS', python: '3.12', os: macos-latest, tox: py312}
           - {name: '3.11', python: '3.11', os: ubuntu-latest, tox: py311}
           - {name: '3.11-min', python: '3.11', os: ubuntu-latest, tox: "py311-min"}


### PR DESCRIPTION
Simplifies the unit-test matrix in `tests-tox.yaml`:

- **Drop** the Linux unit-test jobs for Python 3.13 and 3.12.
- **Keep** `3.12-MacOS` (full unit suite on 3.12 continues on macOS).
- **Add** `3.14-MacOS` so the newest supported Python is exercised on both Linux and macOS.

Python 3.12 retains Linux exercise through the lint, typecheck, security, and coverage environments (all pinned to 3.12 on Ubuntu), so dropping the standalone 3.12 Linux unit job does not remove 3.12 from CI entirely. The `py314` tox environment already exists (used by the existing 3.14 Linux job), so the new macOS job reuses it without further changes.

Resulting unit-test matrix: 3.14 (Linux), 3.14-macOS, 3.12-macOS, 3.11 (Linux), 3.11-min (Linux).