### PR TITLE
Size coverage BED chunks by worker count (#526)

### DIFF
--- a/cnvlib/cli/guess_baits.py
+++ b/cnvlib/cli/guess_baits.py
@@ -179,7 +179,12 @@ def scan_targets(
 ) -> GA:
     """Estimate baited regions from a genome-wide, per-base depth profile."""
     bait_chunks = []
-    # ENH: context manager to call rm on bed chunks? with to_chunks as pool, ck?
+    # Chunk size is deliberately left at the default here rather than derived
+    # from `procs`: _scan_depth applies merge_gaps/drop_small within each chunk,
+    # so chunk boundaries are visible in the output. Deriving them from the
+    # worker count would make the emitted baits depend on -p and on the host's
+    # CPU count. Chunk files are removed below, with to_chunks' atexit
+    # registration as a backstop if this loop raises.
     logging.info("Scanning for enriched regions in:\n  %s", "\n  ".join(sample_bams))
     with parallel.pick_pool(procs) as pool:
         args_iter = (

--- a/cnvlib/coverage.py
+++ b/cnvlib/coverage.py
@@ -20,7 +20,7 @@ from skgenome.chromnames import detect_chr_prefix
 
 from . import core, samutil
 from .cnary import CopyNumArray as CNA
-from .parallel import pick_pool, rm, to_chunks
+from .parallel import effective_procs, pick_pool, rm, to_chunks
 from .params import NULL_LOG2_COVERAGE
 
 if TYPE_CHECKING:
@@ -533,14 +533,18 @@ def interval_coverages_pileup(
     # regions doesn't abort the run -- and so the result is independent of how
     # the BED is split across processes (#620).
     bam_chroms = samutil.get_bam_chroms(bam_fname, fasta)
-    if procs == 1:
+    # Resolve the requested process count once, so the pool and the BED
+    # chunking agree on how many workers there are -- and so a host that can
+    # only give us one worker takes the cheap unchunked path.
+    nprocs = effective_procs(procs)
+    if nprocs == 1:
         table = bedcov(bed_fname, bam_fname, min_mapq, fasta, bam_chroms=bam_chroms)
     else:
         chunks = []
-        with pick_pool(procs) as pool:
+        with pick_pool(nprocs) as pool:
             args_iter = (
                 (bed_chunk, bam_fname, min_mapq, fasta, bam_chroms)
-                for bed_chunk in to_chunks(bed_fname)
+                for bed_chunk in to_chunks(bed_fname, nprocs=nprocs)
             )
             for bed_chunk_fname, table in pool.map(_bedcov, args_iter):
                 if len(table):
@@ -683,18 +687,24 @@ def bedcov(
             f"BED file {bed_fname!r} chromosome names don't match any in "
             f"BAM file {bam_fname!r}"
         )
-    columns = detect_bedcov_columns(raw)  # type: ignore[arg-type]
+    columns = detect_bedcov_columns(raw, has_extra=max_depth is not None)  # type: ignore[arg-type]
     usecols = [c for c in columns if c != "extra"]
     table = pd.read_csv(StringIO(raw), sep="\t", names=columns, usecols=usecols)  # type: ignore[arg-type]
     return table
 
 
-def detect_bedcov_columns(text: str) -> list[str]:
+def detect_bedcov_columns(text: str, has_extra: bool = False) -> list[str]:
     """Determine which 'bedcov' output columns to keep.
 
     bedcov outputs the input BED columns plus an appended numeric column
-    (basecount). With some options (e.g. -d), an additional trailing numeric
-    column may be appended; then basecount is the second-to-last column.
+    (basecount). Passing samtools ``-d`` appends a second numeric column, so
+    basecount is then the second-to-last; the caller knows whether it did that
+    and says so via `has_extra`.
+
+    `has_extra` must not be inferred from the data: a BED whose fifth field is
+    a numeric score is indistinguishable that way from ``-d`` output, and the
+    guess is made per output batch, so under ``--processes`` it could differ
+    between chunks of one BED and silently take depth from the score column.
     """
     firstline = text[: text.index("\n")]
     fields = firstline.split("\t")
@@ -702,15 +712,6 @@ def detect_bedcov_columns(text: str) -> list[str]:
 
     if tabcount < 3:
         raise RuntimeError(f"Bad line from bedcov:\n{firstline!r}")
-
-    def _is_int(s: str) -> bool:
-        try:
-            int(s)
-            return True
-        except ValueError:
-            return False
-
-    has_extra = len(fields) >= 2 and _is_int(fields[-1]) and _is_int(fields[-2])
 
     # BED3
     if tabcount == 3:

--- a/cnvlib/parallel.py
+++ b/cnvlib/parallel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import atexit
 import gzip
+import math
 import os
 import tempfile
 from concurrent import futures
@@ -13,6 +14,12 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from concurrent.futures.process import ProcessPoolExecutor
+
+#: Upper bound on BED lines per parallel chunk, to cap each task's peak memory.
+MAX_CHUNK_SIZE = 5000
+#: Chunks created per worker. More than one chunk per worker lets the pool
+#: balance uneven per-region cost dynamically.
+CHUNKS_PER_PROCESS = 2
 
 
 class SerialPool:
@@ -75,19 +82,29 @@ def available_cpus() -> int:
     return os.cpu_count() or 1
 
 
+def effective_procs(nprocs: int) -> int:
+    """Resolve a requested process count to the number of workers to use.
+
+    `nprocs` <= 0 means "use all available CPUs". The requested count is clamped
+    to the number of usable CPUs, so asking for more workers than cores never
+    oversubscribes.
+    """
+    avail = available_cpus()
+    return avail if nprocs < 1 else min(nprocs, avail)
+
+
 @contextmanager
 def pick_pool(nprocs: int) -> Iterator[SerialPool | ProcessPoolExecutor]:
     """Yield a process pool, or a serial stand-in when parallelism is moot.
 
-    `nprocs` <= 0 means "use all available CPUs". The requested count is clamped
-    to the number of usable CPUs, so asking for more workers than cores never
-    oversubscribes. When the effective count is 1 -- which includes every
-    single-CPU host -- work runs in-process via `SerialPool` instead of forking
-    workers: real multiprocessing offers no speedup there, and on constrained
-    single-CPU build environments forking the pool can deadlock (#1103).
+    `nprocs` is resolved by `effective_procs`: at most 1 means "use all
+    available CPUs", and larger requests are clamped to the usable CPU count.
+    When the effective worker count is 1 -- which includes every single-CPU
+    host -- work runs in-process via `SerialPool` instead of forking workers:
+    real multiprocessing offers no speedup there, and on constrained single-CPU
+    build environments forking the pool can deadlock (#1103).
     """
-    avail = available_cpus()
-    nprocs = avail if nprocs < 1 else min(nprocs, avail)
+    nprocs = effective_procs(nprocs)
     if nprocs <= 1:
         yield SerialPool()
     else:
@@ -101,12 +118,8 @@ def rm(path: str) -> None:
         os.unlink(path)
 
 
-def to_chunks(bed_fname: str, chunk_size: int = 5000) -> Iterator[str]:
-    """Split a BED file into `chunk_size`-line parts for parallelization."""
-    k, chunk = 0, 0
-    fd, name = tempfile.mkstemp(suffix=".bed", prefix=f"tmp.{chunk}.")
-    outfile = os.fdopen(fd, "w")
-    atexit.register(rm, name)
+def _bed_lines(bed_fname: str) -> Iterator[str]:
+    """Yield the content lines of a possibly gzipped BED, skipping comments."""
     opener = gzip.open if bed_fname.endswith(".gz") else open
     with opener(bed_fname) as infile:
         for line in infile:
@@ -114,15 +127,56 @@ def to_chunks(bed_fname: str, chunk_size: int = 5000) -> Iterator[str]:
                 line = line.decode()
             if line[0] == "#":
                 continue
-            k += 1
-            outfile.write(line)
-            if k % chunk_size == 0:
-                outfile.close()
-                yield name
-                chunk += 1
-                fd, name = tempfile.mkstemp(suffix=".bed", prefix=f"tmp.{chunk}.")
-                outfile = os.fdopen(fd, "w")
-    outfile.close()
-    if k % chunk_size:
+            yield line
+
+
+def to_chunks(bed_fname: str, *, nprocs: int = 1) -> Iterator[str]:
+    """Split a BED file into parts for parallel processing.
+
+    Chunk size is derived from the number of workers that will consume the
+    chunks, resolved from `nprocs` by `effective_procs`. Each worker is given
+    `CHUNKS_PER_PROCESS` chunks so the pool can balance uneven per-region cost
+    dynamically, and chunks hold at most `MAX_CHUNK_SIZE` lines. A single worker
+    gets one chunk per `MAX_CHUNK_SIZE` lines, reproducing the fixed-size
+    behavior this replaces: that fixed size serialized any BED smaller than one
+    chunk, so `coverage -p N` ran single-threaded on small (e.g. WGS access)
+    BEDs regardless of N (#526).
+
+    Deriving the size from the worker count makes chunk boundaries a function of
+    `nprocs`, so only callers whose per-chunk processing is independent of those
+    boundaries may pass it (`cnvlib.cli.guess_baits` deliberately does not).
+
+    Yields
+    ------
+    str
+        Path to a temporary BED file holding the next chunk of regions, in the
+        input file's order. Each is registered for removal at interpreter exit;
+        callers should ``rm`` it as soon as the chunk has been processed.
+    """
+    nworkers = effective_procs(nprocs)
+    # A lone worker gains nothing from extra chunks, just extra temp files.
+    nchunks = nworkers * CHUNKS_PER_PROCESS if nworkers > 1 else 1
+    if os.path.isfile(bed_fname):
+        nlines = sum(1 for _ in _bed_lines(bed_fname))
+        chunk_size = min(MAX_CHUNK_SIZE, max(1, math.ceil(nlines / nchunks)))
+    else:
+        # A stream (FIFO, process substitution) can only be read once, so skip
+        # the counting pass rather than hanging on a second open().
+        chunk_size = MAX_CHUNK_SIZE
+    k, chunk = 0, 0
+    name, outfile = "", None
+    for line in _bed_lines(bed_fname):
+        if outfile is None:
+            fd, name = tempfile.mkstemp(suffix=".bed", prefix=f"tmp.{chunk}.")
+            outfile = os.fdopen(fd, "w")
+            atexit.register(rm, name)
+        k += 1
+        outfile.write(line)
+        if k % chunk_size == 0:
+            outfile.close()
+            outfile = None
+            chunk += 1
+            yield name
+    if outfile is not None:
         outfile.close()
         yield name

--- a/test/test_parallel.py
+++ b/test/test_parallel.py
@@ -1,5 +1,9 @@
 """Unit tests for the parallel module."""
 
+import glob
+import gzip
+import os
+import tempfile
 import unittest
 from concurrent import futures
 from unittest import mock
@@ -146,3 +150,115 @@ class ParallelTests(unittest.TestCase):
             with parallel.pick_pool(64) as pool:
                 self.assertIsInstance(pool, futures.ProcessPoolExecutor)
                 self.assertEqual(pool._max_workers, 4)
+
+
+class ToChunksTests(unittest.TestCase):
+    """Tests for splitting a BED file into per-worker chunks."""
+
+    def _write_bed(self, nlines, *, comments=0, gzipped=False):
+        """Write a BED of `nlines` regions, optionally gzipped, and return it."""
+        lines = [f"#comment {i}\n" for i in range(comments)]
+        lines += [f"chr1\t{i * 100}\t{i * 100 + 50}\tbin{i}\n" for i in range(nlines)]
+        suffix = ".bed.gz" if gzipped else ".bed"
+        fd, fname = tempfile.mkstemp(suffix=suffix)
+        os.close(fd)
+        self.addCleanup(parallel.rm, fname)
+        opener = gzip.open if gzipped else open
+        with opener(fname, "wt") as fh:
+            fh.writelines(lines)
+        return fname, lines[comments:]
+
+    @staticmethod
+    def _read_chunks(chunk_fnames):
+        """Read back the lines of each chunk file, in chunk order."""
+        chunks = []
+        for fname in chunk_fnames:
+            with open(fname) as fh:
+                chunks.append(fh.readlines())
+            parallel.rm(fname)
+        return chunks
+
+    def test_to_chunks_fills_every_worker(self):
+        """A BED smaller than the maximum chunk size must still be split across
+        the available workers; a fixed chunk size made `coverage -p N` run
+        single-threaded on small (e.g. WGS access) BEDs regardless of N (#526).
+        """
+        bed, lines = self._write_bed(440)
+        with mock.patch.object(parallel, "available_cpus", return_value=16):
+            chunks = self._read_chunks(parallel.to_chunks(bed, nprocs=16))
+        self.assertEqual(
+            len(chunks),
+            16 * parallel.CHUNKS_PER_PROCESS,
+            "a 440-region BED under 16 workers must be split CHUNKS_PER_PROCESS "
+            "ways per worker, not into a single serialized chunk",
+        )
+        self.assertEqual(
+            [line for chunk in chunks for line in chunk],
+            lines,
+            "chunking must preserve every region, in the BED's original order",
+        )
+        self.assertTrue(all(chunks), "no chunk may be empty")
+
+    def test_to_chunks_serial_yields_one_chunk(self):
+        """With one worker, a BED below the size cap stays a single chunk."""
+        bed, lines = self._write_bed(12)
+        chunks = self._read_chunks(parallel.to_chunks(bed))
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0], lines)
+
+    def test_to_chunks_respects_max_chunk_size(self):
+        """The per-worker size is capped, so a large BED under few workers is
+        still split into bounded chunks rather than one huge task."""
+        bed, lines = self._write_bed(10)
+        with mock.patch.object(parallel, "MAX_CHUNK_SIZE", 3):
+            chunks = self._read_chunks(parallel.to_chunks(bed))
+        self.assertEqual([len(chunk) for chunk in chunks], [3, 3, 3, 1])
+        self.assertEqual([line for chunk in chunks for line in chunk], lines)
+
+    def test_to_chunks_exact_multiple_yields_no_empty_chunk(self):
+        """When the line count divides evenly by the chunk size, the last chunk
+        is not an empty file -- and no unyielded temp file is left behind."""
+        bed, lines = self._write_bed(9)
+        before = set(glob.glob(os.path.join(tempfile.gettempdir(), "tmp.*.bed")))
+        with mock.patch.object(parallel, "MAX_CHUNK_SIZE", 3):
+            chunks = self._read_chunks(parallel.to_chunks(bed))
+        after = set(glob.glob(os.path.join(tempfile.gettempdir(), "tmp.*.bed")))
+        self.assertEqual([len(chunk) for chunk in chunks], [3, 3, 3])
+        self.assertEqual([line for chunk in chunks for line in chunk], lines)
+        self.assertEqual(after - before, set(), "left an unyielded chunk file")
+
+    def test_to_chunks_empty_bed_yields_nothing(self):
+        """A BED with no regions yields no chunks and creates no temp file, so
+        callers see an empty iteration rather than an empty chunk."""
+        bed, _lines = self._write_bed(0, comments=2)
+        before = set(glob.glob(os.path.join(tempfile.gettempdir(), "tmp.*.bed")))
+        with mock.patch.object(parallel, "available_cpus", return_value=4):
+            chunks = self._read_chunks(parallel.to_chunks(bed, nprocs=4))
+        after = set(glob.glob(os.path.join(tempfile.gettempdir(), "tmp.*.bed")))
+        self.assertEqual(chunks, [])
+        self.assertEqual(after - before, set())
+
+    def test_to_chunks_gzipped_input_and_comments(self):
+        """Comment lines are dropped and don't count toward chunk sizing, for
+        gzipped input as well as plain text."""
+        for gzipped in (False, True):
+            with self.subTest(gzipped=gzipped):
+                bed, lines = self._write_bed(8, comments=3, gzipped=gzipped)
+                with mock.patch.object(parallel, "available_cpus", return_value=4):
+                    chunks = self._read_chunks(parallel.to_chunks(bed, nprocs=4))
+                flat = [line for chunk in chunks for line in chunk]
+                self.assertEqual(flat, lines)
+                self.assertFalse(any(line.startswith("#") for line in flat))
+                self.assertEqual([len(chunk) for chunk in chunks], [1] * 8)
+
+    def test_to_chunks_rejects_positional_worker_count(self):
+        """`nprocs` is keyword-only: the parameter used to be a line count, so a
+        stale positional call must fail loudly rather than request 5000 workers.
+        """
+        bed, _lines = self._write_bed(4)
+        with self.assertRaises(TypeError):
+            list(parallel.to_chunks(bed, 5000))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -8,6 +8,7 @@ import shutil
 import tempfile
 import unittest
 import warnings
+from unittest import mock
 
 import pytest
 
@@ -187,6 +188,43 @@ class PreprocessingTests(unittest.TestCase):
                 bed, bam, 0, bam_chroms=bam_chroms, allow_empty=True
             )
             self.assertEqual(len(empty), 0)
