### PR TITLE
Fix read-only/aliasing crash in weighted-array NaN fill (#672)

### DIFF
--- a/cnvlib/descriptives.py
+++ b/cnvlib/descriptives.py
@@ -74,10 +74,15 @@ def on_weighted_array(default: object = None) -> Callable:
                 if default is None:
                     return a[0]
                 return default
-            # Fill w's NaN indices
+            # Fill w's NaN indices with 0. Build a new array rather than
+            # assigning in place: `np.asarray` above returns the caller's
+            # buffer unchanged when it is already float, so an in-place write
+            # would both mutate the caller's weights and raise on a read-only
+            # view (e.g. a pandas copy-on-write slice, as produced by the
+            # non-finite-bin drop in segmentation -> HMM's weighted_std).
             w_nan = np.isnan(w)
             if w_nan.any():
-                w[w_nan] = 0.0
+                w = np.where(w_nan, 0.0, w)
             return f(a, w, **kwargs)
 
         return wrapper

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -32,6 +32,7 @@ from cnvlib.descriptives import (
     median_absolute_deviation,
     q_n,
     weighted_median,
+    weighted_std,
 )
 from cnvlib.smoothing import (
     _width2wing,
@@ -282,6 +283,37 @@ class TestWeightedMedian:
     def test_mismatched_lengths_raises(self):
         with pytest.raises(ValueError, match="Unequal array lengths"):
             weighted_median(np.array([1.0, 2.0]), np.array([1.0]))
+
+
+class TestOnWeightedArrayNaNSafety:
+    """The on_weighted_array wrapper must fill NaN weights safely (#672).
+
+    The wrapper promises to "replace any remaining NaN cells in w with 0."
+    It formerly did so with an in-place ``w[w_nan] = 0.0``, which (a) mutated
+    the caller's weight array and (b) raised ``ValueError: assignment
+    destination is read-only`` on a read-only buffer -- e.g. the pandas
+    copy-on-write slice produced when segmentation drops non-finite-log2 bins
+    and HMM's smooth_log2 then calls weighted_std, aborting the run. The fill
+    must build a new array instead.
+    """
+
+    def test_does_not_mutate_caller_weights(self):
+        a = np.array([0.1, 0.2, 0.3, 0.4])
+        w = np.array([1.0, np.nan, 2.0, 3.0])
+        w_before = w.copy()
+        weighted_std(a, w)
+        weighted_median(a, w)
+        # The NaN weight is untouched: the wrapper worked on a copy.
+        np.testing.assert_array_equal(w, w_before)
+        assert np.isnan(w[1])
+
+    def test_read_only_weights_do_not_raise(self):
+        a = np.array([0.1, 0.2, 0.3, 0.4])
+        w = np.array([1.0, np.nan, 2.0, 3.0])
+        w.setflags(write=False)
+        # Must not raise "assignment destination is read-only".
+        assert np.isfinite(weighted_std(a, w))
+        assert np.isfinite(weighted_median(a, w))
 
 
 class TestGapperScale:

--- a/test/test_segmentation.py
+++ b/test/test_segmentation.py
@@ -485,3 +485,44 @@ class TransferFieldsTests(unittest.TestCase):
         cns = segmentation.do_segmentation(cnarr, "haar", processes=1)
         self.assertGreater(len(cns), 0)
         self.assertTrue(np.isfinite(cns["log2"].to_numpy()).all())
+
+    def test_hmm_tolerates_nonfinite_log2_and_nan_weight(self):
+        """HMM segmentation must not hard-abort on non-finite bins (#672).
+
+        Dropping non-finite-log2 bins (the boundary guard) hands the HMM path a
+        pandas copy-on-write slice whose buffers are read-only. HMM then calls
+        smooth_log2 -> guess_window_size -> weighted_std, whose NaN-weight fill
+        formerly wrote in place and raised "assignment destination is
+        read-only", intermittently aborting batch/coverage runs. A surviving
+        NaN bin weight must be filled on a copy, not the shared buffer.
+
+        Uses a single chromosome so the whole-genome transfer_fields path is not
+        exercised (the separate all-of-first-chromosome-dropped edge is tracked
+        independently); the weighted_std path that crashed is shared by every
+        method.
+        """
+        n = 120  # > guess_window_size / drop_outliers width so smoothing runs
+        rng = np.random.default_rng(0)
+        log2 = rng.normal(0, 0.2, n)
+        log2[5] = np.nan  # dropped at the boundary -> read-only CoW slice
+        log2[60] = np.inf  # ±inf dropped too
+        weight = np.ones(n)
+        weight[70] = np.nan  # survives the log2 drop -> hits the fill path
+        cnarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * n,
+                    "start": np.arange(0, n * 1000, 1000),
+                    "end": np.arange(1000, n * 1000 + 1000, 1000),
+                    "gene": ["G"] * n,
+                    "log2": log2,
+                    "depth": np.ones(n) * 100.0,
+                    "weight": weight,
+                }
+            )
+        )
+        # Must not raise; no non-finite must leak into the segment output.
+        cns = segmentation.do_segmentation(cnarr, "hmm", processes=1)
+        self.assertGreater(len(cns), 0)
+        self.assertTrue(np.isfinite(cns["log2"].to_numpy()).all())
+        self.assertFalse(np.isnan(cns["weight"].to_numpy()).any())


