### PR TITLE
Add overlap-aware depth counting for short-insert libraries (#999)

### DIFF
--- a/cnvlib/batch.py
+++ b/cnvlib/batch.py
@@ -107,16 +107,16 @@ def batch_make_reference(
         0 = use all available CPUs.
     by_count : bool
         Calculate coverage by read count instead of read depth.
-    no_overlap : bool
-        Count each mate-pair fragment's overlapping bases once (avoids
-        FFPE short-insert double-counting). Passed to ``coverage.do_coverage``
-        for every normal sample.
     method : str
         Sequencing protocol: 'hybrid' (default), 'wgs', or 'amplicon'.
         Determines target/antitarget handling and default parameters.
     do_cluster : bool
         Apply hierarchical clustering to identify and separate reference
         sample subgroups (useful for heterogeneous normal cohorts).
+    no_overlap : bool, optional
+        Count each mate-pair fragment's overlapping bases once (avoids FFPE
+        short-insert double-counting), for every normal sample's coverage.
+        Default is False.
 
     Returns
     -------
@@ -388,7 +388,7 @@ def batch_make_reference(
                         min_mapq,
                         procs_per_cnn,
                         fasta,
-                        no_overlap,
+                        no_overlap=no_overlap,
                     )
                 )
                 anti_futures.append(
@@ -401,7 +401,7 @@ def batch_make_reference(
                         min_mapq,
                         procs_per_cnn,
                         fasta,
-                        no_overlap,
+                        no_overlap=no_overlap,
                     )
                 )
 