+        finally:
+            os.unlink(bed)
+
+    def test_bedcov_depth_independent_of_process_count(self):
+        """Emitted depth must not depend on how the BED is split across workers.
+
+        A BED5 whose score field is numeric on some rows and '.' on others used
+        to make the column layout ambiguous: it was guessed per output batch
+        from whether the last two fields both looked like integers, so a numeric
+        score was mistaken for samtools' -d column and depth was computed from
+        the score instead of the basecount. Which rows started a batch depended
+        on the chunk count, hence on --processes and the host's CPU count.
+        """
+        bam = "formats/na12878-chrM-Y-trunc.bam"
+        samutil.ensure_bam_index(bam)
+        with tempfile.NamedTemporaryFile("w+t", suffix=".bed", delete=False) as f:
+            for i in range(40):
+                # Legal BED5 either way: '.' and an integer are both valid scores
+                score = "." if i < 24 else str(100 + i)
+                f.write(f"chrM\t{i * 400}\t{(i + 1) * 400}\tbin{i}\t{score}\n")
+            bed = f.name
+        try:
+            serial = coverage.interval_coverages_pileup(bed, bam, 0, procs=1)
+            with mock.patch.object(parallel, "available_cpus", return_value=8):
+                parallelized = coverage.interval_coverages_pileup(bed, bam, 0, procs=8)
+            self.assertEqual(len(serial), 40)
+            self.assertEqual(list(serial.start), list(parallelized.start))
+            self.assertEqual(
+                list(serial.depth),
+                list(parallelized.depth),
+                "depth must be identical however the BED is chunked",
+            )
+            # Depth comes from the appended basecount, never from the score.
+            self.assertTrue(
+                (serial.depth > 1).all(),
+                "a numeric BED score must not be mistaken for the basecount",
+            )
         finally:
             os.unlink(bed)
 


