### PR TITLE
Log clonal+purity confirmation in call (#424)

### DIFF
--- a/cnvlib/call.py
+++ b/cnvlib/call.py
@@ -184,7 +184,14 @@ def do_call(
             outarr["nbaf"] = 0
 
     if purity and purity < 1.0:
-        logging.info("Rescaling sample with purity %g, ploidy %g", purity, ploidy)
+        if method == "clonal":
+            logging.info(
+                "Calling copy number with clonal ploidy %g, rescaled for purity %g",
+                ploidy,
+                purity,
+            )
+        else:
+            logging.info("Rescaling sample with purity %g, ploidy %g", purity, ploidy)
         absolutes = absolute_clonal(
             outarr,
             ploidy,

--- a/test/test_call.py
+++ b/test/test_call.py
@@ -735,6 +735,87 @@ class CallTests(unittest.TestCase):
             np.isnan(call._log2_ratio_to_absolute(np.nan, 2, 2, purity=0.5))
         )
 
+    @staticmethod
+    def _clonal_purity_cns():
+        """Deterministic 4-segment fixture spanning del/loss/gain/amp log2."""
+        return cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1", "chr1", "chr1", "chr1"],
+                    "start": [0, 1000, 2000, 3000],
+                    "end": [1000, 2000, 3000, 4000],
+                    "gene": ["A", "B", "C", "D"],
+                    "log2": [-1.2, -0.3, 0.4, 0.9],
+                    "weight": [1.0, 1.0, 1.0, 1.0],
+                    "probes": [10, 10, 10, 10],
+                }
+            )
+        )
+
+    def test_call_clonal_purity_honors_purity(self):
+        """clonal + purity uses the purity-aware absolute_clonal path (#424).
+
+        Regression guard: the purity branch computes purity-adjusted clonal
+        absolutes, so -m clonal --purity 0.7 must differ from pure clonal
+        (purity=1.0). This pins the current-master cn values and would fail if
+        a "fix" reordered the branches to overwrite them with absolute_pure.
+        """
+        cns = self._clonal_purity_cns()
+        clonal_purity = commands.do_call(
+            cns,
+            None,
+            "clonal",
+            purity=0.7,
+            is_haploid_x_reference=True,
+            is_sample_female=True,
+        )
+        self.assertEqual(list(clonal_purity["cn"]), [0, 1, 3, 4])
+        pure_clonal = commands.do_call(
+            cns,
+            None,
+            "clonal",
+            is_haploid_x_reference=True,
+            is_sample_female=True,
+        )
+        # Purity must be honored: distinct from the pure-clonal call.
+        self.assertEqual(list(pure_clonal["cn"]), [1, 2, 3, 4])
+
+    def test_call_clonal_purity_log_confirms_clonal(self):
+        """clonal + purity logs a line naming both clonal and purity (#424).
+
+        The reported defect was a misleading log: with --purity <1 and
+        -m clonal, the elif clonal branch is skipped, so the old code only
+        printed "Rescaling sample with purity ...", making users think
+        -m clonal was ignored. The purity branch now confirms clonal.
+        """
+        cns = self._clonal_purity_cns()
+        with self.assertLogs(level="INFO") as ctx:
+            commands.do_call(
+                cns,
+                None,
+                "clonal",
+                purity=0.7,
+                is_haploid_x_reference=True,
+                is_sample_female=True,
+            )
+        clonal_log = "\n".join(ctx.output)
+        self.assertIn("clonal ploidy", clonal_log)
+        self.assertIn("rescaled for purity", clonal_log)
+        # The default (threshold) purity path keeps the plain rescale message
+        # and must NOT claim clonal calling.
+        with self.assertLogs(level="INFO") as ctx:
+            commands.do_call(
+                cns,
+                None,
+                "threshold",
+                purity=0.7,
+                is_haploid_x_reference=True,
+                is_sample_female=True,
+            )
+        threshold_log = "\n".join(ctx.output)
+        self.assertIn("Rescaling sample with purity", threshold_log)
+        self.assertNotIn("rescaled for purity", threshold_log)
+
 
 class LoadHetSnpsTests(unittest.TestCase):
     """Tests for cmdutil.load_het_snps and the _warn_if_baf_input_suspicious helper."""


### PR DESCRIPTION
## Summary

`cnvkit.py call -m clonal --purity <1.0` produced a misleading log line. When both are given, the `if purity and purity < 1.0:` branch is taken and the `elif method == "clonal":` branch is skipped, so the log only reported `Rescaling sample with purity ...`. Users read this as `-m clonal` being ignored (#424).

The copy numbers were already correct: the purity branch computes purity-aware clonal absolutes via `absolute_clonal`, which is the right result for clonal calling with purity. Only the messaging was wrong.

This emits a combined log line naming both clonal and purity in that case, confirming clonal was honored:

```
Calling copy number with clonal ploidy 2, rescaled for purity 0.7
```

The default (threshold) purity path keeps the existing `Rescaling sample with purity ...` message.

## Notes

- **No change to numerical output.** The `absolute_clonal` computation and all downstream branches are untouched; this is a logging clarification only.
- The reporter's originally proposed `elif` -> `if` change was intentionally *not* applied: it would overwrite the purity-adjusted absolutes with `absolute_pure` and discard purity.

## Tests

- `test_call_clonal_purity_honors_purity` pins the clonal+purity=0.7 copy numbers (`[0,1,3,4]`) as distinct from pure clonal (`[1,2,3,4]`), guarding against a regression that discards purity.
- `test_call_clonal_purity_log_confirms_clonal` asserts the clonal-confirmation line appears for `-m clonal --purity 0.7` and is absent for the default threshold path with `--purity 0.7`.

Fixes #424