### PR TITLE
Yield range intersections in the target array's row order

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -404,7 +404,11 @@ def transfer_fields(
 
     Segment gene name is the comma-separated list of bin gene names. Segment
     weight is the sum of bin weights, and depth is the (weighted) mean of bin
-    depths. Bins with NaN weights are excluded from the sums and averages.
+    depths. Bins with NaN weights are excluded from the sums and averages. A
+    segment overlapping no bins takes the placeholder gene "-" and a weight and
+    depth of 0; that happens on the CBS/"none" variant re-segmentation path,
+    where `variants_in_segment` places a breakpoint midway between two SNVs and
+    that midpoint can fall inside a bin-free gap.
 
     Also post-processes the segmentation: within `cnarr`, each chromosome's
     first and last segment is stretched to span that chromosome's bins, keeping
@@ -447,8 +451,8 @@ def transfer_fields(
         # The bins are the source of these segments, so a segment on an unknown
         # chromosome means the name was mangled in transit -- e.g. DNAcopy
         # renders a zero-padded contig '01' as '1'. Fail loudly: the segment
-        # would otherwise silently take the default gene '-' and weight/depth 0
-        # below, since the aggregation matches on chromosome name too.
+        # would otherwise silently take the empty aggregate -- gene '-' and
+        # weight/depth 0 -- since the aggregation matches on chromosome name too.
         raise ValueError(
             "Segments on chromosomes absent from the input bins: "
             + ", ".join(sorted(set(seg_chroms[~matched])))
@@ -457,34 +461,43 @@ def transfer_fields(
     # Aggregate segment depths, weights, gene names
     # ENH refactor so that np/CNA.data access is encapsulated in skgenome
     ignore += params.ANTITARGET_ALIASES
-    cdata = cnarr.data.reset_index()
+    # reset_index so the index labels `iter_slices` yields are also positions
+    # into the numpy arrays extracted below, which the loop indexes directly.
+    cdata = cnarr.data.reset_index(drop=True)
     if "depth" not in cdata.columns:
         cdata["depth"] = np.exp2(cnarr["log2"].to_numpy())
     bin_genes = cdata["gene"].to_numpy()
-    bin_weights = cdata["weight"].to_numpy() if "weight" in cdata.columns else None
     bin_depths = cdata["depth"].to_numpy()
-    seg_genes = ["-"] * len(segments)
-    seg_weights = np.zeros(len(segments))
-    seg_depths = np.zeros(len(segments))
+    bin_weights = (
+        cdata["weight"].to_numpy()
+        if "weight" in cdata.columns
+        # No weight column means equal weighting, so the sum below is the bin
+        # count and the weighted mean is the plain mean.
+        else np.ones(len(cdata))
+    )
+    seg_genes: list[str] = []
+    seg_weights: list[float] = []
+    seg_depths: list[float] = []
 
-    for i, bin_idx in enumerate(iter_slices(cdata, segments.data, "outer", False)):
-        if bin_weights is not None:
-            wt = bin_weights[bin_idx]
-            # Use nansum so NaN weights don't propagate into .cns output
-            seg_wt = float(np.nansum(wt))
-            if seg_wt > 0:
-                valid = ~np.isnan(wt)
-                seg_dp = np.average(bin_depths[bin_idx][valid], weights=wt[valid])
-            else:
-                seg_dp = 0.0
+    # keep_empty=True is what makes `iter_slices` yield one index array per
+    # segment row (the order is always the segments' row order): a segment
+    # spanning no bins must still take a slot, or every later row would take
+    # its successor's bins. A dropped slot then fails loudly on the `assign`
+    # below, which rejects a length mismatch; the ordering half of the
+    # correspondence is `iter_slices`' responsibility.
+    for bin_idx in iter_slices(cdata, segments.data, "outer", keep_empty=True):
+        wt = bin_weights[bin_idx]
+        # Use nansum so NaN weights don't propagate into .cns output
+        seg_wt = float(np.nansum(wt))
+        if seg_wt > 0:
+            valid = ~np.isnan(wt)
+            seg_dp = np.average(bin_depths[bin_idx][valid], weights=wt[valid])
         else:
-            bin_count = len(cdata.iloc[bin_idx])
-            seg_wt = float(bin_count)
-            seg_dp = bin_depths[bin_idx].mean()
-        seg_gn = join_strings(bin_genes[bin_idx], ignore=ignore)
-        seg_genes[i] = seg_gn
-        seg_weights[i] = seg_wt
-        seg_depths[i] = seg_dp
+            # No overlapping bins, or every one weightless: no depth evidence
+            seg_dp = 0.0
+        seg_genes.append(join_strings(bin_genes[bin_idx], ignore=ignore))
+        seg_weights.append(seg_wt)
+        seg_depths.append(float(seg_dp))
 
     segments.data = segments.data.assign(
         gene=seg_genes, weight=seg_weights, depth=seg_depths

--- a/cnvlib/vary.py
+++ b/cnvlib/vary.py
@@ -52,10 +52,11 @@ class VariantArray(GenomicArray):
         """
         if "alt_freq" not in self:
             logging.warning("VCF has no allele frequencies for BAF calculation")
-            # Length must match `ranges` (one value per bin), like the normal
-            # into_ranges path -- not the variant rows (self.data.index), which
-            # made a shorter/longer Series and crashed callers.
-            return pd.Series(np.repeat(np.nan, len(ranges)))
+            # Length and index must match `ranges` (one value per bin), like
+            # the normal into_ranges path -- not the variant rows
+            # (self.data.index), which made a shorter/longer Series and crashed
+            # callers.
+            return pd.Series(np.repeat(np.nan, len(ranges)), index=ranges.data.index)
 
         def summarize(vals):
             mirrored = _mirrored_baf(vals, above_half)

--- a/skgenome/gary.py
+++ b/skgenome/gary.py
@@ -388,7 +388,9 @@ class GenomicArray:
         Yields
         ------
         tuple
-            (other bin, GenomicArray of overlapping rows in self)
+            (other bin, GenomicArray of overlapping rows in self), in `other`'s
+            row order. With `keep_empty`, exactly one per row of `other`, so
+            callers may pair them positionally.
         """
         for bin_row, subrange in by_ranges(self.data, other.data, mode, keep_empty):  # type: ignore[func-returns-value]
             if len(subrange):
@@ -503,7 +505,7 @@ class GenomicArray:
         column: str,
         default: int | float | str,
         summary_func: Callable | None = None,
-    ) -> pd.Series | pd.DataFrame:
+    ) -> pd.Series:
         """Re-bin values from `column` into the corresponding ranges in `other`.
 
         Match overlapping/intersecting rows from `other` to each row in `self`.
@@ -543,11 +545,12 @@ class GenomicArray:
         -------
         pd.Series
             The extracted and summarized values from `self` corresponding to
-            other's genomic ranges, the same length as `other`.
+            other's genomic ranges: the same length as `other`, in `other`'s
+            row order, and indexed by `other`'s index labels.
         """
         if column not in self:
             logging.warning("No '%s' column available for summary calculation", column)
-            return pd.Series(np.repeat(default, len(other)))
+            return pd.Series(np.repeat(default, len(other)), index=other.data.index)
         return into_ranges(self.data, other.data, column, default, summary_func)
 
     def iter_ranges_of(
@@ -557,7 +560,7 @@ class GenomicArray:
         mode: str = "outer",
         keep_empty: bool = True,
     ) -> Iterator[pd.Series]:
-        """Group rows by another GenomicArray's bin coordinate ranges.
+        """Extract values of `column` grouped by another array's ranges.
 
         For example, this can be used to group SNVs by CNV segments.
 
@@ -579,13 +582,15 @@ class GenomicArray:
               selection; the bin start or end position is replaced with the
               selection boundary position.
         keep_empty : bool
-            Whether to also yield `other` bins with no overlapping bins in
-            `self`, or to skip them when iterating.
+            Whether to also emit an empty Series for `other` rows with no
+            overlapping rows in `self`, or to skip those rows.
 
         Yields
         ------
-        tuple
-            (other bin, GenomicArray of overlapping rows in self)
+        pd.Series
+            The `column` values of the rows in `self` overlapping each row of
+            `other`, in `other`'s row order. With `keep_empty`, exactly one per
+            row of `other`, so callers may pair them positionally.
         """
         if column not in self.data.columns:
             raise ValueError(f"No column named {column!r} in this object")
@@ -754,7 +759,8 @@ class GenomicArray:
             pairs = pairs[
                 (pairs["start"] >= pairs["start_"]) & (pairs["end"] <= pairs["end_"])
             ]
-        # Sort by other-index then self-index to match by_ranges ordering
+        # Sort by `other`'s index labels then `self`'s; with `other`'s usual
+        # monotonic index this reproduces `by_ranges`' row order
         pairs = pairs.sort_values(["index_", "index"])
         # Return self rows (with duplicates, one per overlap pair)
         self_indices = pairs["index"].to_numpy()

--- a/skgenome/intersect.py
+++ b/skgenome/intersect.py
@@ -9,6 +9,7 @@ GenomicArray types.
 
 from __future__ import annotations
 
+from itertools import repeat
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 import numpy as np
@@ -20,42 +21,60 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterator, Sequence
 
     from numpy import ndarray
-    from pandas.core.indexes.base import Index
 
 Numeric: TypeAlias = int | float | np.number
+
+# One shared placeholder instead of a fresh array per yield: allocating one
+# costs ~200 ns against ~7 us of per-row work, and the missing-chromosome path
+# yields one for every row of `other`. Safe to hand out repeatedly because a
+# zero-length array has no elements to write.
+_EMPTY_SELECTION = np.empty(0, dtype=np.intp)
 
 
 def by_ranges(
     table: pd.DataFrame, other: pd.DataFrame, mode: str, keep_empty: bool
 ) -> Generator[tuple, None, None]:
-    """Group rows by another GenomicArray's bin coordinate ranges."""
-    for _chrom, bin_rows, src_rows in by_shared_chroms(other, table, keep_empty):
-        if src_rows is not None:
-            subranges = iter_ranges(
+    """Group rows by another GenomicArray's bin coordinate ranges.
+
+    Yields one (row of `other`, overlapping rows of `table`) pair per row of
+    `other`, in `other`'s row order, unless `keep_empty` is false and the
+    selection is empty.
+    """
+    # Build one sub-iterator per chromosome and draw from them in `other`'s row
+    # order; see `iter_slices` for why the grouped order of `by_shared_chroms`
+    # will not do.
+    per_chrom: dict[Any, Iterator] = {}
+    for chrom, bin_rows, src_rows in by_shared_chroms(other, table):
+        if src_rows is None or not len(src_rows):
+            # `table` has no rows on this chromosome, so every selection is
+            # empty. `by_shared_chroms` yields no empty group today; the length
+            # check is defensive, since `idx_ranges` would collapse an empty
+            # table to a single slice(None) and silently under-yield.
+            # ENH: empty dframe matching table, rather than a bare sequence
+            per_chrom[chrom] = repeat((), len(bin_rows))
+        else:
+            per_chrom[chrom] = iter_ranges(
                 src_rows, None, bin_rows["start"], bin_rows["end"], mode
             )
-            for bin_row, subrange in zip(
-                bin_rows.itertuples(index=False), subranges, strict=True
-            ):
-                yield bin_row, subrange
-        elif keep_empty:
-            for bin_row in bin_rows.itertuples(index=False):
-                yield (
-                    bin_row,
-                    [],
-                )  # ENH: empty dframe matching table  # ENH: empty dframe matching table
+    for bin_row in other.itertuples(index=False):
+        subrange = next(per_chrom[bin_row.chromosome])
+        if keep_empty or len(subrange):
+            yield bin_row, subrange
 
 
 def by_shared_chroms(
-    table: pd.DataFrame, other: pd.DataFrame, keep_empty: bool = True
-) -> Iterator[tuple[str, pd.DataFrame, None] | tuple[str, pd.DataFrame, pd.DataFrame]]:
-    """Group rows for both `table` and `other` by matching chromosome names."""
+    table: pd.DataFrame, other: pd.DataFrame
+) -> Iterator[tuple[str, pd.DataFrame, pd.DataFrame | None]]:
+    """Group rows for both `table` and `other` by matching chromosome names.
+
+    Yields one group per chromosome of `table`, in order of first appearance;
+    the third element is None where `other` has no rows on that chromosome.
+    """
     # When both `table` and `other` contain only one chromosome each, and it's
     # the same chromosome, we can just return the original tables.
     table_chr, other_chr = set(table["chromosome"]), set(other["chromosome"])
     if len(table_chr) == 1 and table_chr == other_chr:
         yield table["chromosome"].iat[0], table, other
-        # yield None, table, other
     else:
         # C416 would suggest `dict(...)`, but `dict()` on a pandas
         # DataFrameGroupBy follows the mapping protocol (via __getitem__),
@@ -63,11 +82,7 @@ def by_shared_chroms(
         # `'str' object is not callable`. Keep the comprehension.
         other_chroms = {c: o for c, o in other.groupby("chromosome", sort=False)}  # noqa: C416
         for chrom, ctable in table.groupby("chromosome", sort=False):
-            if chrom in other_chroms:
-                otable = other_chroms[chrom]
-                yield chrom, ctable, otable
-            elif keep_empty:
-                yield chrom, ctable, None
+            yield chrom, ctable, other_chroms.get(chrom)
 
 
 def into_ranges(
@@ -76,10 +91,10 @@ def into_ranges(
     src_col: str,
     default: Any,
     summary_func: Callable | None,
-) -> pd.DataFrame | pd.Series:
+) -> pd.Series:
     """Group a column in `source` by regions in `dest` and summarize."""
     if not len(source) or not len(dest):
-        return dest
+        return pd.Series(np.repeat(default, len(dest)), index=dest.index)
 
     if summary_func is None:
         # Choose a type-appropriate summary function
@@ -105,7 +120,9 @@ def into_ranges(
     result = [
         series2value(column[slc]) for slc in iter_slices(source, dest, "outer", True)
     ]
-    return pd.Series(result)
+    # Index by `dest`'s labels: callers assign the result back onto `dest`
+    # columns, and pandas aligns that assignment by label, not by position.
+    return pd.Series(result, index=dest.index)
 
 
 def iter_ranges(
@@ -141,24 +158,52 @@ def iter_ranges(
 
 def iter_slices(
     table: pd.DataFrame, other: pd.DataFrame, mode: str, keep_empty: bool
-) -> Iterator[ndarray | Index]:
-    """Yields indices to extract ranges from `table`.
+) -> Iterator[ndarray]:
+    """Yields indices to extract ranges from `table`, in `other`'s row order.
 
     Returns an iterable of integer arrays that can apply to Series objects,
     i.e. columns of `table`. These indices are of the DataFrame/Series' Index,
     not array coordinates -- so be sure to use DataFrame.loc, Series.loc, or
     Series getitem, as opposed to .iloc or indexing directly into Numpy arrays.
+
+    The yields are always in `other`'s row order. With `keep_empty` there is
+    additionally exactly one per row, so callers may pair them positionally;
+    without it, a row whose selection is empty is skipped.
     """
-    for _c, bin_rows, src_rows in by_shared_chroms(other, table, keep_empty):
-        if src_rows is None:
-            # Emit empty indices since 'table' is missing this chromosome
-            for _ in range(len(bin_rows)):
-                yield pd.Index([], dtype="int64")
+    # `by_shared_chroms` groups `other` by chromosome, so consuming it directly
+    # would yield in chromosome-of-first-appearance order, which differs from
+    # row order once a chromosome's rows are non-contiguous; a caller pairing
+    # the yields with rows positionally would then write each row's values onto
+    # another chromosome's row. Instead, build one lazy sub-iterator per
+    # chromosome and draw from them in `other`'s row order.
+    per_chrom: dict[Any, Iterator[ndarray]] = {}
+    for chrom, bin_rows, src_rows in by_shared_chroms(other, table):
+        if src_rows is None or not len(src_rows):
+            # `table` has no rows on this chromosome, so every selection is
+            # empty. `by_shared_chroms` yields no empty group today; the length
+            # check is defensive, since `idx_ranges` would collapse an empty
+            # table to a single slice(None) and silently under-yield.
+            per_chrom[chrom] = repeat(_EMPTY_SELECTION, len(bin_rows))
         else:
-            for slc, _s, _e in idx_ranges(src_rows, bin_rows.start, bin_rows.end, mode):
-                indices = src_rows.index[slc].to_numpy()
-                if keep_empty or len(indices):
-                    yield indices
+            per_chrom[chrom] = _chrom_slices(src_rows, bin_rows, mode)
+    for chrom in other["chromosome"].to_numpy():
+        indices = next(per_chrom[chrom])
+        if keep_empty or len(indices):
+            yield indices
+
+
+def _chrom_slices(
+    src_rows: pd.DataFrame, bin_rows: pd.DataFrame, mode: str
+) -> Iterator[ndarray]:
+    """Yield `src_rows` index labels selected by each row of `bin_rows`.
+
+    A named function rather than an inline generator expression: a genexp
+    evaluates only its outermost iterable eagerly, so its body would re-read
+    the caller's loop variables and every chromosome would slice the last one's
+    rows.
+    """
+    for slc, _start, _end in idx_ranges(src_rows, bin_rows.start, bin_rows.end, mode):
+        yield src_rows.index[slc].to_numpy()
 
 
 def idx_ranges(

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -367,6 +367,33 @@ class ExportTests(unittest.TestCase):
         table_ogt = export.export_nexus_ogt(cnr, varr, 0.05)
         self.assertEqual(len(table_ogt), len(cnr))
 
+    def test_export_nexus_ogt_min_weight(self):
+        """BAFs stay on their own rows after --min-weight drops early bins.
+
+        Dropping bins leaves a gapped index, and the BAF column is assigned
+        back onto the filtered table, which pandas aligns by label. Without a
+        matching index the values land on the wrong bins and some are lost.
+        """
+        cnr = cnvlib.read("formats/amplicon.cnr")
+        varr = commands.load_het_snps(
+            "formats/na12878_na12882_mix.vcf", None, None, 15, None
+        )
+        full = export.export_nexus_ogt(cnr.copy(), varr)
+        # amplicon.cnr's lowest weight is ~0.28, so this drops a real prefix
+        kept = cnr["weight"] >= 0.4
+        self.assertTrue(0 < kept.sum() < len(cnr))
+        self.assertFalse(kept.iat[0])
+        table = export.export_nexus_ogt(cnr.copy(), varr, 0.4)
+        self.assertEqual(len(table), int(kept.sum()))
+        expected = full["B-Allele Frequency"][kept.to_numpy()]
+        self.assertEqual(
+            table["B-Allele Frequency"].fillna(-1).tolist(),
+            expected.fillna(-1).tolist(),
+        )
+        self.assertEqual(
+            table["B-Allele Frequency"].notna().sum(), expected.notna().sum()
+        )
+
     def test_export_seg(self):
         """The 'export seg' command."""
         seg_rows = export.export_seg(["formats/tr95t.cns"])

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -173,17 +173,91 @@ class GaryTests(unittest.TestCase):
         self.assertEqual(len(seg_baf), len(segarr))
         cna_baf = varr.into_ranges(cnarr, "alt_freq", 0.0, np.max)
         self.assertEqual(len(cna_baf), len(cnarr))
-        # Edge cases
+        # Edge cases: an empty source or destination still yields one value per
+        # destination row, as a Series indexed by the destination
         mtarr = tabio.read("formats/empty")
-        segarr.into_ranges(mtarr, "start", 0, int)
-        mtarr.into_ranges(segarr, "end", 0, 0)
+        self.assertEqual(len(segarr.into_ranges(mtarr, "start", 0, int)), 0)
+        empty_src = mtarr.into_ranges(segarr, "end", 0, 0)
+        self.assertIsInstance(empty_src, pd.Series)
+        self.assertEqual(empty_src.index.tolist(), segarr.data.index.tolist())
+        self.assertTrue((empty_src == 0).all())
+
+    @staticmethod
+    def _non_contiguous_pair():
+        """A source of two named ranges, and a destination with interleaved rows.
+
+        Source: chr2:0-1000 "AAA", chr10:0-1000 "CCC". Destination rows, in
+        order: chr2:0-1000 (hits AAA), chr10:0-1000 (hits CCC), chr2:2000-3000
+        and chr10:2000-3000 (no overlap).
+
+        Interleaved chromosome rows arise only for an in-memory array assembled
+        by concatenation and never re-sorted, since every file-based route is
+        sorted by ``tabio.read``. chr2 before chr10 makes first-appearance order
+        differ from the lexicographic order pandas would use with
+        ``groupby(sort=True)``, so recovering the groups by sorting fails here
+        too.
+        """
+        src = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr2", "chr10"],
+                    "start": [0, 0],
+                    "end": [1000, 1000],
+                    "gene": ["AAA", "CCC"],
+                }
+            )
+        )
+        dest = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr2", "chr10", "chr2", "chr10"],
+                    "start": [0, 0, 2000, 2000],
+                    "end": [1000, 1000, 3000, 3000],
+                }
+            )
+        )
+        return src, dest
+
+    def test_ranges_into_non_contiguous_chromosomes(self):
+        """into_ranges places each value on its own row of the destination.
+
+        ``by_shared_chroms`` groups the destination by chromosome, so consuming
+        it directly would summarize into chromosome-grouped order rather than
+        the destination's row order.
+        """
+        src, dest = self._non_contiguous_pair()
+        self.assertEqual(
+            src.into_ranges(dest, "gene", "-").tolist(), ["AAA", "CCC", "-", "-"]
+        )
+
+    def test_ranges_into_preserves_dest_index(self):
+        """into_ranges is indexed by the destination's labels, not 0..n-1.
+
+        Callers assign the result straight onto a column of the destination,
+        and pandas aligns that by label. A filtered destination has a gapped
+        index -- ``target --annotate`` drops zero-width baits that way -- so a
+        fresh RangeIndex would drop values onto the wrong rows.
+        """
+        src, dest = self._non_contiguous_pair()
+        # Dropping row 1 leaves chr2, chr2, chr10 -- contiguous, so this test
+        # pins index alignment alone, independent of the ordering fix.
+        gapped = dest[np.array([True, False, True, True])]
+        self.assertEqual(gapped.data.index.tolist(), [0, 2, 3])
+        genes = src.into_ranges(gapped, "gene", "-")
+        self.assertEqual(genes.index.tolist(), [0, 2, 3])
+        gapped["gene"] = genes
+        self.assertEqual(gapped["gene"].tolist(), ["AAA", "-", "-"])
+        # The no-such-column fallback must be indexed the same way
+        with self.assertLogs(level="WARNING"):
+            missing = src.into_ranges(gapped, "nosuchcolumn", "-")
+        self.assertEqual(missing.index.tolist(), [0, 2, 3])
 
     def test_ranges_of(self):
         cnarr = read_ga("formats/amplicon.cnr")
         segarr = read_ga("formats/amplicon.cns")
         by_bins = cnarr.by_ranges(segarr)
         by_slices = cnarr.iter_ranges_of(segarr, "gene")
-        for (_seg, by_bin), by_slice in zip(by_bins, by_slices, strict=False):
+        for (_seg, by_bin), by_slice in zip(by_bins, by_slices, strict=True):
             self.assertEqual(len(by_bin), len(by_slice))
             self.assertTrue((by_bin["gene"].to_numpy() == by_slice.to_numpy()).all())
         # With a VCF
@@ -196,6 +270,33 @@ class GaryTests(unittest.TestCase):
         mtarr = tabio.read("formats/empty")
         self.assertEqual(0, len(list(segarr.iter_ranges_of(mtarr, "start"))))
         self.assertEqual(88, len(list(mtarr.iter_ranges_of(segarr, "end"))))
+
+    def test_ranges_of_non_contiguous_chromosomes(self):
+        """iter_ranges_of and by_ranges yield in the other array's row order.
+
+        Both are consumed positionally against the other array's rows -- see
+        ``segmetrics.do_segmetrics`` and ``CopyNumArray.residuals`` for
+        ``iter_ranges_of``, and the ``variants.by_ranges(segarr)``
+        re-segmentation in ``cnvlib.segmentation`` for ``by_ranges`` -- so a
+        chromosome-grouped order would misassign across chromosomes.
+        """
+        src, dest = self._non_contiguous_pair()
+        self.assertEqual(
+            [s.tolist() for s in src.iter_ranges_of(dest, "gene")],
+            [["AAA"], ["CCC"], [], []],
+        )
+        self.assertEqual(
+            [
+                (row.chromosome, row.start, sub["gene"].tolist())
+                for row, sub in src.by_ranges(dest)
+            ],
+            [
+                ("chr2", 0, ["AAA"]),
+                ("chr10", 0, ["CCC"]),
+                ("chr2", 2000, []),
+                ("chr10", 2000, []),
+            ],
+        )
 
     def test_ranges_resize(self):
         baits_fname = "formats/nv2_baits.interval_list"

--- a/test/test_segmentation.py
+++ b/test/test_segmentation.py
@@ -541,6 +541,203 @@ class TransferFieldsTests(unittest.TestCase):
             segmentation.transfer_fields(segarr, cnarr)
         self.assertIn("1", str(caught.exception))
 
+    @staticmethod
+    def _bin_gap_pair(with_weight):
+        """Two chr1 bins separated by a 99 kb gap, and three segments over them.
+
+        Bins: 0-1000 (AAA, depth 100, weight 1) and 100000-101000 (BBB, depth
+        200, weight 2). Segments: 0-20000, 20000-60000 and 60000-101000, of
+        which the middle one lies wholly inside the gap. ``with_weight`` adds
+        the bin weight column; without it the aggregation weights bins equally.
+        """
+        bins = {
+            "chromosome": ["chr1"] * 2,
+            "start": [0, 100_000],
+            "end": [1000, 101_000],
+            "gene": ["AAA", "BBB"],
+            "log2": [0.0, 0.0],
+            "depth": [100.0, 200.0],
+        }
+        if with_weight:
+            bins["weight"] = [1.0, 2.0]
+        segments = {
+            "chromosome": ["chr1"] * 3,
+            "start": [0, 20_000, 60_000],
+            "end": [20_000, 60_000, 101_000],
+            "gene": ["-"] * 3,
+            "log2": [0.0] * 3,
+        }
+        return (
+            cnary.CopyNumArray(pd.DataFrame(bins)),
+            cnary.CopyNumArray(pd.DataFrame(segments)),
+        )
+
+    def test_transfer_fields_segment_spanning_no_bins(self):
+        """A segment overlapping no bins takes the empty aggregate, not a neighbor's.
+
+        ``iter_slices(..., keep_empty=False)`` omits the yield for such a
+        segment, so a consumer pairing the yields with segment rows
+        positionally would shift every later row onto the following segment's
+        bins. The middle segment here lies wholly inside a bin-free gap; each
+        flanking segment must still get its own bin.
+        """
+        cnarr, segarr = self._bin_gap_pair(with_weight=True)
+        result = segmentation.transfer_fields(segarr, cnarr)
+        self.assertEqual(result["gene"].tolist(), ["AAA", "-", "BBB"])
+        self.assertEqual(result["weight"].tolist(), [1.0, 0.0, 2.0])
+        self.assertEqual(result["depth"].tolist(), [100.0, 0.0, 200.0])
+
+    def test_transfer_fields_non_contiguous_chromosomes(self):
+        """Aggregates follow segment rows, not chromosome-grouped yield order.
+
+        ``by_shared_chroms`` groups the segments by chromosome with
+        ``groupby(sort=False)``, so consuming it directly would yield in
+        chromosome-of-first-appearance order and write values across
+        chromosomes; ``iter_slices`` re-orders to the segment rows. Interleaved
+        chromosome rows arise only for an in-memory array assembled by
+        concatenation and never re-sorted, since every file-based route is
+        sorted by ``tabio.read``. chr2 before chr10 makes first-appearance
+        order differ from the lexicographic order pandas would use with
+        ``groupby(sort=True)``, so recovering the groups by sorting fails here
+        too. Every gene, depth and weight is distinct, so any permutation of
+        the assignment fails.
+        """
+        cnarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr2", "chr2", "chr10", "chr10"],
+                    "start": [0, 1000, 0, 1000],
+                    "end": [1000, 2000, 1000, 2000],
+                    "gene": ["AAA", "BBB", "CCC", "DDD"],
+                    "log2": [0.0] * 4,
+                    "depth": [100.0, 200.0, 300.0, 400.0],
+                    "weight": [1.0, 2.0, 3.0, 4.0],
+                }
+            )
+        )
+        segarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr2", "chr10", "chr2", "chr10"],
+                    "start": [0, 0, 1000, 1000],
+                    "end": [1000, 1000, 2000, 2000],
+                    "gene": ["-"] * 4,
+                    "log2": [0.0] * 4,
+                }
+            )
+        )
+        result = segmentation.transfer_fields(segarr, cnarr)
+        self.assertEqual(result["gene"].tolist(), ["AAA", "CCC", "BBB", "DDD"])
+        self.assertEqual(result["weight"].tolist(), [1.0, 3.0, 2.0, 4.0])
+        self.assertEqual(result["depth"].tolist(), [100.0, 300.0, 200.0, 400.0])
+
+    def test_transfer_fields_no_weight_column_spanning_no_bins(self):
+        """Without a bin weight column, a bin-free segment gets depth 0, not NaN.
+
+        ``weight`` is optional throughout CNVkit; absent, bins are weighted
+        equally, so the segment weight is the bin count and the depth is the
+        plain mean. The mean of an empty selection is NaN and warns, which
+        would put NaN in the .cns.
+        """
+        cnarr, segarr = self._bin_gap_pair(with_weight=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            result = segmentation.transfer_fields(segarr, cnarr)
+        self.assertEqual(result["depth"].tolist(), [100.0, 0.0, 200.0])
+        self.assertEqual(result["weight"].tolist(), [1.0, 0.0, 1.0])
+        # The .cns columns are float, not the int the bin count would infer
+        self.assertEqual(result.data["weight"].dtype, np.float64)
+        self.assertEqual(result.data["depth"].dtype, np.float64)
+
+    def test_transfer_fields_filtered_bins_gapped_index(self):
+        """Bin aggregation survives a bin table whose index has gaps.
+
+        ``iter_slices`` yields index *labels*, and the aggregation indexes the
+        extracted numpy arrays positionally, so ``transfer_fields`` resets the
+        index first. Without that, a filtered ``cnarr`` -- as the upstream log2
+        and coverage filters produce -- reads the wrong bins or runs off the
+        end of the arrays.
+        """
+        cnarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * 4,
+                    "start": [0, 100_000, 200_000, 300_000],
+                    "end": [1000, 101_000, 201_000, 301_000],
+                    "gene": ["AAA", "BBB", "CCC", "DDD"],
+                    "log2": [0.0] * 4,
+                    "depth": [100.0, 200.0, 300.0, 400.0],
+                    "weight": [1.0, 2.0, 3.0, 4.0],
+                }
+            )
+        )
+        # As drop_outliers / drop_low_coverage do: filter without re-indexing
+        kept = cnarr[cnarr["depth"] >= 300.0]
+        self.assertEqual(kept.data.index.tolist(), [2, 3])
+        segarr = cnary.CopyNumArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * 2,
+                    "start": [200_000, 300_000],
+                    "end": [201_000, 301_000],
+                    "gene": ["-"] * 2,
+                    "log2": [0.0] * 2,
+                }
+            )
+        )
+        result = segmentation.transfer_fields(segarr, kept)
+        self.assertEqual(result["gene"].tolist(), ["CCC", "DDD"])
+        self.assertEqual(result["depth"].tolist(), [300.0, 400.0])
+        self.assertEqual(result["weight"].tolist(), [3.0, 4.0])
+
+    def test_do_segmentation_vcf_subsegment_without_bins(self):
+        """End-to-end: --vcf sub-segments can land in a bin-free gap.
+
+        ``variants_in_segment`` places a breakpoint midway between two SNVs,
+        which on a targeted panel can fall entirely inside the gap between two
+        bins. Whatever the resulting breakpoints, each bin's gene, depth and
+        weight must land on the segment that actually contains it.
+        """
+        bins, _segarr = self._bin_gap_pair(with_weight=True)
+        # 180 SNVs, all inside the 99 kb bin-free gap: 120 spread across it,
+        # plus 60 at BAF 0.75 in its middle, so the allele-frequency split
+        # necessarily lands between the bins.
+        pos = np.concatenate(
+            [np.linspace(1500, 99_000, 120), np.linspace(20_000, 60_000, 60)]
+        ).astype(int)
+        baf = np.concatenate([np.full(120, 0.5), np.full(60, 0.75)])
+        order = np.argsort(pos)
+        varr = vary.VariantArray(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * 180,
+                    "start": pos[order],
+                    "end": pos[order] + 1,
+                    "ref": ["A"] * 180,
+                    "alt": ["G"] * 180,
+                    "zygosity": np.full(180, 0.5),
+                    "alt_freq": baf[order],
+                    "depth": np.full(180, 100.0),
+                }
+            )
+        )
+        segarr = segmentation.do_segmentation(bins, "none", variants=varr)
+        # The bin-free sub-segment is the condition under test; assert it exists
+        # so that a later change to `variants_in_segment` cannot make the test
+        # vacuous.
+        covered = [
+            ((bins.start < seg.end) & (bins.end > seg.start)).any()
+            for seg in segarr.data.itertuples()
+        ]
+        self.assertIn(False, covered)
+        for _, abin in bins.data.iterrows():
+            midpoint = (abin.start + abin.end) // 2
+            hits = segarr.data[(segarr.start <= midpoint) & (midpoint < segarr.end)]
+            self.assertEqual(len(hits), 1)
+            self.assertIn(abin.gene, hits["gene"].iat[0])
+            self.assertEqual(hits["depth"].iat[0], abin.depth)
+            self.assertEqual(hits["weight"].iat[0], abin.weight)
+
     def test_do_segmentation_drops_nan_log2(self):
         """do_segmentation tolerates NaN-log2 bins on the default path (#881).
 

--- a/test/test_vary.py
+++ b/test/test_vary.py
@@ -59,6 +59,12 @@ class VariantArrayTests(unittest.TestCase):
         baf = varr.baf_by_ranges(ranges)
         self.assertEqual(len(baf), len(ranges))  # 3, not 5 (the variant count)
         self.assertTrue(baf.isna().all())
+        # Indexed by the ranges, like the normal into_ranges path: callers
+        # assign it onto a column and pandas aligns that by label
+        gapped = ranges[np.array([True, False, True])]
+        self.assertEqual(
+            varr.baf_by_ranges(gapped).index.tolist(), gapped.data.index.tolist()
+        )
 
     def test_mirrored_baf_all_nan(self):
         """All-NaN frequencies mirror to all-NaN without warning (#407).


### PR DESCRIPTION
## Problem

`skgenome.intersect.by_shared_chroms` groups its arguments with
`groupby("chromosome", sort=False)`, so it yields groups in
chromosome-of-first-appearance order. `iter_slices` and `by_ranges` passed that
order straight through, while every consumer pairs the yields with the rows of
their `other` argument **positionally**:

| Consumer | Reached from |
| --- | --- |
| `transfer_fields` | `segment` (all methods) |
| `into_ranges` | `target --annotate`, `cnv_annotate`, `call --vcf`, `export nexus-ogt` |
| `GenomicArray.iter_ranges_of` | `segmetrics`, `CopyNumArray.residuals` |
| `GenomicArray.by_ranges` | `export` (`ci_left`/`ci_right`, theta), `segment --vcf` |

Row order and yield order coincide only while each chromosome's rows are
contiguous, so an array assembled by concatenation and never re-sorted had each
row's values written onto another chromosome's row. Every file-based route is
sorted by `tabio.read`, so that half is not reachable from the command line.

Two further defects in the same code are reachable:

- `iter_slices(..., keep_empty=False)` omits the yield for an empty selection.
  On the CBS/`none` variant re-segmentation path, `variants_in_segment` places a
  breakpoint midway between two SNVs, and on a targeted panel that midpoint can
  fall inside a bin-free gap. The resulting sub-segment took its successor's
  gene, weight and depth, and the segment that actually contained the bin got
  nothing.
- `into_ranges` returned a Series with a fresh `RangeIndex`. Callers assign it
  onto a column of the destination and pandas aligns that by label, so a
  destination with a gapped index silently misplaced values.

## Approach

Fixed at the shared layer rather than at the call sites. `iter_slices` and
`by_ranges` build one lazy sub-iterator per chromosome and draw from them while
walking `other` row by row; with `keep_empty=True` there is exactly one yield
per row. `transfer_fields` relies on that instead of `keep_empty=False`, and its
weighted and unweighted branches collapse into one by treating an absent weight
column as unit weights. `into_ranges` and the three fallback paths in the same
family are indexed by the destination's labels.

The per-chromosome sub-iterator is a named generator function rather than a
generator expression: a genexp evaluates only its outermost iterable eagerly, so
its body would re-read the enclosing loop variable and every chromosome would
slice the last one's rows.

`by_shared_chroms`' `keep_empty` parameter is removed; both remaining callers
now pass `True`, and its name collided confusingly with the callers' own flag.

## Output impact

38 command outputs compared against a baseline worktree at the parent commit,
over the `amplicon` and `p2-9_2` fixtures: all four segmentation methods,
`segment --vcf`, `call`, `export` nexus-basic / nexus-ogt / ci / theta,
`genemetrics`, `bintest`, `metrics`, `residuals`, `intersection` and
`target --annotate`. 32 are byte-identical. Three groups change, all
corrections:

- **`segment -m cbs/none --vcf` on `p2-9_2`.** `chr21:36219110-36221566`
  overlaps no bins and had been taking gene `RUNX1`, depth 239.03 and weight
  2.83 from its successor, while `chr21:36221566-36259444`, which contains the
  RUNX1 bin, was left with gene `-`, depth 0 and weight 0. The two are now the
  right way round, matching what `doc/fileformats.rst` describes for the `.cns`
  gene, weight and depth columns.
- **`export nexus-ogt --min-weight`** with a nonzero threshold, which filters
  bins and leaves a gapped index: 77 B-Allele Frequency values now land on their
  own bins, where 2 were previously lost and others shifted. The default
  threshold of 0 is byte-identical.
- **`segmetrics`' bootstrap `ci_lo`/`ci_hi`**, which are nondeterministic in the
  baseline against itself. Recomputed with the deterministic statistics only
  (mean, median, mode, stdev, mad, mse, iqr, bivar, sem, pi), the output is
  byte-identical.

`target --annotate` is corrected on the same label-alignment defect, though no
fixture exercises it: baits containing a zero-width interval are dropped in
`target.py`, leaving a gapped index, and the regions after the gap came back
unnamed.

## Verification

- Full suite: 548 tests, plus 19 under `-m slow`, including the frozen
  `.cnr`/`.cns`/`.call.cns` regression fixtures.
- `ruff check`, `ruff format`, `mypy` clean.
- Eleven mutants of the changed code were applied one at a time and all were
  killed by the new tests, including reverting either function to
  chromosome-grouped order, inlining the sub-iterator as a generator expression,
  dropping `index=dest.index` from any of the four paths that set it, reverting
  `transfer_fields` to `keep_empty=False`, dropping the `reset_index`, and
  narrowing the segment weight to an integer.
- `iter_slices` throughput on a 165k-row argument: 478 ms before, 488 ms after.