### PR DESCRIPTION
Fixes #526.

## Problem

`cnvkit.py coverage -p N` ran single-threaded on any BED smaller than `to_chunks`' fixed 5000-line chunk size, because the whole file then became a single chunk. The reporter observed this with a WGS access BED of a few hundred regions under `-p 16`: one `Processing reads` pass, one thread, regardless of N.

## Change

Chunk size is derived from the effective worker count. Each worker receives `CHUNKS_PER_PROCESS` chunks so the pool can balance uneven per-region cost dynamically, subject to the existing `MAX_CHUNK_SIZE` cap — which means behaviour is unchanged for BEDs large enough to have been chunked before, and a single worker still yields one chunk per cap's worth of lines, reducing the serial case exactly to the previous behaviour.

`effective_procs` factors out the "at most 0 means all CPUs, clamp to the usable CPU count" resolution that `pick_pool` performed inline, and `interval_coverages_pileup` resolves the count once, so the pool and the chunking cannot disagree and a host that can supply only one worker takes the cheap unchunked path instead of copying the whole BED into a temporary file for a single serial task.

Verified on the test BAM: a 40-region BED under `-p 8` now yields 14 chunks instead of 1, with depth values identical to `-p 1`.

## Two latent defects this exposed

Deriving chunk boundaries from the worker count makes them observable wherever per-chunk processing is not boundary-independent. Both cases are fixed here rather than shipped:

1. **`bedcov` column layout was inferred from the data, per output batch.** `detect_bedcov_columns` decided whether samtools had appended a second numeric column by testing whether the last two fields both parsed as integers — which cannot distinguish a numeric BED5 score from the `-d` column. Depth was then computed from the score. Because the guess was made per batch, emitted `.cnn` values depended on `--processes` and on the host's CPU count: on a 40-bin BED5 whose score is `.` for some rows and numeric for others, 16 of 40 depths differed between `-p 1` and `-p 8` (e.g. 143.34 versus 0.31), and a BED alternating the two forms raised `TypeError` under `-p N` while succeeding under `-p 1`. The extra column exists exactly when we pass `-d`, so the caller now states that and the layout no longer depends on the data. This also corrects `-p 1` on BED5 input, where a numeric score was previously reported as the basecount. Covered by a new regression test that asserts `-p 1` and `-p 8` agree; it fails against the previous implementation.

2. **`guess_baits` post-processing is chunk-local.** `_scan_depth` applies `merge_gaps` and `drop_small` inside each chunk and `scan_targets` only concatenates the results, so bait regions straddling a boundary are never rejoined. With derived boundaries, `scan_targets` on a contiguous access BED emitted 2 baits at `-p 1` and 15 at `-p 8`. That call site therefore keeps the fixed chunk size and stays deterministic; parallelising it requires making the post-processing boundary-independent first, which is tracked separately.

## Smaller fixes in the same area

- Chunk files are created lazily, so an exactly-divisible line count no longer leaves an unyielded empty temp file behind (previously the common case, since the size is now derived from the line count), and every chunk — not only the first — is registered for removal at interpreter exit.
- A non-regular-file BED (FIFO, process substitution) skips the counting pass instead of hanging forever on a second `open()`.
- `nprocs` is keyword-only, because the positional parameter it replaces was a line count: a stale `to_chunks(bed, 5000)` now raises `TypeError` rather than silently requesting 5000 workers.

## Verification

Full test suite passes (575 tests); ruff, ruff format and mypy are clean. New tests cover the worker-count fan-out, the serial and cap-bound regimes, exact-multiple and empty inputs, gzipped input with comments, the keyword-only signature, and the `-p`-invariance of emitted depth.

## Scope

Parts 1 and 2 of the originating triage (silent CBS failure under multiprocessing; `export vcf` crashing on a bintest `.cns`) were already fixed on master and are verified as such — a failing `Rscript` under `-p 2` now raises a `RuntimeError` naming the subprocess. Verifying part 2 surfaced a separate defect in `export vcf`, filed independently: with the `probes` column absent, `segments2vcf` now silently emits zero records.
