### PR TITLE
Guard CBS smoothing against single-bin arm (#594)

### DIFF
--- a/cnvlib/segmentation/cbs.py
+++ b/cnvlib/segmentation/cbs.py
@@ -49,7 +49,10 @@ write("Segmenting the probe data", stderr())
 set.seed(0xA5EED)
 
 # additional smoothing (if --smooth-cbs provided)
-if (smooth_cbs) {
+# smooth.CNA aborts with "NA/NaN/Inf in foreign function call (arg 7)" when an
+# arm has a single bin (e.g. a lone surviving chrY bin), so skip smoothing for
+# arms too short to smooth -- the lone bin becomes one segment either way (#594)
+if (smooth_cbs && nrow(tbl) >= 2) {
     write("Performing smoothing of the data", stderr())
     cna = smooth.CNA(cna)
 }

--- a/test/test_r.py
+++ b/test/test_r.py
@@ -210,6 +210,25 @@ class RTests(unittest.TestCase):
         self.assertEqual(cns.chromosome.unique().tolist(), ["chr2"])
         self.assertIn("chrom", rstr)  # valid stitched SEG string, no crash
 
+    @pytest.mark.slow
+    def test_cbs_smooth_single_bin_arm(self):
+        """Issue #594: --smooth-cbs must not crash on a single-bin arm.
+
+        DNAcopy's ``smooth.CNA`` aborts with "NA/NaN/Inf in foreign function
+        call (arg 7)" when an arm has only one bin (e.g. a lone surviving chrY
+        bin). Segmentation runs the R script once per arm, so the guard skips
+        smoothing for arms too short to smooth; the lone bin must still come
+        back as exactly one segment carrying its own log2. Tested directly (not
+        via ``do_segmentation``), whose process pool would swallow the crash.
+        """
+        cnr = self.tas_cnr[self.tas_cnr["chromosome"] == "chr1"]
+        arm = cnr.as_dataframe(cnr.data.head(1).reset_index(drop=True).copy())
+        segarr = segmentation._do_segmentation(
+            arm, "cbs", None, 0.0001, skip_outliers=0, smooth_cbs=True
+        )
+        self.assertEqual(len(segarr), 1)
+        self.assertAlmostEqual(segarr["log2"].iloc[0], arm["log2"].iloc[0], places=6)
+
 
 def _test_method(self, method):
     for cnr in (


### PR DESCRIPTION
## Summary

`cnvkit.py segment --smooth-cbs` crashed inside DNAcopy's `smooth.CNA()` when a chromosome arm had only one bin after filtering — for example, a lone surviving bin on chrY. R aborted with:

```
Error in smooth.CNA(cna) : NA/NaN/Inf in foreign function call (arg 7)
```

CBS runs the embedded R script once per chromosome arm (`do_segmentation` → `by_arm()` → `_do_segmentation`), so an arm with a single bin reached `smooth.CNA` with a single data point, which it cannot smooth. The identical input segmented cleanly *without* `--smooth-cbs`.

## Fix

Skip smoothing when the arm has fewer than two bins:

```r
if (smooth_cbs && nrow(tbl) >= 2) {
```

The lone bin is emitted as a single segment either way, so no signal is lost. The pre-existing empty-arm guard (#868) already handles the zero-bin case just above. For arms with two or more bins the condition reduces to the previous `if (smooth_cbs)`, so segment output is unchanged.

## Tests

Adds `test_cbs_smooth_single_bin_arm` in `test/test_r.py`, which drives a single-bin arm through `_do_segmentation` with `smooth_cbs=True` (bypassing the process pool that would otherwise swallow the worker crash) and asserts it returns exactly one segment carrying the bin's own log2. Confirmed to crash on the current `master` script and pass with the fix.

Fixes #594