@@ -437,7 +437,7 @@ def batch_write_coverage(
     min_mapq: int,
     processes: int,
     fasta: str | None,
-    no_overlap: bool = False,
+    no_overlap: bool,
 ) -> str:
     """Run coverage on one sample (BAM or bedGraph), write to file."""
     cnarr = coverage.do_coverage(
@@ -482,6 +482,10 @@ def batch_run_sample(
     computed and written to ``{output_dir}/{sample_id}.*coverage.cnn`` earlier in
     the same run (the self-reference workflow where the sample is also a normal,
     #48); when True the existing files are read back instead of recomputed.
+
+    ``no_overlap`` counts each fragment's mate-overlap bases once instead of once
+    per mate when computing this sample's (anti)target coverage; see
+    ``--no-overlap`` on the ``coverage`` subcommand (#999).
     """
     # ENH - return probes, segments (cnarr, segarr)
     logging.info("Running the CNVkit pipeline on %s ...", sample_fname)
@@ -502,7 +506,7 @@ def batch_run_sample(
             min_mapq,
             processes,
             fasta,
-            no_overlap,
+            no_overlap=no_overlap,
         )
         tabio.write(raw_tgt, tgt_cnn)
 
@@ -513,7 +517,7 @@ def batch_run_sample(
             min_mapq,
             processes,
             fasta,
-            no_overlap,
+            no_overlap=no_overlap,
         )
         tabio.write(raw_anti, anti_cnn)
 

--- a/cnvlib/batch.py
+++ b/cnvlib/batch.py
@@ -52,6 +52,7 @@ def batch_make_reference(
     do_cluster: bool,
     cluster_method: str = "hierarchical",
     bias_smoother: str = "median",
+    no_overlap: bool = False,
 ) -> tuple[str, str, str]:
     """Build a complete copy number reference from normal samples.
 
@@ -106,6 +107,10 @@ def batch_make_reference(
         0 = use all available CPUs.
     by_count : bool
         Calculate coverage by read count instead of read depth.
+    no_overlap : bool
+        Count each mate-pair fragment's overlapping bases once (avoids
+        FFPE short-insert double-counting). Passed to ``coverage.do_coverage``
+        for every normal sample.
     method : str
         Sequencing protocol: 'hybrid' (default), 'wgs', or 'amplicon'.
         Determines target/antitarget handling and default parameters.
@@ -383,6 +388,7 @@ def batch_make_reference(
                         min_mapq,
                         procs_per_cnn,
                         fasta,
+                        no_overlap,
                     )
                 )
                 anti_futures.append(
@@ -395,6 +401,7 @@ def batch_make_reference(
                         min_mapq,
                         procs_per_cnn,
                         fasta,
+                        no_overlap,
                     )
                 )
 
@@ -430,10 +437,11 @@ def batch_write_coverage(
     min_mapq: int,
     processes: int,
     fasta: str | None,
+    no_overlap: bool = False,
 ) -> str:
     """Run coverage on one sample (BAM or bedGraph), write to file."""
     cnarr = coverage.do_coverage(
-        bed_fname, sample_fname, by_count, min_mapq, processes, fasta
+        bed_fname, sample_fname, by_count, min_mapq, processes, fasta, no_overlap
     )
     tabio.write(cnarr, out_fname)
     return out_fname
@@ -461,6 +469,7 @@ def batch_run_sample(
     sample_sex: str | None = None,
     bias_smoother: str = "median",
     reuse_coverage: bool = False,
+    no_overlap: bool = False,
 ) -> None:
     """Run the pipeline on one sample (BAM or bedGraph file).
 
@@ -487,12 +496,24 @@ def batch_run_sample(
         raw_anti = read_cna(anti_cnn)
     else:
         raw_tgt = coverage.do_coverage(
-            target_bed, sample_fname, by_count, min_mapq, processes, fasta
+            target_bed,
+            sample_fname,
+            by_count,
+            min_mapq,
+            processes,
+            fasta,
+            no_overlap,
         )
         tabio.write(raw_tgt, tgt_cnn)
 
         raw_anti = coverage.do_coverage(
-            antitarget_bed, sample_fname, by_count, min_mapq, processes, fasta
+            antitarget_bed,
+            sample_fname,
+            by_count,
+            min_mapq,
+            processes,
+            fasta,
+            no_overlap,
         )
         tabio.write(raw_anti, anti_cnn)
 

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -171,6 +171,18 @@ def add_min_mapq(P: argparse._ActionsContainer) -> None:
     )
 
 
+def add_no_overlap(P: argparse._ActionsContainer) -> None:
+    P.add_argument(
+        "--no-overlap",
+        action="store_true",
+        help="""Count each mate-pair fragment's overlapping bases once instead of
+                once per mate (samtools depth -s semantics), avoiding inflated
+                depth from short-insert fragments (e.g. FFPE). Forces the
+                by-count coverage algorithm, since samtools bedcov has no
+                overlap-aware mode.""",
+    )
+
+
 def add_snp_vcf_args(
     P: argparse._ActionsContainer, *, short_min_depth: bool = False
 ) -> None:
@@ -330,6 +342,7 @@ def _cmd_batch(args: argparse.Namespace) -> None:
             args.cluster,
             args.cluster_method,
             bias_smoother=args.bias_smoother,
+            no_overlap=args.no_overlap,
         )
     elif args.targets is None and args.antitargets is None:
         # Extract (anti)target BEDs from the given, existing CN reference
@@ -380,6 +393,7 @@ def _cmd_batch(args: argparse.Namespace) -> None:
                     args.sample_sex,
                     args.bias_smoother,
                     core.fbase(bam) in reusable_sids,
+                    args.no_overlap,
                 )
                 futures.append((bam, future))
             # Wait for all tasks to complete and raise any exceptions
@@ -454,6 +468,7 @@ P_batch.add_argument(
 )
 add_processes(P_batch)
 add_min_mapq(P_batch)
+add_no_overlap(P_batch)
 P_batch.add_argument(
     "--rscript-path",
     metavar="PATH",
@@ -911,6 +926,7 @@ def _cmd_coverage(args: argparse.Namespace) -> None:
         args.min_mapq,
         args.processes,
         args.fasta,
+        args.no_overlap,
     )
     if not args.output:
         # Create an informative but unique name for the coverage output file
@@ -943,6 +959,7 @@ P_coverage.add_argument(
             (An alternative algorithm).""",
 )
 add_min_mapq(P_coverage)
+add_no_overlap(P_coverage)
 P_coverage.add_argument(
     "-o", "--output", metavar="FILENAME", help="""Output file name."""
 )

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -172,14 +172,19 @@ def add_min_mapq(P: argparse._ActionsContainer) -> None:
 
 
 def add_no_overlap(P: argparse._ActionsContainer) -> None:
+    # Unlike the --no-gc/--no-edge/--no-rmask family, this flag switches a
+    # correction ON rather than disabling a default-on step, so the polarity is
+    # store_true with a negative dest -- deliberate, matching `samtools depth -s`
+    # and the option name users asked for in #999.
     P.add_argument(
         "--no-overlap",
         action="store_true",
         help="""Count each mate-pair fragment's overlapping bases once instead of
                 once per mate (samtools depth -s semantics), avoiding inflated
-                depth from short-insert fragments (e.g. FFPE). Forces the
+                depth from short-insert fragments (e.g. FFPE). Implies the
                 by-count coverage algorithm, since samtools bedcov has no
-                overlap-aware mode.""",
+                overlap-aware mode: bases spanned by a read deletion are not
+                counted, and the output column order follows the --count path.""",
     )
 
 
@@ -389,11 +394,11 @@ def _cmd_batch(args: argparse.Namespace) -> None:
                     args.segment_method,
                     procs_per_sample,
                     args.cluster,
-                    args.fasta,
-                    args.sample_sex,
-                    args.bias_smoother,
-                    core.fbase(bam) in reusable_sids,
-                    args.no_overlap,
+                    fasta=args.fasta,
+                    sample_sex=args.sample_sex,
+                    bias_smoother=args.bias_smoother,
+                    reuse_coverage=core.fbase(bam) in reusable_sids,
+                    no_overlap=args.no_overlap,
                 )
                 futures.append((bam, future))
             # Wait for all tasks to complete and raise any exceptions
@@ -926,7 +931,7 @@ def _cmd_coverage(args: argparse.Namespace) -> None:
         args.min_mapq,
         args.processes,
         args.fasta,
-        args.no_overlap,
+        no_overlap=args.no_overlap,
     )
     if not args.output:
         # Create an informative but unique name for the coverage output file

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -194,6 +194,7 @@ def do_coverage(
     min_mapq: int = 0,
     processes: int = 1,
     fasta: str | None = None,
+    no_overlap: bool = False,
 ) -> CNA:
     """Calculate coverage in the given regions from BAM read depths.
 
@@ -214,6 +215,11 @@ def do_coverage(
         Ignored for bedGraph input.
     fasta : str, optional
         Path to reference genome FASTA file.
+    no_overlap : bool, optional
+        Count each mate-pair fragment's overlapping bases once instead of
+        once per mate (``samtools depth -s`` semantics), avoiding inflated
+        depth from short-insert (e.g. FFPE) fragments. Default is False
+        (matches historical behavior). Ignored for bedGraph input.
 
     Returns
     -------
@@ -242,6 +248,11 @@ def do_coverage(
             logging.warning(
                 "Option --processes/-p is not applicable to bedGraph input and will be ignored"
             )
+        if no_overlap:
+            logging.warning(
+                "Option --no-overlap/-s is not applicable to bedGraph input "
+                "(no per-read pair information) and will be ignored"
+            )
         cnarr = interval_coverages_bedgraph(bed_fname, bam_or_bg_fname)
     else:
         # BAM format - use existing logic
@@ -251,7 +262,7 @@ def do_coverage(
             )
         samutil.ensure_bam_index(bam_or_bg_fname)
         cnarr = interval_coverages(
-            bed_fname, bam_or_bg_fname, by_count, min_mapq, processes, fasta
+            bed_fname, bam_or_bg_fname, by_count, min_mapq, processes, fasta, no_overlap
         )
 
     return cnarr
@@ -264,6 +275,7 @@ def interval_coverages(
     min_mapq: int,
     processes: int,
     fasta: str | None = None,
+    no_overlap: bool = False,
 ) -> CNA:
     """Calculate log2 coverages in the BAM file at each interval."""
     meta = {"sample_id": core.fbase(bam_fname)}
@@ -282,14 +294,24 @@ def interval_coverages(
             )
             return CNA.from_rows([], meta_dict=meta)  # type: ignore[return-value]
 
-    # Calculate average read depth in each bin
-    if by_count:
+    # Calculate average read depth in each bin. `samtools bedcov` (the pileup
+    # path below) has no per-fragment overlap awareness, so overlap-aware
+    # mode always routes through the by-read-fetch counting engine, same as
+    # --count -- the only path that can see both mates of a fragment (#999).
+    if by_count or no_overlap:
+        if no_overlap and not by_count:
+            logging.info(
+                "Using the by-count coverage algorithm for --no-overlap "
+                "mate-pair accounting (samtools bedcov has no overlap-aware "
+                "mode)"
+            )
         results = interval_coverages_count(
             bed_fname,
             bam_fname,
             min_mapq,
             processes,
             fasta,  # type: ignore[arg-type]
+            no_overlap,
         )
         read_counts, cna_rows = zip(*results, strict=True)
         read_counts = pd.Series(read_counts)
@@ -410,7 +432,12 @@ def interval_coverages_bedgraph(
 
 
 def interval_coverages_count(
-    bed_fname: str, bam_fname: str, min_mapq: int, procs: int = 1, fasta: None = None
+    bed_fname: str,
+    bam_fname: str,
+    min_mapq: int,
+    procs: int = 1,
+    fasta: None = None,
+    no_overlap: bool = False,
 ) -> Iterator[list[int | tuple[str, int, int, str, float, float]]]:
     """Calculate log2 coverages in the BAM file at each interval."""
     try:
@@ -437,11 +464,15 @@ def interval_coverages_count(
             logging.info(
                 "Processing chromosome %s of %s", chrom, os.path.basename(bam_fname)
             )
-            for count, row in _rdc_chunk(bamfile, subregions, min_mapq):
+            for count, row in _rdc_chunk(
+                bamfile, subregions, min_mapq, no_overlap=no_overlap
+            ):
                 yield [count, row]
     else:
         with pick_pool(procs) as pool:
-            args_iter = ((bam_fname, subr, min_mapq, fasta) for _c, subr in present)
+            args_iter = (
+                (bam_fname, subr, min_mapq, fasta, no_overlap) for _c, subr in present
+            )
             for chunk in pool.map(_rdc, args_iter):
                 for count, row in chunk:
                     yield [count, row]
@@ -457,6 +488,7 @@ def _rdc_chunk(
     regions: GenomicArray,
     min_mapq: int,
     fasta: None = None,
+    no_overlap: bool = False,
 ) -> Iterator[tuple[int, tuple[str, int, int, str, float, float]]]:
     if isinstance(bamfile, str):  # type: ignore[unreachable]
         try:  # type: ignore[unreachable]
@@ -467,7 +499,9 @@ def _rdc_chunk(
             ) from None
         bamfile = pysam.AlignmentFile(bamfile, "rb", reference_filename=fasta)
     for chrom, start, end, gene in regions.coords(["gene"]):
-        yield region_depth_count(bamfile, chrom, start, end, gene, min_mapq)
+        yield region_depth_count(
+            bamfile, chrom, start, end, gene, min_mapq, no_overlap=no_overlap
+        )
 
 
 def region_depth_count(
@@ -477,6 +511,7 @@ def region_depth_count(
     end: int,
     gene: str,
     min_mapq: int,
+    no_overlap: bool = False,
 ) -> tuple[int, tuple[str, int, int, str, float, float]]:
     """Calculate depth of a region via pysam count.
 
@@ -484,6 +519,11 @@ def region_depth_count(
     length and region width to estimate depth.
 
     Coordinates are 0-based, per pysam.
+
+    ``no_overlap``, if True, counts each fragment's (read pair's) covered
+    bases once instead of once per mate, so a short-insert fragment whose
+    mates overlap doesn't inflate depth in the overlap -- the same semantics
+    as ``samtools depth -s`` (#999, FFPE double-counting).
     """
 
     def filter_read(read) -> bool:
@@ -502,11 +542,24 @@ def region_depth_count(
 
     count = 0
     bases = 0
+    # Overlap-aware mode unions each template's (query name's) aligned
+    # positions instead of summing per-read, so mate-pair overlap within a
+    # fragment is counted once; `frag_positions is None` keeps the default
+    # (bit-exact, allocation-free) path unchanged.
+    frag_positions: dict[str | None, set[int]] | None = {} if no_overlap else None
     for read in bamfile.fetch(reference=chrom, start=start, end=end):
-        if filter_read(read):
-            count += 1
+        if not filter_read(read):
+            continue
+        count += 1
+        read_positions = read.positions  # type: ignore[attr-defined]
+        in_region = (p for p in read_positions if start <= p < end)
+        if frag_positions is not None:
+            frag_positions.setdefault(read.query_name, set()).update(in_region)
+        else:
             # Only count the bases aligned to the region
-            bases += sum(1 for p in read.positions if start <= p < end)  # type: ignore[attr-defined,misc]
+            bases += sum(1 for _ in in_region)
+    if frag_positions is not None:
+        bases = sum(len(positions) for positions in frag_positions.values())
     depth = bases / (end - start) if end > start else 0
     row = (
         chrom,

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -250,7 +250,7 @@ def do_coverage(
             )
         if no_overlap:
             logging.warning(
-                "Option --no-overlap/-s is not applicable to bedGraph input "
+                "Option --no-overlap is not applicable to bedGraph input "
                 "(no per-read pair information) and will be ignored"
             )
         cnarr = interval_coverages_bedgraph(bed_fname, bam_or_bg_fname)
@@ -294,10 +294,9 @@ def interval_coverages(
             )
             return CNA.from_rows([], meta_dict=meta)  # type: ignore[return-value]
 
-    # Calculate average read depth in each bin. `samtools bedcov` (the pileup
-    # path below) has no per-fragment overlap awareness, so overlap-aware
-    # mode always routes through the by-read-fetch counting engine, same as
-    # --count -- the only path that can see both mates of a fragment (#999).
+    # Calculate average read depth in each bin. The by-read-fetch engine is the
+    # only path that sees both mates of a fragment, so overlap-aware mode has to
+    # route through it (#999).
     if by_count or no_overlap:
         if no_overlap and not by_count:
             logging.info(
@@ -310,7 +309,7 @@ def interval_coverages(
             bam_fname,
             min_mapq,
             processes,
-            fasta,  # type: ignore[arg-type]
+            fasta,
             no_overlap,
         )
         read_counts, cna_rows = zip(*results, strict=True)
@@ -436,7 +435,7 @@ def interval_coverages_count(
     bam_fname: str,
     min_mapq: int,
     procs: int = 1,
-    fasta: None = None,
+    fasta: str | None = None,
     no_overlap: bool = False,
 ) -> Iterator[list[int | tuple[str, int, int, str, float, float]]]:
     """Calculate log2 coverages in the BAM file at each interval."""
@@ -487,7 +486,7 @@ def _rdc_chunk(
     bamfile: pysam.AlignmentFile,
     regions: GenomicArray,
     min_mapq: int,
-    fasta: None = None,
+    fasta: str | None = None,
     no_overlap: bool = False,
 ) -> Iterator[tuple[int, tuple[str, int, int, str, float, float]]]:
     if isinstance(bamfile, str):  # type: ignore[unreachable]
@@ -513,17 +512,21 @@ def region_depth_count(
     min_mapq: int,
     no_overlap: bool = False,
 ) -> tuple[int, tuple[str, int, int, str, float, float]]:
-    """Calculate depth of a region via pysam count.
+    """Calculate depth of a region by scanning its reads with pysam.
 
-    i.e. counting the number of read starts in a region, then scaling for read
-    length and region width to estimate depth.
+    i.e. counting the bases each read aligns within the region, then dividing by
+    the region's width. Coordinates are 0-based, per pysam.
 
-    Coordinates are 0-based, per pysam.
-
-    ``no_overlap``, if True, counts each fragment's (read pair's) covered
-    bases once instead of once per mate, so a short-insert fragment whose
-    mates overlap doesn't inflate depth in the overlap -- the same semantics
-    as ``samtools depth -s`` (#999, FFPE double-counting).
+    ``no_overlap``, if True, counts each fragment's (read pair's) covered bases
+    once instead of once per mate, so a short-insert fragment whose mates overlap
+    doesn't inflate depth in the overlap -- the semantics of ``samtools depth -s``
+    (#999, FFPE double-counting). Only records that can actually have a mate in
+    this region are pooled -- paired, mate mapped, mate on the same contig --
+    matching the preconditions htslib applies before entering its overlap hash;
+    single-end and cross-contig records are counted per read, as htslib does.
+    Where more than two records share a query name (e.g. a supplementary
+    alignment of a chimeric read), all of them are pooled as one template,
+    whereas htslib pairs only the first two.
     """
 
     def filter_read(read) -> bool:
@@ -542,24 +545,41 @@ def region_depth_count(
 
     count = 0
     bases = 0
-    # Overlap-aware mode unions each template's (query name's) aligned
-    # positions instead of summing per-read, so mate-pair overlap within a
-    # fragment is counted once; `frag_positions is None` keeps the default
-    # (bit-exact, allocation-free) path unchanged.
-    frag_positions: dict[str | None, set[int]] | None = {} if no_overlap else None
+    # Overlap-aware mode collects each template's (query name's) in-region
+    # aligned blocks and merges them, so a fragment's mate overlap is counted
+    # once. Blocks rather than positions: a bin can hold millions of aligned
+    # bases, and per-base Python objects cost both memory and time (#999).
+    frag_blocks: dict[str | None, list[tuple[int, int]]] = {}
     for read in bamfile.fetch(reference=chrom, start=start, end=end):
         if not filter_read(read):
             continue
         count += 1
-        read_positions = read.positions  # type: ignore[attr-defined]
-        in_region = (p for p in read_positions if start <= p < end)
-        if frag_positions is not None:
-            frag_positions.setdefault(read.query_name, set()).update(in_region)
+        if (
+            no_overlap
+            and read.is_paired
+            and not read.mate_is_unmapped
+            and read.next_reference_id == read.reference_id
+        ):
+            blocks = frag_blocks.setdefault(read.query_name, [])
+            for block_start, block_end in read.get_blocks():
+                lo, hi = max(block_start, start), min(block_end, end)
+                if lo < hi:
+                    blocks.append((lo, hi))
         else:
             # Only count the bases aligned to the region
-            bases += sum(1 for _ in in_region)
-    if frag_positions is not None:
-        bases = sum(len(positions) for positions in frag_positions.values())
+            bases += sum(1 for p in read.positions if start <= p < end)  # type: ignore[attr-defined,misc]
+    for blocks in frag_blocks.values():
+        if not blocks:
+            continue
+        blocks.sort()
+        cur_lo, cur_hi = blocks[0]
+        for lo, hi in blocks[1:]:
+            if lo > cur_hi:
+                bases += cur_hi - cur_lo
+                cur_lo, cur_hi = lo, hi
+            else:
+                cur_hi = max(cur_hi, hi)
+        bases += cur_hi - cur_lo
     depth = bases / (end - start) if end > start else 0
     row = (
         chrom,

--- a/cnvlib/parallel.py
+++ b/cnvlib/parallel.py
@@ -21,10 +21,10 @@ class SerialPool:
     def __init__(self) -> None:
         pass
 
-    def submit(self, func: Callable, *args) -> SerialFuture:
+    def submit(self, func: Callable, *args, **kwargs) -> SerialFuture:
         """Just call the function on the arguments."""
         try:
-            result = func(*args)
+            result = func(*args, **kwargs)
             return SerialFuture(result=result)
         except Exception as exc:
             return SerialFuture(exception=exc)

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -353,6 +353,15 @@ Alternatively, using the ``--count`` option counts
 the number of read start positions in the interval and normalizes to the
 interval size.
 
+For short-insert libraries where the two mates of a read pair overlap --
+common in FFPE and other degraded-DNA samples -- the default pileup and
+``--count`` calculations both count the overlapping bases twice, inflating
+apparent depth and occasionally producing artifactual focal copy-number
+calls. The ``--no-overlap`` option counts each fragment's
+mate-overlap bases once instead (the same semantics as ``samtools depth
+-s``), at the cost of forcing the ``--count`` algorithm internally, since
+``samtools bedcov`` has no equivalent overlap-aware mode.
+
 ::
 
     cnvkit.py coverage Sample.bam targets.bed -o Sample.targetcoverage.cnn

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -349,18 +349,24 @@ command.
 Calculate coverage in the given regions from BAM read depths.
 
 By default, coverage is calculated via mean read depth from a pileup.
-Alternatively, using the ``--count`` option counts
-the number of read start positions in the interval and normalizes to the
-interval size.
+Alternatively, the ``--count`` option scans each read individually with pysam
+and counts the bases it aligns within each interval, instead of using a
+samtools pileup.
 
 For short-insert libraries where the two mates of a read pair overlap --
 common in FFPE and other degraded-DNA samples -- the default pileup and
 ``--count`` calculations both count the overlapping bases twice, inflating
 apparent depth and occasionally producing artifactual focal copy-number
-calls. The ``--no-overlap`` option counts each fragment's
-mate-overlap bases once instead (the same semantics as ``samtools depth
--s``), at the cost of forcing the ``--count`` algorithm internally, since
-``samtools bedcov`` has no equivalent overlap-aware mode.
+calls. The ``--no-overlap`` option, available on both the :ref:`coverage` and
+:ref:`batch` commands, counts each fragment's mate-overlap bases once instead
+(the same semantics as ``samtools depth -s``). It implies the ``--count``
+algorithm, since ``samtools bedcov`` has no equivalent overlap-aware mode, and
+that switch carries two further consequences: bases spanned by a read's
+deletion are no longer counted, and the per-read scan is slower than the
+samtools pileup, so ``-p``/``--processes`` is advisable on large inputs. Under
+:ref:`batch`, note that automatic bin sizing (:ref:`autobin`) still estimates
+depth from the pileup, so bins will be somewhat smaller than the requested
+average when mate overlap is substantial.
 
 ::
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,6 @@
+import ast
+import inspect
+
 import matplotlib
 import pytest
 
@@ -19,3 +22,53 @@ def linecount(filename):
         for i, _line in enumerate(handle):
             pass
         return i + 1
+
+
+def ast_calls_to(func, attr, obj=None):
+    """Return the ``ast.Call`` nodes in `func`'s source that call `attr`.
+
+    `obj`, when given, additionally requires the call to be made on that name,
+    so ``ast_calls_to(batch.batch_run_sample, "do_fix", "fix")`` matches only
+    ``fix.do_fix(...)``. Used by the argument-propagation guards, which assert
+    that a high-level entry point forwards an option to the function that
+    implements it -- a regression class that otherwise needs a BAM fixture and
+    a full pipeline run to detect.
+    """
+    calls = []
+    for node in ast.walk(ast.parse(inspect.getsource(func))):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != attr:
+            continue
+        if obj is not None and not (
+            isinstance(node.func.value, ast.Name) and node.func.value.id == obj
+        ):
+            continue
+        calls.append(node)
+    return calls
+
+
+def ast_submit_calls(func, target):
+    """Return the ``pool.submit(target, ...)`` call nodes in `func`'s source."""
+    calls = []
+    for call in ast_calls_to(func, "submit"):
+        if not call.args:
+            continue
+        first = call.args[0]
+        name = first.id if isinstance(first, ast.Name) else getattr(first, "attr", None)
+        if name == target:
+            calls.append(call)
+    return calls
+
+
+def call_arg_names(call):
+    """Names, attribute names and keywords supplied at a call site.
+
+    A propagation guard can then accept ``f(no_overlap)``, ``f(args.no_overlap)``
+    or ``f(no_overlap=...)`` interchangeably.
+    """
+    return (
+        {a.id for a in call.args if isinstance(a, ast.Name)}
+        | {a.attr for a in call.args if isinstance(a, ast.Attribute)}
+        | {kw.arg for kw in call.keywords}
+    )

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -19,7 +19,7 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 import numpy as np
 import pandas as pd
 import pysam
-from conftest import linecount
+from conftest import ast_calls_to, ast_submit_calls, call_arg_names, linecount
 
 import cnvlib
 from cnvlib import (
@@ -287,26 +287,13 @@ class BatchTests(unittest.TestCase):
         AST-level guard so source rearrangements still catch the regression
         cleanly without needing a full BAM fixture per case.
         """
-        src = inspect.getsource(batch.batch_run_sample)
-        tree = ast.parse(src)
-        do_call_invocations = []
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            if (
-                isinstance(func, ast.Attribute)
-                and func.attr == "do_call"
-                and isinstance(func.value, ast.Name)
-                and func.value.id == "call"
-            ):
-                do_call_invocations.append(node)
+        invocations = ast_calls_to(batch.batch_run_sample, "do_call", "call")
         self.assertGreater(
-            len(do_call_invocations),
+            len(invocations),
             0,
             "Expected at least one call.do_call() invocation in batch_run_sample",
         )
-        for inv in do_call_invocations:
+        for inv in invocations:
             kw_names = {kw.arg for kw in inv.keywords}
             self.assertIn(
                 "is_haploid_x_reference",
@@ -333,30 +320,16 @@ class BatchTests(unittest.TestCase):
         AST-level guard so source rearrangements still catch the regression
         cleanly without needing a full BAM fixture.
         """
-        src = inspect.getsource(batch.batch_run_sample)
-        tree = ast.parse(src)
-        do_fix_invocations = []
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            if (
-                isinstance(func, ast.Attribute)
-                and func.attr == "do_fix"
-                and isinstance(func.value, ast.Name)
-                and func.value.id == "fix"
-            ):
-                do_fix_invocations.append(node)
+        invocations = ast_calls_to(batch.batch_run_sample, "do_fix", "fix")
         self.assertGreater(
-            len(do_fix_invocations),
+            len(invocations),
             0,
             "Expected at least one fix.do_fix() invocation in batch_run_sample",
         )
-        for inv in do_fix_invocations:
-            kw_names = {kw.arg for kw in inv.keywords}
+        for inv in invocations:
             self.assertIn(
                 "bias_smoother",
-                kw_names,
+                {kw.arg for kw in inv.keywords},
                 "fix.do_fix inside batch_run_sample must pass bias_smoother "
                 "explicitly so `cnvkit batch --bias-smoother loess` reaches "
                 "center_by_window (#1028).",
@@ -372,31 +345,19 @@ class BatchTests(unittest.TestCase):
         AST-level guard, paired with
         ``test_batch_run_sample_passes_bias_smoother_to_do_fix``.
         """
-        src = inspect.getsource(batch.batch_make_reference)
-        tree = ast.parse(src)
-        do_reference_invocations = []
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            if (
-                isinstance(func, ast.Attribute)
-                and func.attr == "do_reference"
-                and isinstance(func.value, ast.Name)
-                and func.value.id == "reference"
-            ):
-                do_reference_invocations.append(node)
+        invocations = ast_calls_to(
+            batch.batch_make_reference, "do_reference", "reference"
+        )
         self.assertGreater(
-            len(do_reference_invocations),
+            len(invocations),
             0,
             "Expected at least one reference.do_reference() invocation "
             "in batch_make_reference",
         )
-        for inv in do_reference_invocations:
-            kw_names = {kw.arg for kw in inv.keywords}
+        for inv in invocations:
             self.assertIn(
                 "bias_smoother",
-                kw_names,
+                {kw.arg for kw in inv.keywords},
                 "reference.do_reference inside batch_make_reference must "
                 "pass bias_smoother explicitly so `cnvkit batch "
                 "--bias-smoother loess` reaches center_by_window during "
@@ -412,36 +373,18 @@ class BatchTests(unittest.TestCase):
         mate-pair overlap even though the CLI accepted the option.
 
         AST-level guard, paired with the bias_smoother guards above.
-        ``no_overlap`` is threaded positionally (alongside ``fasta``), not
-        by keyword, so this checks the trailing positional argument rather
-        than ``inv.keywords``.
         """
-        src = inspect.getsource(batch.batch_run_sample)
-        tree = ast.parse(src)
-        do_coverage_invocations = []
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            if (
-                isinstance(func, ast.Attribute)
-                and func.attr == "do_coverage"
-                and isinstance(func.value, ast.Name)
-                and func.value.id == "coverage"
-            ):
-                do_coverage_invocations.append(node)
+        invocations = ast_calls_to(batch.batch_run_sample, "do_coverage", "coverage")
         self.assertGreater(
-            len(do_coverage_invocations),
+            len(invocations),
             0,
             "Expected at least one coverage.do_coverage() invocation in "
             "batch_run_sample",
         )
-        for inv in do_coverage_invocations:
-            arg_names = {a.id for a in inv.args if isinstance(a, ast.Name)}
-            kw_names = {kw.arg for kw in inv.keywords}
+        for inv in invocations:
             self.assertIn(
                 "no_overlap",
-                arg_names | kw_names,
+                call_arg_names(inv),
                 "coverage.do_coverage inside batch_run_sample must pass "
                 "no_overlap so `cnvkit batch --no-overlap` reaches "
                 "overlap-aware depth counting (#999).",
@@ -454,33 +397,19 @@ class BatchTests(unittest.TestCase):
         AST-level guard, paired with
         ``test_batch_run_sample_passes_no_overlap_to_do_coverage``.
         """
-        src = inspect.getsource(batch.batch_make_reference)
-        tree = ast.parse(src)
-        submit_invocations = []
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            if (
-                isinstance(func, ast.Attribute)
-                and func.attr == "submit"
-                and node.args
-                and isinstance(node.args[0], ast.Name)
-                and node.args[0].id == "batch_write_coverage"
-            ):
-                submit_invocations.append(node)
+        invocations = ast_submit_calls(
+            batch.batch_make_reference, "batch_write_coverage"
+        )
         self.assertGreater(
-            len(submit_invocations),
+            len(invocations),
             0,
             "Expected at least one pool.submit(batch_write_coverage, ...) "
             "invocation in batch_make_reference",
         )
-        for inv in submit_invocations:
-            arg_names = {a.id for a in inv.args if isinstance(a, ast.Name)}
-            kw_names = {kw.arg for kw in inv.keywords}
+        for inv in invocations:
             self.assertIn(
                 "no_overlap",
-                arg_names | kw_names,
+                call_arg_names(inv),
                 "pool.submit(batch_write_coverage, ...) inside "
                 "batch_make_reference must pass no_overlap so `cnvkit batch "
                 "--no-overlap` reaches normal-sample coverage (#999).",
@@ -490,49 +419,21 @@ class BatchTests(unittest.TestCase):
         """``_cmd_batch`` must forward ``args.no_overlap`` to both
         ``batch.batch_make_reference`` and ``batch.batch_run_sample`` (#999).
         """
-        src = inspect.getsource(commands._cmd_batch)
-        tree = ast.parse(src)
-        checked = 0
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            target_name = None
-            if isinstance(func, ast.Attribute) and func.attr in (
-                "batch_make_reference",
-                "submit",
-            ):
-                target_name = func.attr
-            if target_name == "submit":
-                if not (
-                    node.args
-                    and isinstance(node.args[0], ast.Attribute)
-                    and node.args[0].attr == "batch_run_sample"
-                ):
-                    continue
-            elif target_name != "batch_make_reference":
-                continue
-            # batch_make_reference receives no_overlap by keyword;
-            # pool.submit(batch_run_sample, ...) receives it as a trailing
-            # positional argument (matching every other pool.submit call in
-            # this codebase, cf. batch_write_coverage in batch.py) --
-            # SerialPool.submit only forwards *args, not **kwargs.
-            arg_names = {a.id for a in node.args if isinstance(a, ast.Name)}
-            attr_names = {a.attr for a in node.args if isinstance(a, ast.Attribute)}
-            kw_names = {kw.arg for kw in node.keywords}
-            self.assertIn(
-                "no_overlap",
-                arg_names | attr_names | kw_names,
-                f"_cmd_batch's call to {target_name} must pass "
-                "args.no_overlap through to no_overlap (#999).",
-            )
-            checked += 1
+        invocations = ast_calls_to(commands._cmd_batch, "batch_make_reference")
+        invocations += ast_submit_calls(commands._cmd_batch, "batch_run_sample")
         self.assertEqual(
-            checked,
+            len(invocations),
             2,
             "Expected exactly one batch_make_reference call and one "
             "pool.submit(batch_run_sample, ...) call in _cmd_batch",
         )
+        for inv in invocations:
+            self.assertIn(
+                "no_overlap",
+                call_arg_names(inv),
+                "_cmd_batch must pass args.no_overlap through to no_overlap "
+                "in both the reference-building and per-sample paths (#999).",
+            )
 
     # -- batch coverage-dedup / self-reference (#48) --
 

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -403,6 +403,137 @@ class BatchTests(unittest.TestCase):
                 "reference construction (#1028).",
             )
 
+    def test_batch_run_sample_passes_no_overlap_to_do_coverage(self):
+        """``batch_run_sample`` must forward its ``no_overlap`` argument to
+        every ``coverage.do_coverage`` invocation it makes (#999).
+
+        Without this, ``cnvkit batch --no-overlap`` would silently drop
+        the flag and (anti)target coverage would keep double-counting
+        mate-pair overlap even though the CLI accepted the option.
+
+        AST-level guard, paired with the bias_smoother guards above.
+        ``no_overlap`` is threaded positionally (alongside ``fasta``), not
+        by keyword, so this checks the trailing positional argument rather
+        than ``inv.keywords``.
+        """
+        src = inspect.getsource(batch.batch_run_sample)
+        tree = ast.parse(src)
+        do_coverage_invocations = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "do_coverage"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "coverage"
+            ):
+                do_coverage_invocations.append(node)
+        self.assertGreater(
+            len(do_coverage_invocations),
+            0,
+            "Expected at least one coverage.do_coverage() invocation in "
+            "batch_run_sample",
+        )
+        for inv in do_coverage_invocations:
+            arg_names = {a.id for a in inv.args if isinstance(a, ast.Name)}
+            kw_names = {kw.arg for kw in inv.keywords}
+            self.assertIn(
+                "no_overlap",
+                arg_names | kw_names,
+                "coverage.do_coverage inside batch_run_sample must pass "
+                "no_overlap so `cnvkit batch --no-overlap` reaches "
+                "overlap-aware depth counting (#999).",
+            )
+
+    def test_batch_make_reference_passes_no_overlap_to_batch_write_coverage(self):
+        """``batch_make_reference`` must forward ``no_overlap`` to every
+        ``batch_write_coverage`` call it submits for normal samples (#999).
+
+        AST-level guard, paired with
+        ``test_batch_run_sample_passes_no_overlap_to_do_coverage``.
+        """
+        src = inspect.getsource(batch.batch_make_reference)
+        tree = ast.parse(src)
+        submit_invocations = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "submit"
+                and node.args
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id == "batch_write_coverage"
+            ):
+                submit_invocations.append(node)
+        self.assertGreater(
+            len(submit_invocations),
+            0,
+            "Expected at least one pool.submit(batch_write_coverage, ...) "
+            "invocation in batch_make_reference",
+        )
+        for inv in submit_invocations:
+            arg_names = {a.id for a in inv.args if isinstance(a, ast.Name)}
+            kw_names = {kw.arg for kw in inv.keywords}
+            self.assertIn(
+                "no_overlap",
+                arg_names | kw_names,
+                "pool.submit(batch_write_coverage, ...) inside "
+                "batch_make_reference must pass no_overlap so `cnvkit batch "
+                "--no-overlap` reaches normal-sample coverage (#999).",
+            )
+
+    def test_cmd_batch_passes_no_overlap(self):
+        """``_cmd_batch`` must forward ``args.no_overlap`` to both
+        ``batch.batch_make_reference`` and ``batch.batch_run_sample`` (#999).
+        """
+        src = inspect.getsource(commands._cmd_batch)
+        tree = ast.parse(src)
+        checked = 0
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            target_name = None
+            if isinstance(func, ast.Attribute) and func.attr in (
+                "batch_make_reference",
+                "submit",
+            ):
+                target_name = func.attr
+            if target_name == "submit":
+                if not (
+                    node.args
+                    and isinstance(node.args[0], ast.Attribute)
+                    and node.args[0].attr == "batch_run_sample"
+                ):
+                    continue
+            elif target_name != "batch_make_reference":
+                continue
+            # batch_make_reference receives no_overlap by keyword;
+            # pool.submit(batch_run_sample, ...) receives it as a trailing
+            # positional argument (matching every other pool.submit call in
+            # this codebase, cf. batch_write_coverage in batch.py) --
+            # SerialPool.submit only forwards *args, not **kwargs.
+            arg_names = {a.id for a in node.args if isinstance(a, ast.Name)}
+            attr_names = {a.attr for a in node.args if isinstance(a, ast.Attribute)}
+            kw_names = {kw.arg for kw in node.keywords}
+            self.assertIn(
+                "no_overlap",
+                arg_names | attr_names | kw_names,
+                f"_cmd_batch's call to {target_name} must pass "
+                "args.no_overlap through to no_overlap (#999).",
+            )
+            checked += 1
+        self.assertEqual(
+            checked,
+            2,
+            "Expected exactly one batch_make_reference call and one "
+            "pool.submit(batch_run_sample, ...) call in _cmd_batch",
+        )
+
     # -- batch coverage-dedup / self-reference (#48) --
 
     def test_resolve_batch_sample_ids_self_reference_building(self):

--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -2,6 +2,8 @@
 """Tests for preprocessing commands: access, antitarget, autobin, target, coverage."""
 
 import argparse
+import ast
+import inspect
 import logging
 import os
 import shutil
@@ -232,6 +234,194 @@ class PreprocessingTests(unittest.TestCase):
             self.assertEqual(count, n_kept)
         finally:
             shutil.rmtree(tmpdir)
+
+    def _write_overlap_fixture(self, tmpdir):
+        """Build a BAM/BED pair for exercising --no-overlap.
+
+        ``regionA`` (chr1:90-180, width 90) holds one fragment whose mates
+        overlap by 30bp (mate1 [100,150), mate2 [120,170) -- 70bp of unique
+        fragment span but 100bp of naively-summed mate bases), mimicking the
+        short-insert FFPE double-counting from #999.
+
+        ``regionB`` (chr1:300-400, width 100) holds one fragment whose mates
+        do *not* overlap (mate1 [300,350), mate2 [360,410)), so it's a control
+        proving --no-overlap is a no-op when there's nothing to dedupe.
+
+        Empirically cross-checked against samtools 1.24 on this exact
+        geometry: ``samtools bedcov`` and ``samtools depth`` (no ``-s``) both
+        report basecount 100 in regionA (they double-count); ``samtools depth
+        -s`` and ``samtools mpileup`` (overlap-removal default ON) report 70.
+        ``samtools bedcov`` has no ``-s``-equivalent flag at all, hence the
+        by-fragment Python dedup this option implements.
+        """
+        seqlen = 50
+        header = {
+            "HD": {"VN": "1.6", "SO": "coordinate"},
+            "SQ": [{"SN": "chr1", "LN": 1000}],
+        }
+        bam = os.path.join(tmpdir, "overlap.bam")
+
+        def make_read(name, start, flag, mate_start):
+            a = pysam.AlignedSegment()
+            a.query_name = name
+            a.query_sequence = "A" * seqlen
+            a.flag = flag
+            a.reference_id = 0
+            a.reference_start = start
+            a.mapping_quality = 60
+            a.cigarstring = f"{seqlen}M"
+            a.query_qualities = pysam.qualitystring_to_array("I" * seqlen)
+            a.next_reference_id = 0
+            a.next_reference_start = mate_start
+            return a
+
+        with pysam.AlignmentFile(bam, "wb", header=header) as out:
+            # regionA: overlapping mates (paired, proper_pair, read1/read2)
+            out.write(make_read("fragA", 100, 0x63, 120))
+            out.write(make_read("fragA", 120, 0x93, 100))
+            # regionB: non-overlapping mates -- dedup should be a no-op
+            out.write(make_read("fragB", 300, 0x63, 360))
+            out.write(make_read("fragB", 360, 0x93, 300))
+        pysam.index(bam)
+
+        bed = os.path.join(tmpdir, "region.bed")
+        with open(bed, "w") as fh:
+            fh.write("chr1\t90\t180\tregionA\n")
+            fh.write("chr1\t300\t400\tregionB\n")
+        return bam, bed
+
+    def test_coverage_no_overlap_dedupes_mate_overlap(self):
+        """--no-overlap counts a fragment's mate-overlap bases once
+        (``samtools depth -s`` semantics), leaving non-overlapping fragments
+        untouched (#999)."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            bam, _bed = self._write_overlap_fixture(tmpdir)
+            bamfile = pysam.AlignmentFile(bam, "rb")
+            count_off, row_off = coverage.region_depth_count(
+                bamfile, "chr1", 90, 180, "regionA", 0
+            )
+            count_on, row_on = coverage.region_depth_count(
+                bamfile, "chr1", 90, 180, "regionA", 0, no_overlap=True
+            )
+            self.assertEqual(count_off, 2)
+            self.assertEqual(count_on, 2, "read count is unaffected by dedup")
+            self.assertAlmostEqual(row_off[5], 100 / 90, msg="flag off: double-counted")
+            self.assertAlmostEqual(row_on[5], 70 / 90, msg="flag on: deduped")
+
+            # Control region: mates don't overlap, dedup is a no-op.
+            _count_off, ctrl_off = coverage.region_depth_count(
+                bamfile, "chr1", 300, 400, "regionB", 0
+            )
+            _count_on, ctrl_on = coverage.region_depth_count(
+                bamfile, "chr1", 300, 400, "regionB", 0, no_overlap=True
+            )
+            self.assertEqual(ctrl_off[5], ctrl_on[5])
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_coverage_no_overlap_flag_off_is_bit_exact(self):
+        """Omitting --no-overlap must reproduce the untouched bedcov engine's
+        basecount exactly, for both the affected and control regions -- the
+        historical (double-counting) behavior is unchanged by default."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            bam, bed = self._write_overlap_fixture(tmpdir)
+            cna = commands.do_coverage(bed, bam)  # no_overlap defaults to False
+            bedcov_table = coverage.bedcov(bed, bam, 0)
+            bedcov_table["depth"] = bedcov_table["basecount"] / (
+                bedcov_table["end"] - bedcov_table["start"]
+            )
+            for _i, row in bedcov_table.iterrows():
+                match = cna.data[
+                    (cna.data.start == row.start) & (cna.data.end == row.end)
+                ]
+                self.assertEqual(len(match), 1)
+                self.assertAlmostEqual(float(match["depth"].iloc[0]), row["depth"])
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_coverage_no_overlap_end_to_end(self):
+        """--no-overlap, threaded through do_coverage (both the default
+        pileup-equivalent path and --count), fixes the overlap-inflated bin
+        to its true (deduped) depth while leaving the non-overlapping control
+        bin unchanged, for a fixture BAM with a known overlapping mate pair
+        (#999 acceptance criteria)."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            bam, bed = self._write_overlap_fixture(tmpdir)
+            for by_count in (False, True):
+                with self.subTest(by_count=by_count):
+                    cna = commands.do_coverage(
+                        bed, bam, by_count=by_count, no_overlap=True
+                    )
+                    regionA = cna.data[cna.data.start == 90].iloc[0]
+                    regionB = cna.data[cna.data.start == 300].iloc[0]
+                    self.assertAlmostEqual(float(regionA["depth"]), 70 / 90)
+                    self.assertAlmostEqual(float(regionB["depth"]), 90 / 100)
+                    # The artifact bin's depth actually dropped vs. the
+                    # flag-off value; the control bin didn't move.
+                    cna_off = commands.do_coverage(
+                        bed, bam, by_count=by_count, no_overlap=False
+                    )
+                    off_a = float(
+                        cna_off.data[cna_off.data.start == 90]["depth"].iloc[0]
+                    )
+                    off_b = float(
+                        cna_off.data[cna_off.data.start == 300]["depth"].iloc[0]
+                    )
+                    self.assertLess(float(regionA["depth"]), off_a)
+                    self.assertEqual(float(regionB["depth"]), off_b)
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_coverage_no_overlap_ignored_for_bedgraph(self):
+        """--no-overlap has no per-read information to act on for bedGraph
+        input, so it's ignored with a warning, matching --count/--min-mapq/
+        --processes on the same input type."""
+        bed = "formats/my-targets.bed"
+        bedgraph = "formats/na12878-chrM-Y-trunc.bed.gz"
+        with self.assertLogs(level="WARNING") as cm:
+            cna = commands.do_coverage(bed, bedgraph, no_overlap=True)
+        self.assertTrue(any("no-overlap" in m.lower() for m in cm.output))
+        self.assertGreater(len(cna), 0)
+
+    def test_coverage_no_overlap_cli_flag(self):
+        """--no-overlap parses on both `coverage` and `batch`, default off."""
+        args = commands.AP.parse_args(["coverage", "a.bam", "b.bed"])
+        self.assertFalse(args.no_overlap)
+        args = commands.AP.parse_args(["coverage", "a.bam", "b.bed", "--no-overlap"])
+        self.assertTrue(args.no_overlap)
+        args = commands.AP.parse_args(
+            ["batch", "a.bam", "-r", "ref.cnn", "-d", "out", "--no-overlap"]
+        )
+        self.assertTrue(args.no_overlap)
+
+    def test_coverage_no_overlap_propagated_to_do_coverage(self):
+        """AST guard: `_cmd_coverage` must forward `args.no_overlap` into
+        `coverage.do_coverage`, not silently drop it (cf. the bias_smoother
+        propagation guards in test_batch.py)."""
+        src = inspect.getsource(commands._cmd_coverage)
+        tree = ast.parse(src)
+        found = False
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "do_coverage"
+            ):
+                attrs = {
+                    a.attr
+                    for a in (*node.args, *(kw.value for kw in node.keywords))
+                    if isinstance(a, ast.Attribute)
+                }
+                self.assertIn(
+                    "no_overlap",
+                    attrs,
+                    "_cmd_coverage must pass args.no_overlap to do_coverage",
+                )
+                found = True
+        self.assertTrue(found, "Expected a do_coverage() call in _cmd_coverage")
 
     def test_coverage_partial_chrom_mismatch(self):
         """coverage tolerates a BED mixing present and absent contigs,

--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -2,8 +2,6 @@
 """Tests for preprocessing commands: access, antitarget, autobin, target, coverage."""
 
 import argparse
-import ast
-import inspect
 import logging
 import os
 import shutil
@@ -19,7 +17,7 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 import numpy as np
 import pandas as pd
 import pysam
-from conftest import linecount
+from conftest import ast_calls_to, call_arg_names, linecount
 
 import cnvlib
 from cnvlib import (
@@ -245,14 +243,14 @@ class PreprocessingTests(unittest.TestCase):
 
         ``regionB`` (chr1:300-400, width 100) holds one fragment whose mates
         do *not* overlap (mate1 [300,350), mate2 [360,410)), so it's a control
-        proving --no-overlap is a no-op when there's nothing to dedupe.
+        proving --no-overlap is a no-op when no mate bases overlap.
 
         Empirically cross-checked against samtools 1.24 on this exact
         geometry: ``samtools bedcov`` and ``samtools depth`` (no ``-s``) both
-        report basecount 100 in regionA (they double-count); ``samtools depth
-        -s`` and ``samtools mpileup`` (overlap-removal default ON) report 70.
-        ``samtools bedcov`` has no ``-s``-equivalent flag at all, hence the
-        by-fragment Python dedup this option implements.
+        report basecount 100 in regionA (they count the overlap twice);
+        ``samtools depth -s`` and ``samtools mpileup`` (overlap-removal default
+        ON) report 70. ``samtools bedcov`` has no ``-s``-equivalent flag at all,
+        hence the per-template position union this option implements.
         """
         seqlen = 50
         header = {
@@ -279,7 +277,7 @@ class PreprocessingTests(unittest.TestCase):
             # regionA: overlapping mates (paired, proper_pair, read1/read2)
             out.write(make_read("fragA", 100, 0x63, 120))
             out.write(make_read("fragA", 120, 0x93, 100))
-            # regionB: non-overlapping mates -- dedup should be a no-op
+            # regionB: non-overlapping mates -- the union changes nothing
             out.write(make_read("fragB", 300, 0x63, 360))
             out.write(make_read("fragB", 360, 0x93, 300))
         pysam.index(bam)
@@ -290,7 +288,7 @@ class PreprocessingTests(unittest.TestCase):
             fh.write("chr1\t300\t400\tregionB\n")
         return bam, bed
 
-    def test_coverage_no_overlap_dedupes_mate_overlap(self):
+    def test_coverage_no_overlap_counts_mate_overlap_once(self):
         """--no-overlap counts a fragment's mate-overlap bases once
         (``samtools depth -s`` semantics), leaving non-overlapping fragments
         untouched (#999)."""
@@ -305,11 +303,17 @@ class PreprocessingTests(unittest.TestCase):
                 bamfile, "chr1", 90, 180, "regionA", 0, no_overlap=True
             )
             self.assertEqual(count_off, 2)
-            self.assertEqual(count_on, 2, "read count is unaffected by dedup")
-            self.assertAlmostEqual(row_off[5], 100 / 90, msg="flag off: double-counted")
-            self.assertAlmostEqual(row_on[5], 70 / 90, msg="flag on: deduped")
+            self.assertEqual(
+                count_on, 2, "read count is unaffected by overlap unioning"
+            )
+            self.assertAlmostEqual(
+                row_off[5], 100 / 90, msg="flag off: overlap counted twice"
+            )
+            self.assertAlmostEqual(
+                row_on[5], 70 / 90, msg="flag on: overlap counted once"
+            )
 
-            # Control region: mates don't overlap, dedup is a no-op.
+            # Control region: mates don't overlap, so the union changes nothing.
             _count_off, ctrl_off = coverage.region_depth_count(
                 bamfile, "chr1", 300, 400, "regionB", 0
             )
@@ -320,10 +324,11 @@ class PreprocessingTests(unittest.TestCase):
         finally:
             shutil.rmtree(tmpdir)
 
-    def test_coverage_no_overlap_flag_off_is_bit_exact(self):
-        """Omitting --no-overlap must reproduce the untouched bedcov engine's
-        basecount exactly, for both the affected and control regions -- the
-        historical (double-counting) behavior is unchanged by default."""
+    def test_coverage_defaults_to_overlap_unaware_pileup(self):
+        """Omitting --no-overlap must leave the historical (overlap-inflated)
+        behavior in place: the default routes to the pileup engine, whose
+        basecount it reproduces exactly, and the by-count engine still sums both
+        mates over the overlap."""
         tmpdir = tempfile.mkdtemp()
         try:
             bam, bed = self._write_overlap_fixture(tmpdir)
@@ -338,15 +343,63 @@ class PreprocessingTests(unittest.TestCase):
                 ]
                 self.assertEqual(len(match), 1)
                 self.assertAlmostEqual(float(match["depth"].iloc[0]), row["depth"])
+            # The by-count engine, which --no-overlap reroutes through, also
+            # double-counts the overlap by default (100 of 90bp, not 70).
+            cna_count = commands.do_coverage(bed, bam, by_count=True)
+            self.assertAlmostEqual(
+                float(cna_count.data[cna_count.data.start == 90]["depth"].iloc[0]),
+                100 / 90,
+            )
+            self.assertAlmostEqual(
+                float(cna_count.data[cna_count.data.start == 300]["depth"].iloc[0]),
+                90 / 100,
+            )
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_coverage_no_overlap_only_pools_matable_records(self):
+        """Overlap unioning applies only to records that could have a mate in
+        the region. Two *unpaired* records sharing a query name -- e.g. from
+        name-collided merged BAMs -- must still be counted separately, as
+        ``samtools depth -s`` does, rather than silently losing their overlap."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            seqlen = 50
+            header = {
+                "HD": {"VN": "1.6", "SO": "coordinate"},
+                "SQ": [{"SN": "chr1", "LN": 1000}],
+            }
+            bam = os.path.join(tmpdir, "unpaired.bam")
+            with pysam.AlignmentFile(bam, "wb", header=header) as out:
+                for start in (100, 120):
+                    a = pysam.AlignedSegment()
+                    a.query_name = "collided"
+                    a.query_sequence = "A" * seqlen
+                    a.flag = 0  # single-end, mapped, forward
+                    a.reference_id = 0
+                    a.reference_start = start
+                    a.mapping_quality = 60
+                    a.cigarstring = f"{seqlen}M"
+                    a.query_qualities = pysam.qualitystring_to_array("I" * seqlen)
+                    out.write(a)
+            pysam.index(bam)
+            bamfile = pysam.AlignmentFile(bam, "rb")
+            _count, row = coverage.region_depth_count(
+                bamfile, "chr1", 90, 180, "regionA", 0, no_overlap=True
+            )
+            self.assertAlmostEqual(row[5], 100 / 90)
         finally:
             shutil.rmtree(tmpdir)
 
     def test_coverage_no_overlap_end_to_end(self):
         """--no-overlap, threaded through do_coverage (both the default
-        pileup-equivalent path and --count), fixes the overlap-inflated bin
-        to its true (deduped) depth while leaving the non-overlapping control
-        bin unchanged, for a fixture BAM with a known overlapping mate pair
-        (#999 acceptance criteria)."""
+        pileup-equivalent path and --count), fixes the overlap-inflated bin to
+        its true depth while leaving the non-overlapping control bin unchanged,
+        for a fixture BAM with a known overlapping mate pair (#999 acceptance
+        criteria). The flag-off values it is measured against are pinned exactly
+        by ``test_coverage_no_overlap_counts_mate_overlap_once`` (count engine)
+        and ``test_coverage_no_overlap_flag_off_is_bit_exact`` (pileup engine).
+        """
         tmpdir = tempfile.mkdtemp()
         try:
             bam, bed = self._write_overlap_fixture(tmpdir)
@@ -359,19 +412,6 @@ class PreprocessingTests(unittest.TestCase):
                     regionB = cna.data[cna.data.start == 300].iloc[0]
                     self.assertAlmostEqual(float(regionA["depth"]), 70 / 90)
                     self.assertAlmostEqual(float(regionB["depth"]), 90 / 100)
-                    # The artifact bin's depth actually dropped vs. the
-                    # flag-off value; the control bin didn't move.
-                    cna_off = commands.do_coverage(
-                        bed, bam, by_count=by_count, no_overlap=False
-                    )
-                    off_a = float(
-                        cna_off.data[cna_off.data.start == 90]["depth"].iloc[0]
-                    )
-                    off_b = float(
-                        cna_off.data[cna_off.data.start == 300]["depth"].iloc[0]
-                    )
-                    self.assertLess(float(regionA["depth"]), off_a)
-                    self.assertEqual(float(regionB["depth"]), off_b)
         finally:
             shutil.rmtree(tmpdir)
 
@@ -401,27 +441,16 @@ class PreprocessingTests(unittest.TestCase):
         """AST guard: `_cmd_coverage` must forward `args.no_overlap` into
         `coverage.do_coverage`, not silently drop it (cf. the bias_smoother
         propagation guards in test_batch.py)."""
-        src = inspect.getsource(commands._cmd_coverage)
-        tree = ast.parse(src)
-        found = False
-        for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr == "do_coverage"
-            ):
-                attrs = {
-                    a.attr
-                    for a in (*node.args, *(kw.value for kw in node.keywords))
-                    if isinstance(a, ast.Attribute)
-                }
-                self.assertIn(
-                    "no_overlap",
-                    attrs,
-                    "_cmd_coverage must pass args.no_overlap to do_coverage",
-                )
-                found = True
-        self.assertTrue(found, "Expected a do_coverage() call in _cmd_coverage")
+        invocations = ast_calls_to(commands._cmd_coverage, "do_coverage", "coverage")
+        self.assertGreater(
+            len(invocations), 0, "Expected a do_coverage() call in _cmd_coverage"
+        )
+        for inv in invocations:
+            self.assertIn(
+                "no_overlap",
+                call_arg_names(inv),
+                "_cmd_coverage must pass args.no_overlap to do_coverage",
+            )
 
     def test_coverage_partial_chrom_mismatch(self):
         """coverage tolerates a BED mixing present and absent contigs,


### PR DESCRIPTION
Closes #999.

## Problem

`cnvkit.py coverage` counts read bases with no pair awareness, so the two mates of a short fragment double-count the bases in their overlapping region. This inflates apparent depth locally and can produce artifactual focal copy-number calls — a notable contributor to false-positive calls in FFPE and other degraded-DNA samples. Neither depth path handled it: `samtools bedcov` (the default pileup engine) sums pileup bases without clipping mate overlap, and the `--count` engine summed `read.positions` per read independently.

## Change

A new opt-in `--no-overlap` option on `coverage` and `batch` counts each fragment's mate-overlap bases once, matching `samtools depth -s` semantics. Because `samtools bedcov` has no overlap-aware mode, the option routes through the by-read-fetch counting engine, collecting each template's aligned blocks (`read.get_blocks()`) clipped to the bin and merging them before summing. Only records that can have a mate in the region are pooled (paired, mate mapped, mate on the same contig), which is the same precondition htslib applies before entering its overlap hash.

The default path is untouched and remains bit-exact: with the flag omitted, no new code executes on the pileup path and the `--count` counting expression is unchanged.

## Verification

- Flag-off basecounts match both the previous implementation and `samtools depth` on every bin tested (137 bp, 500 bp and 5 kb bins across the test BAM), and the emitted `.cnn` depth values reproduce `samtools bedcov` exactly.
- Flag-on matches `samtools depth -s` on all but one position out of 1.57 Mb; that residual is htslib's `tweak_overlap_quality` dropping a template whose mates disagree at base quality 2.
- On the documented fixture geometry (mate1 [100,150), mate2 [120,170) in a 90 bp bin): `samtools bedcov` and `samtools depth` report 100 bases, while `samtools depth -s`, `samtools mpileup` and this implementation report 70.
- Memory and runtime for the overlap-aware path on a 150 kb bin (CNVkit's default antitarget size) at 30x coverage: 6 MB peak and 0.28 s, versus 235 MB and 2.66 s for a per-position set formulation.
- Full test suite passes (581 tests); ruff, ruff format and mypy are clean; `batch --no-overlap` was smoke-tested end to end through both the reference-build and per-sample paths, with `-p 1` and `-p 2` producing identical `.cnr` output.

## Notes for review

- `--no-overlap` implies the `--count` engine, which carries two further consequences now stated in the help text and `doc/pipeline.rst`: bases spanned by a read's deletion are not counted, and the output column order follows the `--count` path. Automatic bin sizing (`autobin`) still estimates depth from the pileup, so bins come out somewhat smaller than requested when mate overlap is substantial.
- No short option is registered: `-s` denotes `--segment` or `--segments` in six other subcommands, so a boolean `-s` on `coverage` and `batch` would invite misreading.
- `SerialPool.submit` now forwards `**kwargs` so the trailing boolean options reach `batch_run_sample` and `batch_write_coverage` by keyword rather than through a 20+ argument positional hand-off in which `reuse_coverage` and `no_overlap` were adjacent booleans.
- The second commit records the fixes from a three-reviewer pass over the first (memory and pairing preconditions in the counting loop, the removed short option, documentation of the implied engine switch, and extraction of the shared AST call-site walker used by the argument-propagation guards).