### PR DESCRIPTION
## Problem

`on_weighted_array` in `cnvlib/descriptives.py` (the decorator wrapping `weighted_std` and `weighted_median`) promises to replace NaN weight cells with 0. It did so in place with `w[w_nan] = 0.0`, which had two defects:

- `w = np.asarray(w, dtype=float)` returns the caller's buffer unchanged when it is already float, so the in-place write **mutated the caller's weights array** (aliasing bug).
- On a read-only buffer it raised `ValueError: assignment destination is read-only`. This is reached in the HMM segmentation path: `do_segmentation` drops non-finite-log2 bins with a boolean-mask slice, which under pandas copy-on-write yields a read-only array; HMM then calls `smooth_log2 → guess_window_size → weighted_std`, and a surviving NaN bin weight triggers the crash — intermittently aborting `batch`/`coverage` runs.

## Fix

Fill on a fresh array with `w = np.where(w_nan, 0.0, w)`. No caller mutation, no read-only crash. The finite-weight path is **byte-identical**: the fill is guarded by `w_nan.any()`, so weights without NaN pass through untouched, and numerical output on normal data is unchanged.

## Scope / relationship to #672

The error #672 was triaged under (`Cannot convert non-finite values (NA or inf) to integer`) is **already fixed on master**: non-finite log2 is dropped at the segmentation boundary (`segmentation/__init__.py`, `~np.isfinite`) before any integer cast, and `coverage` floors log2 to `NULL_LOG2_COVERAGE`. Verifying that (across CBS/haar/none/HMM on a non-finite fixture) surfaced this residual non-finite hard-abort in the HMM path, which this PR addresses.

A deeper HMM `transfer_fields` `AssertionError` (when a non-finite log2 wipes out the entire first chromosome) was found and is tracked independently — it is a behavioral `.cns` change requiring separate validation, so it is intentionally out of scope here.

## Tests

- `test/test_properties.py::TestOnWeightedArrayNaNSafety` — unit tests for the aliasing (caller weights unmutated) and read-only (no crash) invariants of `on_weighted_array`.
- `test/test_segmentation.py::TransferFieldsTests::test_hmm_tolerates_nonfinite_log2_and_nan_weight` — HMM integration test exercising the real `smooth_log2 → weighted_std` path on non-finite-log2 + NaN-weight input.

All three fail on the pre-fix code (aliasing mutation; read-only `ValueError`; HMM abort) and pass with the fix. Full suite: 548 passed; `ruff check` and `ruff format --check` clean.

Refs #672