### PR TITLE
Call: substitute neutral copy number for NaN log2 (#647)

### DIFF
--- a/cnvlib/call.py
+++ b/cnvlib/call.py
@@ -326,7 +326,9 @@ def absolute_threshold(
             row.chromosome, ploidy, is_haploid_x_reference
         )
         if np.isnan(row.log2):
-            # XXX fallback
+            # A NaN log2 (malformed input) is replaced with the neutral
+            # reference copy number, consistent with absolute_pure and
+            # absolute_clonal, rather than emitting a garbage integer.
             logging.warning(
                 "log2=nan found; replacing with neutral copy number %s", ref_copies
             )
@@ -374,6 +376,12 @@ def absolute_pure(
         ref_copies = _reference_copies_pure(
             row.chromosome, ploidy, is_haploid_x_reference
         )
+        if np.isnan(row.log2):
+            logging.warning(
+                "log2=nan found; replacing with neutral copy number %s", ref_copies
+            )
+            absolutes[i] = ref_copies
+            continue
         absolutes[i] = _log2_ratio_to_absolute_pure(row.log2, ref_copies)
     return absolutes
 
@@ -396,6 +404,13 @@ def absolute_dataframe(
         ),
         axis=1,
     )
+    nan_mask = df["log2"].isna()
+    if nan_mask.any():
+        logging.warning(
+            "log2=nan found in %d segment(s); replacing with neutral copy number",
+            int(nan_mask.sum()),
+        )
+        df.loc[nan_mask, "absolute"] = df.loc[nan_mask, "reference"]
     return df[["absolute", "expect", "reference"]]
 
 
@@ -546,9 +561,10 @@ def _log2_ratio_to_absolute(
         # deletion, or the NULL_LOG2_COVERAGE sentinel from zero-coverage bins),
         # this formula extrapolates to a negative count; clamp it to 0 so the
         # 'call' command never emits a nonsensical negative copy number (#503).
-        # A NaN log2 (malformed input) is left to propagate rather than silently
-        # floored to 0 -- a false homozygous-deletion call would be worse than a
-        # surfaced error (cf. the np.isnan guard in absolute_threshold).
+        # A NaN log2 (malformed input) yields NaN here; skip the clamp so it
+        # stays NaN and the caller (absolute_clonal/absolute_dataframe) can
+        # substitute the neutral reference copy number -- matching the np.isnan
+        # guard in absolute_threshold rather than emitting a false deletion.
         if not np.isnan(ncopies):
             ncopies = max(0.0, ncopies)
     else:

--- a/test/test_call.py
+++ b/test/test_call.py
@@ -111,6 +111,62 @@ class CallTests(unittest.TestCase):
         )
         self.assertEqual(len(cl_cns), len(cl_none))
 
+    def test_call_nan_log2_neutral_fallback(self):
+        """A NaN log2 segment must not produce a garbage integer copy number.
+
+        Regression for #647: a non-finite log2 reaching the integer cast in
+        do_call silently yielded the int64 sentinel (-9223372036854775808) on
+        older NumPy, or a false homozygous-deletion cn=0 on newer NumPy, for
+        the clonal and pure paths -- whereas the threshold path already mapped
+        NaN to the neutral reference copy number. All methods must agree:
+        substitute the neutral copy number, never emit garbage.
+        """
+        # NaN log2 on an autosome and on both sex chromosomes, where the
+        # neutral reference copy number differs (chr1=2; chrX=1 and chrY=1
+        # under a haploid-X reference). Interleave finite segments as controls.
+        segarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1", "chr1", "chrX", "chrY"],
+                    "start": [0, 1000, 0, 0],
+                    "end": [1000, 2000, 1000, 1000],
+                    "gene": ["A", "B", "C", "D"],
+                    "log2": [np.nan, 0.5, np.nan, np.nan],
+                    "weight": [1.0, 1.0, 1.0, 1.0],
+                    "probes": [10, 10, 10, 10],
+                }
+            )
+        )
+        sentinel = np.iinfo(np.int64).min
+        # Neutral reference copies per NaN segment: chr1=2, chrX=1, chrY=1.
+        expected_neutral = {0: 2, 2: 1, 3: 1}
+        results = {}
+        for method, kwargs in (
+            ("clonal", {}),  # -> absolute_pure
+            ("clonal_purity", {"purity": 0.6}),  # -> absolute_clonal
+            ("threshold", {}),  # already guarded; pin the shared contract
+        ):
+            out = commands.do_call(
+                segarr,
+                None,
+                method.split("_")[0],
+                is_haploid_x_reference=True,
+                is_sample_female=True,
+                **kwargs,
+            )
+            cn = out["cn"]
+            results[method] = list(cn)
+            for idx, neutral in expected_neutral.items():
+                self.assertEqual(cn[idx], neutral, f"{method} seg{idx}")
+                self.assertNotEqual(cn[idx], sentinel, f"{method} seg{idx}")
+            self.assertTrue((cn >= 0).all(), method)
+        # All three call methods must agree on the NaN-segment copy numbers.
+        for idx in expected_neutral:
+            called = {m: r[idx] for m, r in results.items()}
+            self.assertEqual(
+                len(set(called.values())), 1, f"methods disagree at seg{idx}: {called}"
+            )
+
     def test_call_filter(self):
         segments = cnvlib.read("formats/tr95t.segmetrics.cns")
         variants = tabio.read("formats/na12878_na12882_mix.vcf", "vcf")


### PR DESCRIPTION
## Problem

A non-finite `log2` reaching the integer cast in `do_call` (`absolutes.round().astype("int")`, `cnvlib/call.py`) silently produced a garbage integer copy number in the `.cns` `cn` column:

- the int64 sentinel `-9223372036854775808` on older NumPy, or
- a false homozygous-deletion `cn=0` with a spurious `invalid value encountered in cast` RuntimeWarning on NumPy 2.x.

Only `absolute_threshold` guarded NaN. The clonal path (`absolute_pure`) and the clonal-with-purity path (`absolute_clonal` → `absolute_dataframe`) did not, so `call -m clonal` and `call -m clonal --purity` on a segment carrying a NaN `log2` emitted the garbage value with no error. Reported in #647.

## Fix

Guard both unguarded paths, substituting the **neutral per-chromosome reference copy number** with a warning, mirroring the existing `absolute_threshold` behavior. Because the guards sit at the shared layer, the `export` command (`export_bed` and the export path via `absolute_dataframe`) is fixed at the same time.

Also updates the now-accurate comment in `_log2_ratio_to_absolute` (which previously claimed a NaN would surface as an error — it never did) and drops the stale `XXX fallback` marker above the threshold guard.

## Semantics

A non-finite `log2` now yields the neutral reference copy number (never a garbage integer), consistently across the `clonal`, `clonal --purity`, and `threshold` methods — a false homozygous-deletion call would be worse than a defined neutral fallback.

## Test

Adds `test_call_nan_log2_neutral_fallback`, pinning the neutral fallback on chr1/chrX/chrY (where the neutral copy number differs: 2/1/1 under a haploid-X reference) and asserting all three methods agree on NaN segments. It discriminates against the pre-fix code (`cn=0` on the ndarray path; `IntCastingNaNError` on the Series path).

Verified: `test_call`, `test_export`, `test_regression`, `test_cnvlib` pass; `ruff check` / `ruff format --check` clean.

Fixes #647