### PR TITLE
Fix antitarget crash when --output is omitted (#806)

### DIFF
--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -686,7 +686,7 @@ def _cmd_antitarget(args: argparse.Namespace) -> None:
     access = tabio.read_auto(args.access) if args.access else None
     out_arr = antitarget.do_antitarget(targets, access, args.avg_size, args.min_size)
     if not args.output:
-        base, ext = args.interval.rsplit(".", 1)
+        base, ext = args.targets.rsplit(".", 1)
         args.output = base + ".antitarget." + ext
     tabio.write(out_arr, args.output, "bed4")
 

--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Tests for preprocessing commands: access, antitarget, autobin, target, coverage."""
 
+import argparse
 import logging
 import os
 import shutil
@@ -94,6 +95,33 @@ class PreprocessingTests(unittest.TestCase):
         self.assertLess(0, len(commands.do_antitarget(baits, acs)))
         self.assertLess(0, len(commands.do_antitarget(baits, acs, 200000)))
         self.assertLess(0, len(commands.do_antitarget(baits, acs, 10000, 5000)))
+
+    def test_cmd_antitarget_default_output(self):
+        """#806: the 'antitarget' CLI command with -o/--output omitted must
+        derive the default output filename from args.targets. The pre-fix code
+        referenced the nonexistent args.interval and raised AttributeError in
+        this default-output branch; after the args.targets fix it succeeds.
+        Exercises commands._cmd_antitarget, which the (slow) test_antitarget
+        above never touches."""
+        with tempfile.TemporaryDirectory() as tmp:
+            # Copy a tiny targets BED into a temp dir so the derived default
+            # output lands there, not in test/formats/.
+            targets_bed = os.path.join(tmp, "mytargets.bed")
+            shutil.copy("formats/agilent.bed", targets_bed)
+            args = argparse.Namespace(
+                targets=targets_bed,
+                access=None,
+                avg_size=150000,
+                min_size=None,
+                output=None,
+            )
+            # Pre-fix: raises AttributeError here (args.interval). Post-fix: OK.
+            commands._cmd_antitarget(args)
+            expect_out = os.path.join(tmp, "mytargets.antitarget.bed")
+            self.assertTrue(os.path.exists(expect_out))
+            self.assertGreater(os.path.getsize(expect_out), 0)
+            # Sanity: the derived file parses back as a genomic table.
+            self.assertGreater(len(tabio.read_auto(expect_out)), 0)
 
     def test_autobin(self):
         """The 'autobin' command."""


### PR DESCRIPTION
Fixes #806.

## Problem

`cnvkit.py antitarget <targets>` raised `AttributeError: 'Namespace' object has no attribute 'interval'` whenever `-o/--output` was omitted. The default-output-filename branch of `_cmd_antitarget` derived the name from `args.interval`, but the `antitarget` subparser defines its positional as `targets` and has no `interval` attribute. (`interval` is the positional of the separate `target` command; this was a copy-paste from `_cmd_target`.) Because the branch always failed on that attribute access, the default-output path never worked.

## Fix

Derive the default name from `args.targets` (one token). The handler already reads `args.targets` when loading the input, so it is now internally consistent.

## Test

Adds `test/test_preprocessing.py::PreprocessingTests::test_cmd_antitarget_default_output`, which exercises `_cmd_antitarget` with `output=None` and asserts the derived `<base>.antitarget.bed` is written and parses. This path was previously uncovered (the existing `test_antitarget` calls `do_antitarget` directly, never the CLI wrapper). Revert-verified: the test fails on the old `args.interval` line with the exact `AttributeError` and passes on the fix.

## Note (out of scope)

The fix makes a previously-unreachable branch live. That branch's filename derivation uses `str.rsplit('.', 1)`, which would raise `ValueError` on an extension-less targets filename; `os.path.splitext` would handle it gracefully. This is pre-existing and does not affect normal BED/interval inputs (which always carry an extension), so it is left as a possible follow-up rather than folded into this minimal fix.
