### PR TITLE
Merge overlapping and duplicate baits in 'target' (#567)

### DIFF
--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -638,7 +638,9 @@ P_target.add_argument(
 P_target.add_argument(
     "--split",
     action="store_true",
-    help="Split large tiled intervals into smaller, consecutive targets.",
+    help="""Split large tiled intervals into smaller, consecutive targets.
+            Contiguous intervals are joined first, then divided evenly, so
+            existing bin boundaries are not preserved.""",
 )
 # Exons: [114--188==203==292--21750], mean=353 -> outlier=359, extreme=515
 #   NV2:  [65--181==190==239--12630], mean=264 -> outlier=277, extreme=364

--- a/cnvlib/fix.py
+++ b/cnvlib/fix.py
@@ -333,8 +333,12 @@ def match_ref_to_sample(
         if dupes.any():
             raise ValueError(
                 (
-                    "Duplicated genomic coordinates in {} set. Total duplicated regions: {}, starting with:\n"
-                    "{}."
+                    "Duplicated genomic coordinates in {} set. Total duplicated "
+                    "regions: {}, starting with:\n{}.\nThese usually come from "
+                    "duplicate or overlapping rows in the bait BED. Rebuild the "
+                    "targets with 'cnvkit.py target', which merges overlapping "
+                    "baits into disjoint bins, then redo 'coverage' and "
+                    "'reference' with the rebuilt BED."
                 ).format(
                     name,
                     len(dset.index[dupes]),

--- a/cnvlib/target.py
+++ b/cnvlib/target.py
@@ -37,7 +37,9 @@ def do_target(
         Reduce multi-accession bait labels to be short and consistent.
         Default is False.
     do_split : bool, optional
-        Split large target intervals into smaller pieces. Default is False.
+        Normalize target sizes: join contiguous intervals and divide them into
+        pieces of about `avg_size`. Bin boundaries already present in the bait
+        file are not preserved. Default is False.
     avg_size : float, optional
         Average target size when splitting large intervals.
         Default is 200/0.75 (~267 bp).
@@ -45,14 +47,40 @@ def do_target(
     Returns
     -------
     GenomicArray
-        Processed target intervals ready for CNVkit analysis.
+        Processed target intervals ready for CNVkit analysis: zero-width bait
+        intervals have been dropped and overlapping ones merged, so the targets
+        are disjoint and each genomic position falls in at most one bin.
+        Without `do_split`, bait intervals that merely abut are kept apart.
     """
     tgt_arr = bait_arr.copy()
     # Drop zero-width regions
     tgt_arr = tgt_arr[tgt_arr.start != tgt_arr.end]
+    unmerged_baits = tgt_arr  # kept for re-labeling the split bins below
+    # Merge duplicate and overlapping baits, joining their gene labels, so that
+    # each position is covered by one target. Left in place, duplicated
+    # coordinates reach `fix` as "Duplicated genomic coordinates" (#567), and
+    # overlapping baits count the shared reads twice. Bookended baits (the
+    # consecutive tiles of a capture kit) are kept separate, so a target BED
+    # without overlaps is passed through unchanged. `subdivide` would merge
+    # these anyway, but doing it here holds the postcondition on both paths.
+    n_baits = len(tgt_arr)
+    tgt_arr = tgt_arr.merge(bp=1)
+    if len(tgt_arr) < n_baits:
+        logging.info(
+            "Merged overlapping or duplicated baits: %d intervals -> %d targets",
+            n_baits,
+            len(tgt_arr),
+        )
     if do_split:
         logging.info("Splitting large targets")
         tgt_arr = tgt_arr.subdivide(avg_size, 0)
+        if not annotate:
+            # Unless an annotation is about to replace every label: `subdivide`
+            # re-merges bookended regions before splitting them evenly, so the
+            # joined label of a whole contiguous run would otherwise be stamped
+            # on every bin the run is cut into. Take each bin's label from the
+            # baits it actually covers instead.
+            tgt_arr["gene"] = unmerged_baits.into_ranges(tgt_arr, "gene", "-")
     if annotate:
         logging.info("Applying annotations as target names")
         annotation = tabio.read_auto(annotate)

--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -112,12 +112,37 @@ Prepare a BED file of baited regions for use with CNVkit.
     cnvkit.py target my_baits.bed --annotate data/refFlat_hg38.txt --split -o my_targets.bed
 
 The BED file should be the baited genomic regions for your target capture kit,
-as provided by your vendor. Since these regions (usually exons) may be of
-unequal size, the ``--split`` option divides the larger regions so that the
-average bin size after dividing is close to the size specified by
-``--avg-size``.  If any of these three (``--split``, ``--annotate``, or
-``--short-names``) flags are used, a new target BED file will be created;
-otherwise, the provided target BED file will be used as-is.
+as provided by your vendor. The ``--annotate`` and ``--short-names`` options
+rewrite the region labels. The :ref:`batch` command runs this step for you,
+writing a processed ``*.target.bed`` next to its other output files.
+
+Vendor bait files sometimes repeat a region, or list baits that overlap --
+for instance, two rows with the same coordinates but different symbols for a
+pair of synonymous or nested genes. Every CNVkit bin must cover a distinct
+stretch of the genome, so ``target`` merges overlapping baits into a single
+bin labeled with the joined names of the baits it covers. Left in place,
+repeated coordinates propagate through :ref:`coverage` into the
+:ref:`reference` and abort :ref:`fix` with a "Duplicated genomic coordinates"
+error, and overlapping baits count the reads in the shared stretch twice.
+
+Whether the bins you get back follow your bait file's own boundaries depends
+on ``--split``:
+
+- **Without** ``--split``, only overlaps are resolved. Baits that merely abut
+  each other stay separate, so a bait file you have already curated into
+  meaningful capture regions comes through with its boundaries -- and its gene
+  labels -- intact.
+- **With** ``--split``, target sizes are normalized instead: runs of
+  contiguous baits are joined and then divided into pieces of about
+  ``--avg-size``, discarding the original boundaries within each run. Joining
+  first is what allows a kit that tiles its exons with small baits to reach the
+  requested bin size at all, since dividing alone can only make bins smaller.
+  Each resulting bin is labeled for the baits it actually covers, not for the
+  whole run it was cut from -- unless ``--annotate`` supplies the labels
+  instead.
+
+Since exons are of unequal size, ``--split`` is the right choice for raw
+vendor baits, and the one :ref:`batch` applies.
 
 If you don't have the capture regions BED file, but you do know which commercial
 exome capture kit was used to prepare your samples, you might find the file you

--- a/skgenome/cli/skg_convert.py
+++ b/skgenome/cli/skg_convert.py
@@ -50,9 +50,11 @@ def argument_parsing():
         type=int,
         const=1,
         help="""Merge overlapping regions with different names.
-                    Recommended with --exons. Optional argument value is the
-                    number of overlapping bases between two regions to trigger a
-                    merge. [Default: %(const)s]""",
+                    Recommended with --exons. The optional argument value is
+                    the gap to bridge: 0 also merges bookended regions, and
+                    negative values merge regions up to that many bases apart.
+                    Any positive value merges only regions that genuinely
+                    overlap. [Default: %(const)s]""",
     )
     # ENH combine --gff-type, --refflat-type
     # AP.add_argument('-e', '--exons', action='store_true',
@@ -106,7 +108,7 @@ def skg_convert(args) -> None:
     # Post-processing
     if args.flatten:
         regions = regions.flatten()
-    elif args.merge:
+    elif args.merge is not None:
         regions = regions.merge(bp=args.merge)
 
     tabio.write(regions, args.output, args.out_fmt)

--- a/skgenome/combiners.py
+++ b/skgenome/combiners.py
@@ -60,24 +60,36 @@ def join_strings(
     sep: str = ",",
     ignore: tuple[str, ...] = (),
 ) -> str:
-    """Join a Series of unique strings, skipping NaN values and ignored names.
+    """Join a Series of unique names, skipping NaN values and ignored names.
+
+    Inputs may themselves already be joined labels -- a bin spanning two genes
+    carries the label ``"GENEA,GENEB"`` -- and combining operations chain:
+    :func:`skgenome.merge.merge` joins the labels of overlapping baits, and
+    :meth:`GenomicArray.into_ranges` then joins those already-joined labels
+    again when re-labelling the bins cut from them. Names are therefore
+    deduplicated across the separator, so joining is idempotent and no name is
+    repeated in the result.
 
     Parameters
     ----------
     elems : iterable
         Values to join. Non-string elements (e.g. NaN) are silently skipped.
     sep : str
-        Separator between joined names.
+        Separator between joined names, and within any already-joined input.
     ignore : tuple of str
-        String values to exclude from the result (e.g. placeholder gene names).
+        Names to exclude from the result (e.g. placeholder gene names).
 
     Returns
     -------
     str
-        The joined string, or ``"-"`` if no valid strings remain.
+        The joined string, or ``"-"`` if no valid names remain.
     """
     unique_strs = dict.fromkeys(
-        e for e in elems if isinstance(e, str) and e not in ignore
+        name
+        for e in elems
+        if isinstance(e, str)
+        for name in e.split(sep)
+        if name not in ignore
     )
     return sep.join(unique_strs) or "-"
 

--- a/skgenome/gary.py
+++ b/skgenome/gary.py
@@ -774,7 +774,8 @@ class GenomicArray:
     ) -> GenomicArray:
         """Merge adjacent or overlapping regions into single rows.
 
-        Similar to 'bedtools merge'.
+        Similar to 'bedtools merge'. Pass ``bp=1`` to merge only regions that
+        genuinely overlap, leaving bookended regions as separate rows.
         """
         return self.as_dataframe(merge(self.data, bp, stranded, combine))
 
@@ -832,9 +833,13 @@ class GenomicArray:
         return self.as_dataframe(squash(self.data, by=by, combine=combine))
 
     def subdivide(
-        self, avg_size: int, min_size: int = 0, verbose: bool = False
+        self, avg_size: float, min_size: int = 0, verbose: bool = False
     ) -> GenomicArray:
-        """Split this array's regions into roughly equal-sized sub-regions."""
+        """Resize this array's regions to roughly equal-sized sub-regions.
+
+        Contiguous regions are merged before being divided, so their original
+        boundaries are not preserved.
+        """
         return self.as_dataframe(subdivide(self.data, avg_size, min_size, verbose))
 
     def subtract(self, other: GenomicArray) -> GenomicArray:

--- a/skgenome/merge.py
+++ b/skgenome/merge.py
@@ -50,16 +50,45 @@ def _fill_unnamed(table: pd.DataFrame, cmb: dict[str, Callable]) -> pd.DataFrame
     return table
 
 
+def _nothing_to_cluster(table: pd.DataFrame, bp: int) -> bool:
+    """Whether no two rows would cluster together, so the table passes through.
+
+    Rows cluster when the gap between them is at most ``-bp`` bases: ``bp = 0``
+    clusters bookended rows, and ``bp = 1`` clusters only rows that genuinely
+    overlap.
+
+    Each row is compared against the running maximum end of the preceding rows
+    on the same chromosome, which assumes the table is sorted -- as everything
+    read through :mod:`skgenome.tabio` is. Tables whose rows are out of order,
+    or whose chromosomes are not in contiguous blocks, fall through to the
+    clustering path, which sorts.
+    """
+    chromosomes = table.chromosome.to_numpy()
+    changes = chromosomes[1:] != chromosomes[:-1]
+    if 1 + int(changes.sum()) != table.chromosome.nunique():
+        # A chromosome occurs in more than one block, so the running maximum
+        # below would skip comparisons between rows that are not adjacent
+        return False
+    covered = table.groupby("chromosome", sort=False).end.cummax().to_numpy()
+    gap_sizes = table.start.to_numpy()[1:] - covered[:-1]
+    return bool((changes | (gap_sizes > -bp)).all())
+
+
 def flatten(
     table: pd.DataFrame,
     combine: dict[str, Callable] | None = None,
     split_columns: Iterable[str] | None = None,
 ) -> pd.DataFrame:
-    """Combine overlapping regions into single rows, similar to bedtools merge."""
+    """Split overlapping regions at every breakpoint, combining extra fields.
+
+    Unlike :func:`merge`, which emits an overlapping group's union as one row,
+    this emits one row per distinct sub-interval, so partially overlapping
+    regions yield fragments narrower than either input.
+    """
     if table.empty:
         return table
     cmb = get_combiners(table, False, combine)
-    if (table.start.to_numpy()[1:] >= table.end.cummax().to_numpy()[:-1]).all():
+    if _nothing_to_cluster(table, 1):
         return _fill_unnamed(table, cmb)
     # NB: Input rows and columns should already be sorted like this
     table = table.sort_values(["chromosome", "start", "end"])
@@ -111,16 +140,43 @@ def merge(
     stranded: bool = False,
     combine: dict[str, Callable] | None = None,
 ) -> pd.DataFrame:
-    """Merge overlapping rows in a DataFrame."""
+    """Merge rows that overlap, or that lie within a given gap of each other.
+
+    Parameters
+    ----------
+    table : DataFrame
+        Genomic intervals, with at least chromosome, start and end columns.
+        Must be sorted by chromosome, start, end.
+    bp : int
+        Rows are merged when the gap between them is at most ``-bp`` bases.
+        The default 0 merges bookended rows too, as ``bedtools merge`` does,
+        and negative values bridge gaps of that many bases. Any value above 0
+        merges only rows that genuinely overlap, leaving bookended rows -- the
+        consecutive tiles of a bait file, say -- separate; bioframe cannot
+        express a finer distinction, so 1 is the effective maximum.
+    stranded : bool
+        Merge only rows on the same strand, keeping the strand in the output.
+    combine : dict, optional
+        Column-to-function mapping for aggregating the merged rows' other
+        fields. See :func:`skgenome.combiners.get_combiners`.
+
+    Returns
+    -------
+    DataFrame
+        A new table with the overlapping (or near-enough) rows merged.
+    """
     if table.empty:
         return table
     cmb = get_combiners(table, stranded, combine)
-    gap_sizes = table.start.to_numpy()[1:] - table.end.cummax().to_numpy()[:-1]
-    if (gap_sizes > -bp).all():
+    # bioframe clusters rows at most `min_dist` bases apart, and with None only
+    # rows that truly overlap -- the finest distinction it can express, so any
+    # `bp` above 1 is the same as 1.
+    bp = min(bp, 1)
+    if _nothing_to_cluster(table, bp):
         return _fill_unnamed(table, cmb)
     groupkey = ["chromosome", "strand"] if stranded else ["chromosome"]
     table = table.sort_values([*groupkey, "start", "end"])
-    min_dist = max(0, -bp)
+    min_dist = None if bp == 1 else -bp
     on = ["strand"] if stranded else None
     clustered = bioframe.cluster(
         table,
@@ -135,11 +191,19 @@ def merge(
         for c in clustered.columns
         if c not in ("cluster", "cluster_start", "cluster_end")
     ]
-    result_rows = []
-    for _cluster_id, group in clustered.groupby("cluster", sort=False):
-        if len(group) == 1:
-            result_rows.append(group[data_cols].iloc[0])
-        else:
+    # Rows that cluster alone are emitted verbatim; only the rows that really
+    # combine are worth a Python-level pass. When a bait file holds a handful
+    # of duplicates nearly every cluster is a singleton, and visiting them all
+    # otherwise dominates the runtime.
+    cluster_ids = clustered["cluster"]
+    is_first = ~cluster_ids.duplicated().to_numpy()
+    in_multi_row_cluster = cluster_ids.duplicated(keep=False).to_numpy()
+    out = clustered.loc[is_first, data_cols].reset_index(drop=True)
+    if in_multi_row_cluster.any():
+        combined_rows = []
+        for _cluster_id, group in clustered[in_multi_row_cluster].groupby(
+            "cluster", sort=False
+        ):
             vals = {}
             for col in data_cols:
                 if col == "start":
@@ -150,8 +214,16 @@ def merge(
                     vals[col] = cmb[col](group[col].values)
                 else:
                     vals[col] = group[col].iloc[0]
-            result_rows.append(pd.Series(vals))
-    out = pd.DataFrame(result_rows, columns=data_cols).reset_index(drop=True)
+            combined_rows.append(vals)
+        # `groupby(sort=False)` yields clusters in order of first appearance,
+        # which is the order `is_first` picked them out of `out`. Splice via
+        # `concat` so pandas widens each column's dtype to fit the combined
+        # values, e.g. a joined name landing in an all-NaN float column.
+        combining = in_multi_row_cluster[is_first]
+        replacement = pd.DataFrame(
+            combined_rows, columns=data_cols, index=np.flatnonzero(combining)
+        )
+        out = pd.concat([out[~combining], replacement]).sort_index(kind="mergesort")
     # Re-sort chromosomes cleverly instead of lexicographically
     out = out.reindex(
         out.chromosome.apply(sorter_chrom).sort_values(kind="mergesort").index

--- a/skgenome/subdivide.py
+++ b/skgenome/subdivide.py
@@ -15,22 +15,29 @@ from .merge import merge
 
 
 def subdivide(
-    table, avg_size: int, min_size: int = 0, verbose: bool = False
+    table, avg_size: float, min_size: int = 0, verbose: bool = False
 ) -> pd.DataFrame:
-    """Split `table` rows into sub-regions of about `avg_size`."""
+    """Resize `table` rows to sub-regions of about `avg_size`.
+
+    Overlapping and bookended rows are merged before being divided, so a run of
+    contiguous small regions is normalized up to ``avg_size`` rather than left
+    as it is -- dividing alone could only ever make regions smaller. The
+    original boundaries within such a run are therefore not preserved.
+    """
     return pd.DataFrame.from_records(
         _split_targets(table, avg_size, min_size, verbose), columns=table.columns
     )
 
 
-def _split_targets(regions, avg_size: int, min_size: int, verbose: bool):
+def _split_targets(regions, avg_size: float, min_size: int, verbose: bool):
     """Split large regions into smaller, consecutive regions.
 
-    Output bin metadata and additional columns match the input dataframe.
+    Rows are merged before being split, per :func:`subdivide`. Output bin
+    metadata and additional columns match the input dataframe.
 
     Parameters
     ----------
-    avg_size : int
+    avg_size : float
         Split regions into equal-sized subregions of about this size.
         Specifically, subregions are no larger than 150% of this size, no
         smaller than 75% this size, and the average will approach this size

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -13,6 +13,7 @@ import pandas as pd
 from cnvlib import read_ga
 from skgenome import GenomicArray as GA
 from skgenome import chromsort, rangelabel, tabio
+from skgenome.combiners import join_strings
 
 
 class GaryTests(unittest.TestCase):
@@ -463,6 +464,63 @@ class IntervalTests(unittest.TestCase):
             expect = self._from_intervals(merged_coords)
             self._compare_regions(result, expect)
 
+    def test_merge_overlapping_only(self):
+        """``merge(bp=1)`` merges overlapping rows but not bookended ones.
+
+        The bookended distinction matters to the 'target' command: consecutive
+        bait tiles must survive as separate bins, or a capture kit's targets
+        get coarsened (#567). It is also what ``skg_convert --merge`` has
+        always documented -- "the number of overlapping bases ... to trigger a
+        merge" -- while the default ``bp=0`` follows ``bedtools merge`` in
+        merging bookended rows too.
+        """
+        regions = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": "chr0",
+                    "start": [100, 150, 400, 500, 700, 720],
+                    "end": [200, 300, 500, 600, 750, 800],
+                    "gene": ["A", "B", "C", "D", "E", "F"],
+                }
+            )
+        )
+        merged = regions.merge(bp=1)
+        self.assertEqual(
+            list(zip(merged.start, merged.end, merged["gene"], strict=True)),
+            [(100, 300, "A,B"), (400, 500, "C"), (500, 600, "D"), (700, 800, "E,F")],
+        )
+        # The default also merges the bookended pair chr0:400-500 / 500-600
+        default_merged = regions.merge()
+        self.assertEqual(
+            list(zip(default_merged.start, default_merged.end, strict=True)),
+            [(100, 300), (400, 600), (700, 800)],
+        )
+        # A table with no overlaps at all passes through unchanged
+        disjoint = GA(regions.data.iloc[[2, 3]].reset_index(drop=True))
+        self.assertTrue(disjoint.merge(bp=1).data.equals(disjoint.data))
+        # Overlaps are found even when a chromosome's rows are not contiguous,
+        # where the sorted-input shortcut for spotting them does not apply
+        interleaved = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1", "chr2", "chr1"],
+                    "start": [100, 500, 150],
+                    "end": [200, 600, 250],
+                    "gene": ["A", "Z", "B"],
+                }
+            )
+        )
+        self.assertEqual(
+            list(
+                zip(
+                    interleaved.merge(bp=1).start,
+                    interleaved.merge(bp=1).end,
+                    strict=True,
+                )
+            ),
+            [(100, 250), (500, 600)],
+        )
+
     def test_nan_gene_names(self):
         """merge/flatten/subdivide tolerate NaN-float gene names (issue #850).
 
@@ -510,6 +568,45 @@ class IntervalTests(unittest.TestCase):
             for gene in result["gene"]:
                 self.assertIsInstance(gene, str)
                 self.assertNotIn("nan", gene.lower())
+
+        # A name column with no strings at all is typed float64 (all-NaN) or
+        # int64 (numeric bait names, which Picard interval_list files carry),
+        # and merging must widen it to hold the "-" that join_strings returns
+        # rather than coerce the value into the incumbent dtype
+        for names in ([np.nan] * 3, [1, 2, 3]):
+            numeric = GA(
+                pd.DataFrame(
+                    {
+                        "chromosome": "chr0",
+                        "start": [100, 150, 700],
+                        "end": [400, 600, 900],
+                        "gene": names,
+                    }
+                )
+            )
+            self.assertEqual(list(numeric.merge()["gene"]), ["-", "-"])
+
+    def test_join_strings_deduplicates_across_separator(self):
+        """Joining already-joined gene labels repeats no name (#567).
+
+        Combining operations chain -- ``target`` merges overlapping baits and
+        then re-labels the bins split out of them from those already-joined
+        labels, and ``segmentation`` joins the gene labels of the bins a
+        segment spans -- so the inputs to ``join_strings`` are often themselves
+        joined labels. Treating each input as opaque yielded labels such as
+        "GENEA,GENEA,GENEB,GENEB".
+        """
+        self.assertEqual(join_strings(["GENEA", "GENEA,GENEB"]), "GENEA,GENEB")
+        self.assertEqual(
+            join_strings(["GENEA,GENEB", "GENEB,GENEC"]), "GENEA,GENEB,GENEC"
+        )
+        # Order of first appearance is preserved, and joining is idempotent
+        joined = join_strings(["B,A", "C"])
+        self.assertEqual(joined, "B,A,C")
+        self.assertEqual(join_strings([joined]), joined)
+        # Ignored names are dropped from within joined labels too
+        self.assertEqual(join_strings(["-,GENEA"], ignore=("-",)), "GENEA")
+        self.assertEqual(join_strings(["-", np.nan]), "-")
 
     def test_intersect(self):
         selections1 = self._from_intervals(

--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -714,6 +714,19 @@ class PreprocessingTests(unittest.TestCase):
     def test_target(self):
         """The 'target' command."""
         annot_fname = "formats/refflat-mini.txt"
+
+        def assert_disjoint(arr, msg):
+            """Bins are sorted and non-overlapping: next start >= previous end."""
+            for _c, subarr in arr.by_chromosome():
+                self.assertTrue(subarr.start.is_monotonic_increasing, msg)
+                self.assertTrue(subarr.end.is_monotonic_increasing, msg)
+                gaps = subarr.start.to_numpy()[1:] - subarr.end.to_numpy()[:-1]
+                self.assertTrue((gaps >= 0).all(), msg)
+
+        def covered_bases(arr):
+            merged = arr.merge()
+            return int((merged.end - merged.start).sum())
+
         for bait_fname in (
             "formats/nv2_baits.interval_list",
             "formats/amplicon.bed",
@@ -723,7 +736,14 @@ class PreprocessingTests(unittest.TestCase):
             bait_len = len(baits)
             # No splitting: w/o and w/ re-annotation
             r1 = commands.do_target(baits)
-            self.assertEqual(len(r1), bait_len)
+            # Overlapping baits are merged, so the row count may shrink, but
+            # the covered territory is unchanged and no bin is smaller than the
+            # smallest bait it came from (#567)
+            assert_disjoint(r1, bait_fname)
+            self.assertEqual(covered_bases(r1), covered_bases(baits), bait_fname)
+            self.assertGreaterEqual(
+                (r1.end - r1.start).min(), (baits.end - baits.start).min(), bait_fname
+            )
             r1a = commands.do_target(baits, do_short_names=True, annotate=annot_fname)
             self.assertEqual(len(r1a), len(r1))
             # Splitting, w/o and w/ re-annotation
@@ -731,15 +751,7 @@ class PreprocessingTests(unittest.TestCase):
                 baits, do_short_names=True, do_split=True, avg_size=100
             )
             self.assertGreater(len(r2), len(r1))
-            for _c, subarr in r2.by_chromosome():
-                self.assertTrue(subarr.start.is_monotonic_increasing, bait_fname)
-                self.assertTrue(subarr.end.is_monotonic_increasing, bait_fname)
-                # Bins are non-overlapping; next start >= prev. end
-                self.assertTrue(
-                    (
-                        (subarr.start.to_numpy()[1:] - subarr.end.to_numpy()[:-1]) >= 0
-                    ).all()
-                )
+            assert_disjoint(r2, bait_fname)
             r2a = commands.do_target(
                 baits,
                 do_short_names=True,
@@ -750,3 +762,113 @@ class PreprocessingTests(unittest.TestCase):
             self.assertEqual(len(r2a), len(r2))
             # Original regions object should be unmodified
             self.assertEqual(len(baits), bait_len)
+
+    def test_target_collapses_duplicate_baits(self):
+        """'target' merges duplicate and overlapping baits (#567).
+
+        Duplicate BED rows, and rows with identical coordinates but different
+        gene labels, otherwise reach `fix` as duplicated coordinates and abort
+        the run. Before this change nothing collapsed them unless --split was
+        given.
+        """
+        baits = tabio.read_auto("formats/baits-funky.bed")
+
+        def coords(arr):
+            return list(zip(arr.chromosome, arr.start, arr.end, strict=True))
+
+        self.assertGreater(len(coords(baits)), len(set(coords(baits))))
+
+        with self.assertLogs(level="INFO") as cm:
+            out = commands.do_target(baits)
+        self.assertTrue(any("overlapping or duplicated" in m for m in cm.output))
+        self.assertEqual(len(coords(out)), len(set(coords(out))))
+
+        # Genes of coincident baits are joined, each name appearing once --
+        # including names that arrive already joined, as at chr1:14360-14409,
+        # where two of the three duplicate rows are labelled "DDX11L1,WASH7P"
+        for chromosome, start, end, gene in [
+            ("chr1", 14360, 14409, "DDX11L1,WASH7P,WASH7P_DUPE"),
+            ("chrX", 69673485, 69673643, "DLG3,DLG3_DUPE"),
+            # A nested bait is absorbed by the one containing it
+            ("chr1", 16605, 16765, "WASH7P,WASH7P_NESTED"),
+            # Partly overlapping baits merge into their union
+            ("chr1", 14968, 15150, "WASH7P,WASH7P_OVERLAP"),
+        ]:
+            row = out[(out.chromosome == chromosome) & (out.start == start)]
+            self.assertEqual(len(row), 1, (chromosome, start))
+            self.assertEqual(row["end"].iloc[0], end)
+            self.assertEqual(row["gene"].iloc[0], gene)
+
+        # Bookended baits are left alone: merging them would coarsen the tiling
+        # of a capture kit, whose targets are consecutive by design
+        bookended = out[(out.chromosome == "chr1") & (out.start == 17367)]
+        self.assertEqual(list(bookended["end"]), [17368])
+
+    def test_target_is_idempotent(self):
+        """Re-running 'target' on its own output changes nothing.
+
+        The output of `target` is a valid bait file, so feeding it back in with
+        the same options must be a no-op: merging is confined to genuine
+        overlaps, of which the output has none, and re-splitting an evenly
+        divided run reproduces the same bins. Users do chain the command this
+        way, and `batch` effectively does so when handed an already-processed
+        target BED.
+        """
+        options = [
+            {},
+            {"do_split": True, "avg_size": 200},
+            {"do_split": True, "avg_size": 100, "do_short_names": True},
+            {"do_split": True, "avg_size": 200, "annotate": "formats/refflat-mini.txt"},
+        ]
+        for bait_fname in (
+            "formats/amplicon.bed",
+            "formats/baits-funky.bed",
+        ):
+            baits = tabio.read_auto(bait_fname)
+            for kwargs in options:
+                once = commands.do_target(baits, **kwargs)
+                twice = commands.do_target(once, **kwargs)
+                self.assertTrue(
+                    once.data.reset_index(drop=True).equals(
+                        twice.data.reset_index(drop=True)
+                    ),
+                    f"{bait_fname} {kwargs}",
+                )
+
+    def test_target_split_labels_come_from_covering_baits(self):
+        """Each split bin is named for the baits it covers, not its whole run.
+
+        `subdivide` re-merges bookended regions before dividing them evenly, so
+        the joined label of a contiguous run used to be stamped on every bin the
+        run was cut into -- naming bins after genes they do not overlap.
+        """
+        out = commands.do_target(
+            tabio.read_auto("formats/baits-funky.bed"), do_split=True, avg_size=200
+        )
+        labels = {
+            (int(s), int(e)): g
+            for c, s, e, g in zip(
+                out.chromosome, out.start, out.end, out["gene"], strict=True
+            )
+            if c == "chr1"
+        }
+        # chr1:13219-14829 is one contiguous run of DDX11L1 and WASH7P baits.
+        # Every bin cut from it used to carry the whole run's joined label.
+        self.assertEqual(labels[(13219, 13420)], "DDX11L1")
+        self.assertEqual(labels[(14225, 14426)], "DDX11L1,WASH7P,WASH7P_DUPE")
+        self.assertEqual(labels[(14627, 14829)], "WASH7P")
+
+        # No bin anywhere may claim a bait it does not overlap
+        for bait_fname in (
+            "formats/nv2_baits.interval_list",
+            "formats/baits-funky.bed",
+        ):
+            baits = tabio.read_auto(bait_fname)
+            split = commands.do_target(baits, do_split=True, avg_size=200)
+            covering = baits.into_ranges(split, "gene", "-")
+            for bin_label, bait_labels in zip(split["gene"], covering, strict=True):
+                self.assertEqual(
+                    set(bin_label.split(",")),
+                    set(str(bait_labels).split(",")),
+                    bait_fname,
+                )


### PR DESCRIPTION
`cnvkit.py fix` aborts with "Duplicated genomic coordinates in sample set" whenever the bait BED contains exact-duplicate rows, or rows with identical coordinates but different gene labels — synonymous genes such as TREX2 and HAUS7 at chrX:152719709-152719829. `do_target` dropped zero-width bins, optionally subdivided and annotated, but never merged, so duplicates propagated through `coverage` into the reference and crashed `fix`. Reporters worked around it with `sort | uniq`.

Fixes #567.

## `target` merges overlapping baits

`do_target` now merges overlapping and duplicate baits, joining their gene labels, and leaves bookended baits alone.

The two alternatives were measured and rejected. Flattening at every breakpoint cuts partly overlapping vendor baits into slivers; merging bookended runs coarsens a kit's tiling even when nothing overlaps:

| bait file | `flatten()` | `merge(bp=0)` | `merge(bp=1)` (this PR) |
|---|---|---|---|
| nv2_baits (142 overlapping pairs) | 6809 → 6951, **100 bins under 50 bp, minimum 1 bp** | 6809 → 6655 | 6809 → **6667, minimum stays 64 bp** |
| amplicon.bed (no overlaps, 381 bookended pairs) | unchanged | **1433 → 1052** | unchanged |

Should duplicates still reach `fix` — from a reference built before this change, say — the error now names the remedy.

## Supporting fixes in `skgenome.merge`

Merging only genuine overlaps required `merge` to be coherent about what `bp` means, which it was not:

- **The pass-through predicate was chromosome-blind.** It compared each start against a whole-table `end.cummax()`, so past the first chromosome every start trailed the previous chromosome's maximum end and the fast path never fired. It is now chromosome-aware, and declines the shortcut when a chromosome's rows are not contiguous, where a running maximum would skip comparisons between rows that are not adjacent.
- **`bp > 0` was self-contradictory.** The predicate implemented `gap > -bp` while the slow path passed `min_dist=0`, i.e. the bookended merging of `bp=0`. Both now mean overlap-only. bioframe cannot express a minimum overlap width, so values above 1 behave as 1, and `skg_convert --merge` no longer advertises a base count it cannot honour.
- **Every cluster went through a Python loop, singletons included.** Only the rows that actually combine are visited now, spliced back with `concat` so pandas widens each column's dtype to fit the combined values. Merging a 216k-bait BED holding three duplicates takes 0.28 s instead of 36.6 s; `target --split` on that BED is unchanged at 15.6 s.

`join_strings` deduplicates across the separator, so labels that are themselves joined cannot compound into `GENEA,GENEA,GENEB`.

## Gene labels on subdivided bins

`subdivide` merges bookended regions before dividing them, so the joined label of a whole contiguous run was stamped on every bin cut from it, naming bins after genes they do not overlap — 5 of 9118 bins on the Nimblegen fixture, one labelled `CGH,SPRY4` while lying entirely inside a SPRY4 bait. Split bins now take their label from the baits they actually cover, by the same `into_ranges` mechanism `--annotate` uses.

## Numerical impact

Verified against a `HEAD` worktree with `PYTHONPATH` pinning, provenance confirmed through `cnvlib.__file__`:

- `target --split` output is **coordinate-identical** on every fixture; `amplicon.bed` is identical in both modes.
- Segmentation `.cns` **non-gene columns are bit-identical**; gene labels change only by dropping a repeated name or a gene the bin does not overlap.
- `GenomicArray.total_range_size` is unchanged on every fixture, including `formats/amplicon.cns`, which carries eight segments with `start > end`.
- 195 differential `merge`/`flatten`/`squash` cases (7 fixtures × three `bp` values, plus 40 randomised multi-chromosome tables with duplicates, nesting and bookending) match `HEAD` except where `bp=1` semantics intentionally changed.
- Idempotence: `target` applied to its own output is a no-op, across fixtures and option combinations.
- End-to-end `target → coverage → reference → fix` on a duplicate-carrying bait BED completes.

## Documentation

The bookended policy was real but buried inside `subdivide`, whose docstring never mentioned that it merges first. `doc/pipeline.rst`, the `--split` help, and the `subdivide`/`do_target` docstrings now state it: omit `--split` to keep a curated bait file's own boundaries, pass `--split` to normalise raw vendor baits. Joining contiguous runs first is what lets `--avg-size` reach the requested bin size at all, since dividing alone can only make bins smaller.

## Testing

595 tests pass; `ruff`, `mypy` and the Sphinx build are clean. New coverage: overlap-only merging including interleaved chromosomes, non-string name columns, `join_strings` idempotence, `target` idempotence, duplicate-bait collapse, and per-bin label provenance.
