### PR TITLE
Stretch segment endpoints per chromosome in transfer_fields

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -406,28 +406,14 @@ def transfer_fields(
     weight is the sum of bin weights, and depth is the (weighted) mean of bin
     depths. Bins with NaN weights are excluded from the sums and averages.
 
-    Also: Post-process segmentation output.
-
-    1. Ensure every chromosome has at least one segment.
-    2. Ensure first and last segment ends match 1st/last bin ends
-       (but keep log2 as-is).
+    Also post-processes the segmentation: within `cnarr`, each chromosome's
+    first and last segment is stretched to span that chromosome's bins, keeping
+    log2 as-is. (`cnarr` is one chromosome arm on the per-arm CBS/haar/none
+    path, and the whole genome on the HMM path.) A chromosome whose bins were
+    all dropped upstream yields no segment at all -- fabricating a null segment
+    would report it as neutral, log2=0.
 
     """
-
-    def make_null_segment(chrom, orig_start, orig_end):
-        """Closes over 'segments'."""
-        vals = {
-            "chromosome": chrom,
-            "start": orig_start,
-            "end": orig_end,
-            "gene": "-",
-            "depth": 0.0,
-            "log2": 0.0,
-            "probes": 0.0,
-            "weight": 0.0,
-        }
-        row_vals = tuple(vals[c] for c in segments.data.columns)
-        return row_vals
 
     if not len(cnarr):
         # This Should Never Happen (TM)
@@ -435,28 +421,42 @@ def transfer_fields(
         logging.warning("No bins for:\n%s", segments.data)
         return segments
 
-    # Adjust segment endpoints to cover the chromosome arm's original bins
-    # (Stretch first and last segment endpoints to match first/last bins)
-    bins_chrom = cnarr.chromosome.iat[0]
-    bins_start = cnarr.start.iat[0]
-    bins_end = cnarr.end.iat[-1]
-    if not len(segments):
-        # All bins in this chromosome arm were dropped: make a dummy segment
-        return make_null_segment(bins_chrom, bins_start, bins_end)  # type: ignore[return-value,no-any-return]
-    # Stretch the first and last segment endpoints to cover the arm's original
-    # bins. Address by POSITION, not index label: haar concatenates per-arm
-    # segment tables whose labels can repeat, and `.loc[label]` would broadcast
-    # the write to every row sharing that label, collapsing distinct segments to
+    # Locate the boundary segments per chromosome, not once for the whole
+    # table: the HMM methods segment the whole genome in a single call (only
+    # CBS/haar/none run per chromosome arm), so a single global stretch would
+    # extend just the genome's very first and last segments.
+    # Address by POSITION, not index label: haar concatenates per-arm segment
+    # tables whose labels can repeat, and `.loc[label]` would broadcast the
+    # write to every row sharing that label, collapsing distinct segments to
     # the full-arm span (#1125).
     start_col = segments.data.columns.get_loc("start")
     end_col = segments.data.columns.get_loc("end")
-    segments.data.iloc[0, start_col] = bins_start
-    segments.data.iloc[-1, end_col] = bins_end
+    seg_chroms = segments.chromosome.to_numpy()
+    matched = np.zeros(len(seg_chroms), dtype=bool)
+    for chrom, bin_rows in cnarr.by_chromosome():
+        seg_pos = np.flatnonzero(seg_chroms == chrom)
+        if not len(seg_pos):
+            # The bin filters in _do_segmentation (non-finite log2, low
+            # coverage, outliers, zero weight) dropped every bin of this
+            # chromosome, so it has no segments to stretch.
+            continue
+        matched[seg_pos] = True
+        segments.data.iloc[seg_pos[0], start_col] = bin_rows.start.iat[0]
+        segments.data.iloc[seg_pos[-1], end_col] = bin_rows.end.iat[-1]
+    if not matched.all():
+        # The bins are the source of these segments, so a segment on an unknown
+        # chromosome means the name was mangled in transit -- e.g. DNAcopy
+        # renders a zero-padded contig '01' as '1'. Fail loudly: the segment
+        # would otherwise silently take the default gene '-' and weight/depth 0
+        # below, since the aggregation matches on chromosome name too.
+        raise ValueError(
+            "Segments on chromosomes absent from the input bins: "
+            + ", ".join(sorted(set(seg_chroms[~matched])))
+        )
 
     # Aggregate segment depths, weights, gene names
     # ENH refactor so that np/CNA.data access is encapsulated in skgenome
     ignore += params.ANTITARGET_ALIASES
-    assert bins_chrom == segments.chromosome.iat[0]
     cdata = cnarr.data.reset_index()
     if "depth" not in cdata.columns:
         cdata["depth"] = np.exp2(cnarr["log2"].to_numpy())

--- a/test/test_segmentation.py
+++ b/test/test_segmentation.py
@@ -447,6 +447,100 @@ class TransferFieldsTests(unittest.TestCase):
         self.assertEqual(result2["weight"].iat[0], 0.0)
         self.assertEqual(result2["depth"].iat[0], 0.0)
 
+    def test_transfer_fields_stretches_every_chromosome(self):
+        """Each chromosome's boundary segments cover that chromosome's bins.
+
+        The HMM methods segment the whole genome in one call, so transfer_fields
+        receives a multi-chromosome table. Stretching only the global first and
+        last segment would leave every other chromosome's boundary segments
+        short of their bins. Each chromosome gets a distinct coordinate origin
+        so that looking the bin bounds up globally instead of per chromosome
+        fails the assertions too.
+        """
+        n = 10
+        origins = {"chr1": 0, "chr2": 1_000_000, "chr3": 2_000_000}
+        bins = pd.concat(
+            [
+                pd.DataFrame(
+                    {
+                        "chromosome": [chrom] * n,
+                        "start": origin + np.arange(0, n * 1000, 1000),
+                        "end": origin + np.arange(1000, n * 1000 + 1000, 1000),
+                        "gene": ["G"] * n,
+                        "log2": np.zeros(n),
+                        "depth": np.ones(n) * 100.0,
+                        "weight": np.ones(n),
+                    }
+                )
+                for chrom, origin in origins.items()
+            ],
+            ignore_index=True,
+        )
+        cnarr = cnary.CopyNumArray(bins)
+        # Two segments per chromosome, all inset from that chromosome's bounds
+        segarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1", "chr1", "chr2", "chr2", "chr3", "chr3"],
+                    "start": [o + s for o in origins.values() for s in (2000, 5000)],
+                    "end": [o + e for o in origins.values() for e in (5000, 8000)],
+                    "gene": ["-"] * 6,
+                    "log2": [0.0] * 6,
+                    "probes": [3, 3] * 3,
+                    "weight": [0.0] * 6,
+                }
+            )
+        )
+        result = segmentation.transfer_fields(segarr, cnarr)
+        self.assertEqual(
+            result["start"].tolist(),
+            [o + s for o in origins.values() for s in (0, 5000)],
+        )
+        self.assertEqual(
+            result["end"].tolist(),
+            [o + e for o in origins.values() for e in (5000, 10000)],
+        )
+
+    def test_transfer_fields_rejects_unknown_chromosome(self):
+        """A segment on a chromosome absent from the bins must fail loudly.
+
+        Segments derive from the bins, so a mismatch means a name was mangled
+        in transit -- DNAcopy renders a zero-padded contig '01' as '1'. Both the
+        endpoint stretch and the gene/weight/depth aggregation match on
+        chromosome name, so such a segment would otherwise be emitted with the
+        placeholder gene '-' and weight/depth 0 and no warning.
+        """
+        n = 10
+        cnarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["01"] * n,
+                    "start": np.arange(0, n * 1000, 1000),
+                    "end": np.arange(1000, n * 1000 + 1000, 1000),
+                    "gene": ["G"] * n,
+                    "log2": np.zeros(n),
+                    "depth": np.ones(n) * 100.0,
+                    "weight": np.ones(n),
+                }
+            )
+        )
+        segarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["1"],  # as DNAcopy renders '01'
+                    "start": [2000],
+                    "end": [8000],
+                    "gene": ["-"],
+                    "log2": [0.0],
+                    "probes": [6],
+                    "weight": [0.0],
+                }
+            )
+        )
+        with self.assertRaises(ValueError) as caught:
+            segmentation.transfer_fields(segarr, cnarr)
+        self.assertIn("1", str(caught.exception))
+
     def test_do_segmentation_drops_nan_log2(self):
         """do_segmentation tolerates NaN-log2 bins on the default path (#881).
 
@@ -526,9 +620,9 @@ class TransferFieldsTests(unittest.TestCase):
         NaN bin weight must be filled on a copy, not the shared buffer.
 
         Uses a single chromosome so the whole-genome transfer_fields path is not
-        exercised (the separate all-of-first-chromosome-dropped edge is tracked
-        independently); the weighted_std path that crashed is shared by every
-        method.
+        exercised (that edge is covered by
+        test_hmm_first_chromosome_entirely_dropped); the weighted_std path that
+        crashed is shared by every method.
         """
         n = 120  # > guess_window_size / drop_outliers width so smoothing runs
         rng = np.random.default_rng(0)
@@ -555,3 +649,55 @@ class TransferFieldsTests(unittest.TestCase):
         self.assertGreater(len(cns), 0)
         self.assertTrue(np.isfinite(cns["log2"].to_numpy()).all())
         self.assertFalse(np.isnan(cns["weight"].to_numpy()).any())
+
+    def test_hmm_first_chromosome_entirely_dropped(self):
+        """HMM survives the non-finite guard dropping a whole first chromosome.
+
+        The HMM path segments the genome in one call, then transfers fields from
+        the unfiltered bins. When every bin of the leading chromosome is
+        non-finite, the first segment belongs to a later chromosome than the
+        first bin, which used to trip a bare AssertionError in transfer_fields.
+        The dropped chromosome must simply be absent from the output -- not
+        emitted as a fabricated neutral segment.
+
+        chr2's leading and chr3's trailing bins are dropped as well, with a
+        distinct coordinate origin per chromosome, so the surviving
+        chromosomes' spans pin the per-chromosome endpoint stretch rather than
+        holding vacuously.
+        """
+        n = 60
+        rng = np.random.default_rng(0)
+        origins = {"chr1": 0, "chr2": 1_000_000, "chr3": 2_000_000}
+        frames = []
+        for chrom, origin in origins.items():
+            if chrom == "chr1":
+                log2 = np.full(n, np.nan)  # entire leading chromosome dropped
+            else:
+                log2 = rng.normal(0, 0.2, n)
+                # Chromosome-edge bins the stretch must reclaim
+                if chrom == "chr2":
+                    log2[:3] = np.nan
+                else:
+                    log2[-3:] = np.nan
+            frames.append(
+                pd.DataFrame(
+                    {
+                        "chromosome": [chrom] * n,
+                        "start": origin + np.arange(0, n * 1000, 1000),
+                        "end": origin + np.arange(1000, n * 1000 + 1000, 1000),
+                        "gene": ["G"] * n,
+                        "log2": log2,
+                        "depth": np.ones(n) * 100.0,
+                        "weight": np.ones(n),
+                    }
+                )
+            )
+        cnarr = cnary.CopyNumArray(pd.concat(frames, ignore_index=True))
+        cns = segmentation.do_segmentation(cnarr, "hmm", processes=1)
+        # chr1 absent, and no fabricated segment in its place
+        self.assertEqual(set(cns.chromosome), {"chr2", "chr3"})
+        # Surviving chromosomes span their original bins, dropped edges included
+        for chrom, subseg in cns.by_chromosome():
+            subbins = cnarr[cnarr.chromosome == chrom]
+            self.assertEqual(subseg["start"].iat[0], subbins["start"].iat[0])
+            self.assertEqual(subseg["end"].iat[-1], subbins["end"].iat[-1])


### PR DESCRIPTION
## Problem

`transfer_fields` post-processes segmentation output: it stretches each boundary segment back to the original bin bounds and aggregates per-segment gene names, weights and depths. It was written assuming its bins cover a single chromosome arm, which holds for the CBS/haar/none path — `do_segmentation` maps `_do_segmentation` over `cnarr.by_arm()` — but not for the HMM methods, which fit one model across the whole genome and pass every chromosome in a single call.

Two defects followed:

1. Only the genome's very first segment start and very last segment end were stretched. On the HMM path, every other chromosome's boundary segments stayed short of their bins whenever edge bins had been dropped by the non-finite-log2 guard, the low-coverage filter, the outlier filter or the weight filter.

2. When the non-finite-log2 guard dropped every bin of the leading chromosome, the first segment belonged to a later chromosome than the first bin, and an unlabelled `assert` fired. Reproducer: set the log2 of `test/formats/amplicon.cnr`'s single chr1 bin to NaN and segment with `-m hmm`. The realistic trigger is a degenerate flat-reference WGS subtraction driving an entire leading chromosome non-finite.

## Change

The boundary segments are now located per chromosome. This restores the shape the code had as `repair_segments` before it was folded into `transfer_fields` in 2018; the single global stretch was valid at the time, because the HMM methods came later.

A chromosome whose bins were all dropped now yields no segment at all. The alternative — the null segment the pre-2018 code emitted — carries `log2=0.0` and would report an unmeasurable chromosome as neutral. That branch was already unreachable from the sole caller and returned a bare tuple where a `CopyNumArray` was required, so it is removed and the docstring corrected.

The `assert` is replaced by an explicit error naming the offending chromosomes rather than simply dropped. It was the only check that the segments' chromosome names matched the bins', and the gene/weight/depth aggregation matches on name too, so without it a mismatch silently emits gene `-` with weight and depth 0 for every segment. DNAcopy renders a zero-padded contig `01` as `1`, which reaches exactly that path.

## Verification

- The reproducer above now runs clean: the dropped chromosome is absent from the output and every surviving chromosome's endpoints equal its own bins' bounds.
- Segmentation output was diffed against the pre-fix code on `test/formats/amplicon.cnr` for `cbs`, `haar`, `none` and `hmm`: byte-identical in all four. The per-arm methods cannot change, since one arm is one chromosome group.
- With chromosome-edge bins dropped mid-genome, `hmm` changes exactly as intended: chr5's first segment start moves back from the filtered bin to the original bin, and chr9's last segment end likewise.
- Full test suite green, including the slow end-to-end pipeline comparison against the frozen `.cnr`/`.cns`/`.call.cns` fixtures.
- Both new tests were confirmed to fail against the pre-fix code, and also against a mutant that locates boundary segments per chromosome but looks the bin bounds up globally.
