### PR TITLE
Export segments with no probe count to VCF

### DIFF
--- a/cnvlib/export.py
+++ b/cnvlib/export.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from collections import OrderedDict as OD
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -312,6 +312,13 @@ def export_vcf(
         segments, ploidy, is_haploid_x_reference, diploid_parx_genome, is_sample_female
     )
     table = pd.DataFrame.from_records(vcf_rows, columns=vcf_columns)
+    if table.empty and len(segments):
+        logging.info(
+            "No VCF records emitted from %d input segments; the VCF will have a "
+            "header only. Only segments differing from the copy number expected "
+            "for this sample's sex and ploidy are exported.",
+            len(segments),
+        )
     vcf_body = table.to_csv(sep="\t", header=True, index=False, float_format="%.3g")
     return VCF_HEADER, vcf_body
 
@@ -413,13 +420,18 @@ def segments2vcf(
     else:
         has_ci = False
 
+    n_bad_probes = 0
     # Reformat this data to create INFO and genotype
     # TODO be more clever about this
     for out_row, abs_exp in zip(
         out_dframe.itertuples(index=False), abs_expect, strict=True
     ):
-        # Survive files from buggy v0.7.1 (#53)
-        if not str(out_row.probes).isdigit():
+        probes_str = _vcf_probes_str(out_row.probes)
+        if probes_str is None:
+            # Present but not a usable count: a segment file from the buggy
+            # v0.7.1 release (#53). Skip the segment, but say so afterward
+            # rather than silently emitting a header-only VCF.
+            n_bad_probes += 1
             continue
 
         cn_changed = out_row.ncopies != abs_exp
@@ -452,7 +464,7 @@ def segments2vcf(
         elif cn_changed and out_row.ncopies < abs_exp:
             # TODO XXX handle non-diploid ploidies, haploid chroms
             gt = "1/1" if out_row.ncopies == 0 else "0/1"
-            gq = str(out_row.probes)
+            gq = probes_str
         else:
             # Copy-neutral LOH: same diploid genotype call, allele identity
             # encoded by CN1/CN2.
@@ -462,9 +474,7 @@ def segments2vcf(
         if has_allele_specific:
             cn1_str = "." if pd.isna(out_row.cn1) else str(int(out_row.cn1))
             cn2_str = "." if pd.isna(out_row.cn2) else str(int(out_row.cn2))
-            genotype = (
-                f"{gt}:{gq}:{out_row.ncopies}:{cn1_str}:{cn2_str}:{out_row.probes}"
-            )
+            genotype = f"{gt}:{gq}:{out_row.ncopies}:{cn1_str}:{cn2_str}:{probes_str}"
             fmt_str = "GT:GQ:CN:CN1:CN2:CNQ"
         elif svtype == "DEL":
             # Preserve legacy GT:GQ-only shape for losses when no
@@ -472,7 +482,7 @@ def segments2vcf(
             genotype = f"{gt}:{gq}"
             fmt_str = "GT:GQ"
         else:
-            genotype = f"{gt}:{gq}:{out_row.ncopies}:{out_row.probes}"
+            genotype = f"{gt}:{gq}:{out_row.ncopies}:{probes_str}"
             fmt_str = "GT:GQ:CN:CNQ"
 
         fields = [
@@ -482,7 +492,7 @@ def segments2vcf(
             f"SVLEN={svlen_out}",
             f"FOLD_CHANGE={2.0**out_row.log2}",
             f"FOLD_CHANGE_LOG={out_row.log2}",
-            f"PROBES={out_row.probes}",
+            f"PROBES={probes_str}",
         ]
         if has_baf and not pd.isna(out_row.baf):
             fields.append(f"BAF={out_row.baf:.4g}")
@@ -511,6 +521,37 @@ def segments2vcf(
             fmt_str,
             genotype,
         )
+
+    if n_bad_probes:
+        logging.warning(
+            "Skipped %d of %d segments carrying an unparseable probe count; "
+            "was this segment file written by CNVkit v0.7.1?",
+            n_bad_probes,
+            len(segments),
+        )
+
+
+def _vcf_probes_str(probes: Any) -> str | None:
+    """Format a segment's probe count for VCF, or None to skip the segment.
+
+    An absent count -- a .cns written without a ``probes`` column, or with the
+    field left blank -- yields ".", the VCF missing value: missing support
+    information is not a reason to drop the segment from the export. A count
+    that is present but is not a whole number in the range of a VCF ``Integer``
+    yields None, skipping the segment, as such values indicate a segment file
+    written by the buggy v0.7.1 release (#53).
+    """
+    if pd.isna(probes):
+        return "."
+    try:
+        count = float(probes)
+    except (TypeError, ValueError):
+        return None
+    # A blank field in any row makes the whole column float-typed, so an intact
+    # count can arrive here as 6.0 rather than 6.
+    if not count.is_integer() or not 0 <= count < 2**31:
+        return None
+    return str(int(count))
 
 
 # _____________________________________________________________________________

--- a/doc/fileformats.rst
+++ b/doc/fileformats.rst
@@ -28,13 +28,13 @@ GATK and Picard interval list coordinates are 1-indexed, like R or Matlab code.
 In the same example, the first nucleotide of a 1000-basepair sequence has
 position 1, the last nucleotide has position 1000, and the entire region is
 indicated by the range 1-1000. These files usually have the extension
-`.interval_list`.
+``.interval_list``.
 
 In GATK4, the term "interval list" also refers to samtools-style genomic
 coordinate specifications of the form *chromosome:start-end*, e.g.
-`chr1:1-1000`. As with Picard and older GATK style interval lists, the
+``chr1:1-1000``. As with Picard and older GATK style interval lists, the
 coordinates are 1-indexed. When used with GATK4, these files usually have the
-extension `.list` or `.interval`.
+extension ``.list`` or ``.interval``.
 
 CNVkit will load these files by automatically determining the specific format
 based on the file contents, not the filename extension.
@@ -219,7 +219,8 @@ Segmented log2 ratios (.cns)
 In addition to the ``chromosome``, ``start``, ``end``, ``gene``, ``log2``,
 ``depth`` and ``weight`` columns present in .cnr files, the .cns file format has
 the additional column ``probes``, indicating the number of bins covered by the
-segment.
+segment. CNVkit always writes this column, but treats it as optional on input,
+so segment files from other tools can be loaded without it.
 
 The **gene** column concatenates the gene names of all the bins that the segment
 covers. The **weight** column sums the bin-level weights, and the **depth** and

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -163,6 +163,15 @@ to construct the :ref:`reference`, use it here, too.
 
     cnvkit.py export vcf Sample.cns -y -x female -i "SampleID" -o Sample.cnv.vcf
 
+The ``probes`` column of the input segments, if present, is reported as the
+``PROBES`` INFO field, the ``CNQ`` FORMAT field, and -- for deletions -- the
+genotype quality ``GQ``. The column is optional: segment files produced by
+other tools, or post-processed after ``cnvkit.py segment``, may omit it, in
+which case those three fields report the VCF missing value ``.`` and the
+segments themselves are still exported. A probe count that is present but is
+not a whole number indicates a segment file written by the buggy v0.7.1
+release; those segments are skipped, and the number skipped is logged.
+
 Allele-specific copy number and LOH evidence
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -345,6 +345,165 @@ class ExportTests(unittest.TestCase):
             info = dict(kv.split("=", 1) for kv in fields[7].split(";") if "=" in kv)
             self.assertIn(info["SVTYPE"], {"DUP", "DEL"})
 
+    def test_export_vcf_missing_probes_column(self):
+        """A .cns without a ``probes`` column still yields records, with ``PROBES=.``
+
+        ``segments2vcf`` reindexes the segment table onto a fixed column list, so
+        a segment file lacking ``probes`` gets NaN there rather than raising. The
+        #53 guard against unparseable probe counts then skipped every segment,
+        turning a missing optional column into a silent, header-only VCF. A
+        missing support count must not suppress the record: PROBES, CNQ and the
+        deletion genotype's GQ report the VCF missing value instead.
+        """
+        cns = cnvlib.read("formats/amplicon.cns")
+        # Sex context used for this fixture elsewhere in this class: a male
+        # sample against a haploid-X reference.
+        args = (2, True, None, False)
+        with_probes = self._vcf_records(cns, args)
+        without = self._vcf_records(
+            cns.as_dataframe(cns.data.drop(columns=["probes"])), args
+        )
+        self.assertTrue(with_probes)
+        # The same segments are emitted, and everything up to INFO is identical.
+        self.assertEqual(len(without), len(with_probes))
+        self.assertEqual([f[:7] for f in without], [f[:7] for f in with_probes])
+        self.assertTrue([f for f in without if f[4] == "<DEL>"])  # GQ check below
+        for fields in without:
+            where = f"{fields[0]}:{fields[1]}"
+            info = dict(kv.split("=", 1) for kv in fields[7].split(";") if "=" in kv)
+            self.assertEqual(info["PROBES"], ".", where)
+            fmt = fields[8].split(":")
+            vals = fields[9].split(":")
+            if "CNQ" in fmt:
+                self.assertEqual(vals[fmt.index("CNQ")], ".", where)
+            if info["SVTYPE"] == "DEL":
+                # GQ carries the probe count for losses (legacy GT:GQ shape).
+                self.assertEqual(vals[fmt.index("GQ")], ".", where)
+
+    def test_export_vcf_blank_probes_field(self):
+        """A blank ``probes`` field drops only that segment's count, not the file.
+
+        One missing value makes the whole column float-typed, so an intact count
+        arrives at the exporter as 6.0 rather than 6; the #53 guard rejected
+        every such value and emptied the VCF. Intact counts must still render as
+        integers, and only the blank one as the VCF missing value.
+        """
+        rows = [
+            ("chr1", 0, 1000, "-", -1.0, 6.0),  # loss, probe count intact
+            ("chr1", 1000, 2000, "-", 0.58, np.nan),  # gain, probe count blank
+        ]
+        cns = cnary.CopyNumArray(
+            pd.DataFrame(
+                rows,
+                columns=["chromosome", "start", "end", "gene", "log2", "probes"],
+            ),
+            {"sample_id": "T1"},
+        )
+        records = self._vcf_records(cns, (2, False, None, True))
+        self.assertEqual([f[4] for f in records], ["<DEL>", "<DUP>"])
+        self.assertEqual(self._probes_info(records), ["6", "."])
+        # The loss reports its count as GQ; the gain reports missing CNQ.
+        self.assertEqual(records[0][9].split(":"), ["0/1", "6"])
+        self.assertEqual(records[1][9].split(":")[-1], ".")
+
+    def test_export_vcf_missing_probes_allele_specific(self):
+        """CNQ is the VCF missing value in allele-specific records, too.
+
+        The allele-specific ``GT:GQ:CN:CN1:CN2:CNQ`` genotype reports the probe
+        count in its own field, which must not fall back to the NaN text when
+        the segments carry no ``probes`` column.
+        """
+        rows = [
+            # copy-loss LOH and a copy-neutral LOH segment, no probes column
+            ("chr1", 0, 1000, "-", -1.0, 1, 1, 0, 1.00, 20),
+            ("chr1", 1000, 2000, "-", 0.0, 2, 2, 0, 1.00, 30),
+        ]
+        cns = cnary.CopyNumArray(
+            pd.DataFrame(
+                rows,
+                columns=[
+                    "chromosome",
+                    "start",
+                    "end",
+                    "gene",
+                    "log2",
+                    "cn",
+                    "cn1",
+                    "cn2",
+                    "baf",
+                    "nbaf",
+                ],
+            ),
+            {"sample_id": "T1"},
+        )
+        records = self._vcf_records(cns, (2, False, None, True))
+        self.assertEqual(len(records), 2)
+        self.assertEqual(self._probes_info(records), [".", "."])
+        for fields in records:
+            fmt = fields[8].split(":")
+            self.assertEqual(fmt[-1], "CNQ")
+            self.assertEqual(fields[9].split(":")[-1], ".")
+
+    def test_export_vcf_nonnumeric_probes_skipped_loudly(self):
+        """Present-but-unparseable probe counts are still skipped, with a warning.
+
+        Segment files written by the buggy v0.7.1 release carry unparseable
+        probe counts (#53); those segments remain excluded. Unlike before, the
+        exporter reports the dropped segments instead of quietly writing a
+        header-only VCF.
+        """
+        cns = cnvlib.read("formats/amplicon.cns")
+        garbled = cns.as_dataframe(cns.data.assign(probes="foo"))
+        with self.assertLogs(level="WARNING") as cm:
+            self.assertEqual(
+                list(export.segments2vcf(garbled, 2, True, None, False)), []
+            )
+        self.assertTrue(any("unparseable probe count" in m for m in cm.output))
+        with self.assertLogs(level="WARNING"):
+            _vheader, vcf_body = export.export_vcf(garbled, 2, True, None, False)
+        # Header row of the table only -- no variant records.
+        self.assertEqual(len(vcf_body.splitlines()), 1)
+
+    def test_export_vcf_copy_neutral_sample_is_not_a_warning(self):
+        """A flat sample emitting no records is reported, but not as a warning.
+
+        Every segment matching the expected copy number is the correct outcome
+        for a copy-neutral sample, so it must not be conflated with the
+        unparseable-probe-count pathology above.
+        """
+        rows = [
+            ("chr1", 0, 1000, "-", 0.0, 50),
+            ("chr1", 1000, 2000, "-", 0.01, 60),
+        ]
+        cns = cnary.CopyNumArray(
+            pd.DataFrame(
+                rows,
+                columns=["chromosome", "start", "end", "gene", "log2", "probes"],
+            ),
+            {"sample_id": "T1"},
+        )
+        with self.assertLogs(level="INFO") as cm:
+            _vheader, vcf_body = export.export_vcf(cns, 2, False, None, True)
+        self.assertEqual(len(vcf_body.splitlines()), 1)
+        self.assertTrue(any("No VCF records" in m for m in cm.output))
+        self.assertEqual({r.levelname for r in cm.records}, {"INFO"})
+
+    @staticmethod
+    def _vcf_records(segments, args):
+        """Emitted VCF records of `segments`, each split into its 10 fields."""
+        _vheader, vcf_body = export.export_vcf(segments, *args)
+        return [
+            ln.split("\t") for ln in vcf_body.splitlines() if not ln.startswith("#")
+        ]
+
+    @staticmethod
+    def _probes_info(records):
+        """The PROBES INFO value of each split VCF record."""
+        return [
+            dict(kv.split("=", 1) for kv in fields[7].split(";") if "=" in kv)["PROBES"]
+            for fields in records
+        ]
+
     def test_export_cdt_jtv(self):
         """The 'export' command for CDT and Java TreeView formats."""
         fnames = ["formats/p2-20_1.cnr", "formats/p2-20_2.cnr"]


### PR DESCRIPTION
Fixes #1142.

### Problem

`segments2vcf` reindexes the segment table onto a fixed column list, so a `.cns`
without a `probes` column yields NaN there rather than raising a `KeyError`. The
guard that lets CNVkit survive segment files written by the buggy v0.7.1 release
(#53),

```python
if not str(out_row.probes).isdigit():
    continue
```

then skips every segment, because `str(nan) == "nan"` is not a digit string:
`cnvkit.py export vcf` wrote a header-only VCF with no warning and exit status 0.
On `test/formats/amplicon.cns` (88 segments), the unmodified file exports 69
records and the same file without the `probes` column exported 0.

The same guard also discarded every segment of a `.cns` whose `probes` field is
blank in any row, since one blank value makes the whole column float-typed and
`str(6.0).isdigit()` is likewise `False`. Because `probes` is optional in
practice — segment files from other tools, or post-processed after
`cnvkit.py segment`, may omit it — this turned an optional column into silent,
complete data loss, which is a particular concern where an empty VCF may be read
as a negative result.

### Change

An absent probe count is now separated from one that is present but unusable.
`_vcf_probes_str` formats the count for VCF, returning `"."` (the missing value)
when it is absent and `None` when the segment must be skipped, and the emission
loop substitutes the result at all four sites that report the count: the deletion
genotype's `GQ`, the allele-specific and default `CNQ` fields, and the `PROBES`
INFO field. Values that are present but are not a whole number within the range
of a VCF `Integer` are still skipped, preserving the #53 behaviour, and counts in
a float-typed column render as integers rather than being discarded.

An export that emits nothing is now explained rather than silent, with the log
level chosen by cause:

- `segments2vcf` warns once, reporting how many segments carried an unparseable
  probe count.
- `export_vcf` reports an empty result at INFO. A sample whose every segment
  matches the expected copy number legitimately exports no records — `f-on-f.cns`
  and `m-on-m.cns` do so at ploidy 2 with `-y` — so a warning there would be a
  false quality signal for pipelines that treat `stderr` warnings as QC output.

### Verification

- `amplicon.cns` without a `probes` column now exports 69 records with
  `PROBES=.`, `CNQ=.` and, for deletions, `GQ=.` (previously 0 records).
- The same file with three blank `probes` fields exports 69 records, three with
  `PROBES=.` and the rest with integer counts.
- Output is byte-identical to the previous behaviour for all nine `.cns`
  fixtures, which carry `int64` probe counts.
- htslib (via pysam) parses the emitted VCF and resolves `PROBES=.` and `GQ=.` as
  missing values.
- Five tests added in `test/test_export.py`: missing column, blank field,
  allele-specific `CNQ`, the #53 skip with its warning, and a copy-neutral sample
  reported at INFO with no warning. Full suite passes (590 tests); `mypy` and
  `ruff` are clean.

Documentation: the `export vcf` section of `doc/importexport.rst` now describes
how the probe count is reported and when segments are skipped, and the `.cns`
description in `doc/fileformats.rst` notes that `probes` is optional on input.
Three pre-existing single-backtick literals in `doc/fileformats.rst` were
converted to double backticks, as the `rst-backticks` pre-commit hook checks the
whole file.
