### PR TITLE
Fix savgol overshoot check on non-finite input (#543)

### DIFF
--- a/cnvlib/smoothing.py
+++ b/cnvlib/smoothing.py
@@ -307,18 +307,27 @@ def savgol(
         # TODO fit edges here, too
         window = savgol_coeffs(window_width, order)
         y, _w = convolve_weighted(window, signal, weights, n_iter)
-    # Safety
-    bad_idx = (y > x.max()) | (y < x.min())
-    if bad_idx.any():
-        logging.warning(
-            "Smoothing overshot at %s / %s indices: (%s, %s) vs. original (%s, %s)",
-            bad_idx.sum(),
-            len(bad_idx),
-            y.min(),
-            y.max(),
-            x.min(),
-            x.max(),
-        )
+    # Safety: flag smoothed values that overshoot the input's finite range.
+    # Bounds are taken over finite bins only: non-finite bins (NaN/inf, e.g.
+    # zero-depth antitargets on WGS that reach savgol via smooth_log2 without a
+    # prior drop) make a plain x.max()/x.min() NaN, which silently disables this
+    # check (every comparison against NaN is False) and, on older numpy, emitted
+    # "invalid value encountered in less/greater" RuntimeWarnings (#543).
+    finite = np.isfinite(x)
+    if finite.any():
+        xf = x[finite]
+        lo, hi = xf.min(), xf.max()
+        bad_idx = (y > hi) | (y < lo)
+        if bad_idx.any():
+            logging.warning(
+                "Smoothing overshot at %s / %s indices: (%s, %s) vs. original (%s, %s)",
+                bad_idx.sum(),
+                len(bad_idx),
+                np.nanmin(y),
+                np.nanmax(y),
+                lo,
+                hi,
+            )
     return y[total_wing:-total_wing]
 
 

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -10,7 +10,9 @@ See: https://github.com/etal/cnvkit/issues/1038
 
 from __future__ import annotations
 
+import logging
 import os
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -507,6 +509,48 @@ class TestSavgol:
         assert np.isfinite(result).all()
         assert calls["interp"] >= 1, "Interp path should have been attempted"
         assert calls["fallback"] >= 1, "Fallback (non-polyfit) path should have run"
+
+    def test_nan_input_runs_clean_on_nan_bins(self):
+        """Savgol runs the weighted NaN path without warning or crashing (#543).
+
+        Zero-depth antitarget bins on WGS reach savgol via smooth_log2 with NaN
+        log2 values and zero weight. This is a smoke test for that end-to-end
+        scenario: it does not discriminate the fix on the supported numpy floor
+        (numpy >= 2.3.5 no longer signals FP-invalid on NaN comparisons, so the
+        pre-fix NaN bounds were warning-free there too), but it guards the path
+        against regressions and against older numpy that did warn. The
+        functional value of the fix -- restoring the overshoot check that NaN
+        bounds silently disabled -- is covered by the companion test below.
+        """
+        x = np.array([1.0, 2.0, np.nan, 4.0, 5.0, np.nan, 7.0, 8.0, 9.0, 10.0])
+        weights = np.where(np.isnan(x), 0.0, 1.0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = savgol(x, total_width=5, weights=weights)
+        assert len(result) == len(x)
+
+    def test_overshoot_check_ignores_nan_bounds(self, caplog):
+        """The overshoot check uses finite bounds even when x contains NaN.
+
+        A plain x.max()/x.min() is NaN on non-finite input, so every
+        comparison is False and a genuine overshoot goes silently undetected.
+        Computing the bounds over the finite values restores the check: a
+        spike that makes the smoother overshoot the input's [0, 100] range is
+        still logged despite an intervening NaN bin (#543).
+        """
+        n = 60
+        x = np.zeros(n)
+        x[30] = 100.0  # spike -> smoother overshoots the finite [0, 100] range
+        x[10] = np.nan  # non-finite bin that would poison x.max()/x.min()
+        weights = np.where(np.isnan(x), 0.0, 1.0)
+        with caplog.at_level(logging.WARNING):
+            savgol(x, total_width=11, weights=weights)
+        overshoot = [
+            r.getMessage() for r in caplog.records if "overshot" in r.getMessage()
+        ]
+        assert overshoot, "Overshoot must be detected despite the NaN bin"
+        # The logged 'original' bounds are the finite range, not NaN.
+        assert "vs. original (0.0, 100.0)" in overshoot[0]
 
 
 class TestLoess:


### PR DESCRIPTION
## Problem

The Savitzky-Golay overshoot safety check in `savgol()` compared the smoothed signal against `x.max()`/`x.min()`. When `x` contains non-finite bins (NaN/inf — e.g. zero-depth antitarget bins on WGS that reach `savgol` via `CopyNumArray.smooth_log2` without a prior drop), those bounds are non-finite, so every elementwise comparison is `False` and the overshoot check **silently no-ops**. On older numpy the same comparison also emitted the recurring `RuntimeWarning: invalid value encountered in less/greater` reported in #543. (On numpy >= 2.3.5 the warning no longer fires, but the check is still silently disabled on non-finite input.)

## Fix

Compute the overshoot bounds over the finite values only. This restores the check on non-finite input and is warning-free on every numpy. `np.isfinite` also excludes `±inf`, matching the intent of the check.

Behavior on all-finite input is unchanged: the returned smoothed array is untouched, and the overshoot bounds are identical, so numerical output (`.cnr`/`.cns`/`.cnn`/SEG/VCF) is bit-exact.

## Tests

- `test_overshoot_check_ignores_nan_bounds` — asserts the overshoot check still fires when a NaN bin is present (fails without this fix).
- `test_nan_input_runs_clean_on_nan_bins` — smoke test for the weighted NaN path.

Fixes #543