### PR TITLE
Give each flattened sub-interval the fields of its covering regions

### DIFF
--- a/doc/scripts.rst
+++ b/doc/scripts.rst
@@ -62,8 +62,11 @@ Additional scripts
 
     In either mode, the input region coordinates can be provided in any of the
     formats handled by skgenome.tabio, but it's best to first run them through
-    either the command :ref:`target` or script ``skg_convert.py --flatten``
-    (see below) to ensure the input regions do not overlap.
+    either the command :ref:`target` or the script ``skg_convert.py --merge``
+    (see below) to ensure the input regions do not overlap. Prefer those to
+    ``skg_convert.py --flatten``, which also removes overlaps but does so by
+    splitting each region at every boundary, shattering partly overlapping
+    bait tiles into slivers a few bases wide.
 
 ``reference2targets.py``
     Extract target and antitarget BED files from a CNVkit reference file.

--- a/skgenome/cli/skg_convert.py
+++ b/skgenome/cli/skg_convert.py
@@ -40,13 +40,12 @@ def argument_parsing():
     AP.add_argument(
         "--flatten",
         action="store_true",
-        help="""Split overlapping regions at every boundary, keeping the
-                    original boundaries and giving each output region the
-                    fields of the input regions covering it. Partly overlapping
-                    regions yield fragments narrower than either input, and any
-                    'weight' or 'probes' field is divided among them, so
-                    --merge is usually the better choice for bait files. Not
-                    recommended with --exons.""",
+        help="""Split overlapping regions at every boundary, giving each output
+                    region the fields of the input regions covering it. Partly
+                    overlapping regions yield fragments narrower than either
+                    input, and any 'weight' or 'probes' field is divided among
+                    them, so --merge is usually the better choice for bait
+                    files. Not recommended with --exons.""",
     )
     AP.add_argument(
         "--merge",

--- a/skgenome/cli/skg_convert.py
+++ b/skgenome/cli/skg_convert.py
@@ -40,8 +40,13 @@ def argument_parsing():
     AP.add_argument(
         "--flatten",
         action="store_true",
-        help="""Flatten overlapping regions, keeping original
-                    boundaries. Not recommended with --exons.""",
+        help="""Split overlapping regions at every boundary, keeping the
+                    original boundaries and giving each output region the
+                    fields of the input regions covering it. Partly overlapping
+                    regions yield fragments narrower than either input, and any
+                    'weight' or 'probes' field is divided among them, so
+                    --merge is usually the better choice for bait files. Not
+                    recommended with --exons.""",
     )
     AP.add_argument(
         "--merge",

--- a/skgenome/gary.py
+++ b/skgenome/gary.py
@@ -727,7 +727,11 @@ class GenomicArray:
         combine: dict[str, Callable] | None = None,
         split_columns: Iterable[str] | None = None,
     ) -> GenomicArray:
-        """Split this array's regions where they overlap."""
+        """Split this array's regions where they overlap.
+
+        Each sub-interval takes its fields from the rows covering it alone.
+        See :func:`skgenome.merge.flatten` for `combine` and `split_columns`.
+        """
         return self.as_dataframe(
             flatten(self.data, combine=combine, split_columns=split_columns)
         )

--- a/skgenome/merge.py
+++ b/skgenome/merge.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 import bioframe
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_integer_dtype
 
 from .chromsort import sorter_chrom
 from .combiners import first_of, get_combiners, join_strings
@@ -101,9 +102,15 @@ def flatten(
         than a property of it -- ``weight`` and ``probes`` by default. Each
         row's value is apportioned among its sub-intervals in proportion to
         their lengths before the covering rows are combined, so the column's
-        total is preserved instead of being duplicated into every piece. Pass
-        an empty sequence to combine these columns like any other; columns
-        without a combiner are ignored.
+        total is preserved instead of being duplicated into every piece. An
+        integer column stays integral, rounded piece by piece, since a count
+        such as ``probes`` is not meaningful as a fraction. Pass an empty
+        sequence to combine these columns like any other.
+
+        Conservation holds for a column with an additive combiner, the default
+        for both of these, and for regions of positive length: a zero-width
+        row contributes a breakpoint but has no sub-interval to carry its
+        value, so it is dropped as it always has been.
 
     Returns
     -------
@@ -115,6 +122,8 @@ def flatten(
     cmb = get_combiners(table, False, combine)
     if _nothing_to_cluster(table, 1):
         return _fill_unnamed(table, cmb)
+    # Filtered to the columns that have a combiner, since a column with none is
+    # taken from its covering row verbatim and so cannot be apportioned
     split_cols = {
         col
         for col in (_SPLIT_COLUMNS if split_columns is None else split_columns)
@@ -128,46 +137,18 @@ def flatten(
     clustered = bioframe.cluster(
         table, min_dist=None, cols=_BF_COLS, return_cluster_ids=True
     )
-    data_cols = [
-        c
-        for c in clustered.columns
-        if c not in ("cluster", "cluster_start", "cluster_end")
-    ]
-    # Rows that cluster alone are emitted verbatim; only the rows that really
-    # overlap are worth a Python-level pass. When a bait file holds a handful
-    # of overlaps nearly every cluster is a singleton, and visiting them all
-    # otherwise dominates the runtime.
-    cluster_ids = clustered["cluster"]
-    is_first = ~cluster_ids.duplicated().to_numpy()
-    in_multi_row_cluster = cluster_ids.duplicated(keep=False).to_numpy()
-    out = clustered.loc[is_first, data_cols].reset_index(drop=True)
-    if in_multi_row_cluster.any():
-        splitting = in_multi_row_cluster[is_first]
-        pieces = []
-        # `groupby(sort=False)` yields clusters in order of first appearance,
-        # which is the order `is_first` picked them out of `out`. Each cluster's
-        # sub-intervals replace the one row standing in for it there, so index
-        # them within its position to interleave them back in coordinate order.
-        for position, (_cluster_id, group) in zip(
-            np.flatnonzero(splitting),
-            clustered[in_multi_row_cluster].groupby("cluster", sort=False),
-            strict=True,
-        ):
-            rows = _flatten_cluster(group[data_cols], cmb, split_cols)
-            pieces.append(
-                pd.DataFrame(
-                    rows,
-                    columns=data_cols,
-                    index=position + np.arange(len(rows)) / len(rows),
-                )
-            )
-        # Splice via `concat` so pandas widens each column's dtype to fit the
-        # combined values, e.g. a joined name landing in an all-NaN float column.
-        out = (
-            pd.concat([out[~splitting], *pieces])
-            .sort_index(kind="mergesort")
-            .reset_index(drop=True)
-        )
+    data_cols = _data_columns(clustered)
+    out = _splice_clusters(
+        clustered,
+        data_cols,
+        lambda group: _flatten_cluster(group[data_cols], cmb, split_cols),
+    )
+    # A count stays a count: 'probes' is documented as a number of bins, and
+    # `export vcf` reads a fractional probe count as a corrupt segment and drops
+    # it. Rounding the shares back costs under one count per piece.
+    for col in split_cols:
+        if is_integer_dtype(table[col]):
+            out[col] = out[col].round().astype(table[col].dtype)
     # Re-sort chromosomes cleverly instead of lexicographically
     out = out.reindex(
         out.chromosome.apply(sorter_chrom).sort_values(kind="mergesort").index
@@ -175,40 +156,103 @@ def flatten(
     return _fill_unnamed(out, cmb)
 
 
+def _data_columns(clustered: pd.DataFrame) -> list[str]:
+    """The columns of a `bioframe.cluster` result that came from the input."""
+    return [
+        col
+        for col in clustered.columns
+        if col not in ("cluster", "cluster_start", "cluster_end")
+    ]
+
+
+def _splice_clusters(
+    clustered: pd.DataFrame,
+    data_cols: list[str],
+    expand: Callable[[pd.DataFrame], list[dict]],
+) -> pd.DataFrame:
+    """Rebuild a clustered table, replacing each multi-row cluster with `expand`.
+
+    Rows that cluster alone are emitted verbatim; only the rows that really
+    cluster together are worth a Python-level pass. When a bait file holds a
+    handful of overlaps nearly every cluster is a singleton, and visiting them
+    all otherwise dominates the runtime.
+    """
+    cluster_ids = clustered["cluster"]
+    is_first = ~cluster_ids.duplicated().to_numpy()
+    in_multi_row_cluster = cluster_ids.duplicated(keep=False).to_numpy()
+    out = clustered.loc[is_first, data_cols].reset_index(drop=True)
+    if not in_multi_row_cluster.any():
+        return out
+    # `groupby(sort=False)` yields clusters in order of first appearance, which
+    # is the order `is_first` picked them out of `out`. The rows replacing a
+    # cluster take the index of the one row standing in for it there, and
+    # `mergesort` is stable, so they keep the order `expand` gave them.
+    changing = in_multi_row_cluster[is_first]
+    rows: list[dict] = []
+    index: list[int] = []
+    for position, (_cluster_id, group) in zip(
+        np.flatnonzero(changing).tolist(),
+        clustered[in_multi_row_cluster].groupby("cluster", sort=False),
+        strict=True,
+    ):
+        new_rows = expand(group)
+        rows.extend(new_rows)
+        index.extend(itertools.repeat(position, len(new_rows)))
+    # Splice via `concat` so pandas widens each column's dtype to fit the
+    # combined values, e.g. a joined name landing in an all-NaN float column.
+    replacement = pd.DataFrame(rows, columns=data_cols, index=index)
+    return (
+        pd.concat([out[~changing], replacement])
+        .sort_index(kind="mergesort")
+        .reset_index(drop=True)
+    )
+
+
 def _flatten_cluster(
-    group_df: pd.DataFrame, combine: dict[str, Callable], split_cols: set[str]
+    group_df: pd.DataFrame, cmb: dict[str, Callable], split_cols: set[str]
 ) -> list[dict]:
     """Divide one cluster of overlapping rows at each of their breakpoints.
 
     Every sub-interval draws its values from the rows covering that
-    sub-interval alone: the columns in `combine` through their combiner, the
-    rest from the first covering row. Columns in `split_cols` are apportioned
-    by length before being combined.
+    sub-interval alone: the columns in `cmb` through their combiner, the rest
+    from the first covering row. Columns in `split_cols` are apportioned by
+    length before being combined.
     """
-    columns = list(group_df.columns)
-    rows = list(group_df.itertuples(index=False))
-    breaks = sorted({bound for row in rows for bound in (row.start, row.end)})
+    # Address the rows positionally: `itertuples` renames any column whose name
+    # is not an identifier, and a tabular input's header is the user's own
+    positions = {col: i for i, col in enumerate(group_df.columns)}
+    i_start = positions["start"]
+    i_end = positions["end"]
+    rows = list(group_df.itertuples(index=False, name=None))
+    breaks = sorted({bound for row in rows for bound in (row[i_start], row[i_end])})
     result = []
     for bp_start, bp_end in itertools.pairwise(breaks):
         # The cluster spans a contiguous range and no breakpoint falls strictly
         # within this sub-interval, so at least one row covers all of it
-        covering = [row for row in rows if row.start <= bp_start and row.end >= bp_end]
+        covering = [
+            row for row in rows if row[i_start] <= bp_start and row[i_end] >= bp_end
+        ]
         piece = {}
-        for col in columns:
+        for col, i_col in positions.items():
             if col == "start":
                 piece[col] = bp_start
             elif col == "end":
                 piece[col] = bp_end
-            elif col in combine:
-                values = [getattr(row, col) for row in covering]
+            elif col in cmb:
                 if col in split_cols:
-                    values = [
-                        val * (bp_end - bp_start) / (row.end - row.start)
-                        for val, row in zip(values, covering, strict=True)
-                    ]
-                piece[col] = combine[col](values)
+                    # A row's share of the quantity is its share of the length
+                    piece[col] = cmb[col](
+                        [
+                            row[i_col]
+                            * (bp_end - bp_start)
+                            / (row[i_end] - row[i_start])
+                            for row in covering
+                        ]
+                    )
+                else:
+                    piece[col] = cmb[col]([row[i_col] for row in covering])
             else:
-                piece[col] = getattr(covering[0], col)
+                piece[col] = covering[0][i_col]
         result.append(piece)
     return result
 
@@ -265,44 +309,23 @@ def merge(
         return_cluster_ids=True,
         return_cluster_intervals=True,
     )
-    data_cols = [
-        c
-        for c in clustered.columns
-        if c not in ("cluster", "cluster_start", "cluster_end")
-    ]
-    # Rows that cluster alone are emitted verbatim; only the rows that really
-    # combine are worth a Python-level pass. When a bait file holds a handful
-    # of duplicates nearly every cluster is a singleton, and visiting them all
-    # otherwise dominates the runtime.
-    cluster_ids = clustered["cluster"]
-    is_first = ~cluster_ids.duplicated().to_numpy()
-    in_multi_row_cluster = cluster_ids.duplicated(keep=False).to_numpy()
-    out = clustered.loc[is_first, data_cols].reset_index(drop=True)
-    if in_multi_row_cluster.any():
-        combined_rows = []
-        for _cluster_id, group in clustered[in_multi_row_cluster].groupby(
-            "cluster", sort=False
-        ):
-            vals = {}
-            for col in data_cols:
-                if col == "start":
-                    vals[col] = group["cluster_start"].iloc[0]
-                elif col == "end":
-                    vals[col] = group["cluster_end"].iloc[0]
-                elif col in cmb:
-                    vals[col] = cmb[col](group[col].values)
-                else:
-                    vals[col] = group[col].iloc[0]
-            combined_rows.append(vals)
-        # `groupby(sort=False)` yields clusters in order of first appearance,
-        # which is the order `is_first` picked them out of `out`. Splice via
-        # `concat` so pandas widens each column's dtype to fit the combined
-        # values, e.g. a joined name landing in an all-NaN float column.
-        combining = in_multi_row_cluster[is_first]
-        replacement = pd.DataFrame(
-            combined_rows, columns=data_cols, index=np.flatnonzero(combining)
-        )
-        out = pd.concat([out[~combining], replacement]).sort_index(kind="mergesort")
+    data_cols = _data_columns(clustered)
+
+    def combine_cluster(group: pd.DataFrame) -> list[dict]:
+        """Combine one cluster's rows into the single row of their union."""
+        vals = {}
+        for col in data_cols:
+            if col == "start":
+                vals[col] = group["cluster_start"].iloc[0]
+            elif col == "end":
+                vals[col] = group["cluster_end"].iloc[0]
+            elif col in cmb:
+                vals[col] = cmb[col](group[col].values)
+            else:
+                vals[col] = group[col].iloc[0]
+        return [vals]
+
+    out = _splice_clusters(clustered, data_cols, combine_cluster)
     # Re-sort chromosomes cleverly instead of lexicographically
     out = out.reindex(
         out.chromosome.apply(sorter_chrom).sort_values(kind="mergesort").index

--- a/skgenome/merge.py
+++ b/skgenome/merge.py
@@ -122,16 +122,53 @@ def flatten(
     }
     # NB: Input rows and columns should already be sorted like this
     table = table.sort_values(["chromosome", "start", "end"])
+    # Bookended rows share no breakpoint to split at, so cluster only the rows
+    # that genuinely overlap -- the same distinction `_nothing_to_cluster`
+    # makes above when it lets a whole table through.
     clustered = bioframe.cluster(
-        table, min_dist=0, cols=_BF_COLS, return_cluster_ids=True
+        table, min_dist=None, cols=_BF_COLS, return_cluster_ids=True
     )
-    all_rows: list = []
-    for _cluster_id, group in clustered.groupby("cluster", sort=False):
-        group_rows = group.drop(
-            columns=["cluster", "cluster_start", "cluster_end"], errors="ignore"
+    data_cols = [
+        c
+        for c in clustered.columns
+        if c not in ("cluster", "cluster_start", "cluster_end")
+    ]
+    # Rows that cluster alone are emitted verbatim; only the rows that really
+    # overlap are worth a Python-level pass. When a bait file holds a handful
+    # of overlaps nearly every cluster is a singleton, and visiting them all
+    # otherwise dominates the runtime.
+    cluster_ids = clustered["cluster"]
+    is_first = ~cluster_ids.duplicated().to_numpy()
+    in_multi_row_cluster = cluster_ids.duplicated(keep=False).to_numpy()
+    out = clustered.loc[is_first, data_cols].reset_index(drop=True)
+    if in_multi_row_cluster.any():
+        splitting = in_multi_row_cluster[is_first]
+        pieces = []
+        # `groupby(sort=False)` yields clusters in order of first appearance,
+        # which is the order `is_first` picked them out of `out`. Each cluster's
+        # sub-intervals replace the one row standing in for it there, so index
+        # them within its position to interleave them back in coordinate order.
+        for position, (_cluster_id, group) in zip(
+            np.flatnonzero(splitting),
+            clustered[in_multi_row_cluster].groupby("cluster", sort=False),
+            strict=True,
+        ):
+            rows = _flatten_cluster(group[data_cols], cmb, split_cols)
+            pieces.append(
+                pd.DataFrame(
+                    rows,
+                    columns=data_cols,
+                    index=position + np.arange(len(rows)) / len(rows),
+                )
+            )
+        # Splice via `concat` so pandas widens each column's dtype to fit the
+        # combined values, e.g. a joined name landing in an all-NaN float column.
+        out = (
+            pd.concat([out[~splitting], *pieces])
+            .sort_index(kind="mergesort")
+            .reset_index(drop=True)
         )
-        all_rows.extend(_flatten_cluster(group_rows, cmb, split_cols))
-    out = pd.DataFrame(all_rows, columns=table.columns)
+    # Re-sort chromosomes cleverly instead of lexicographically
     out = out.reindex(
         out.chromosome.apply(sorter_chrom).sort_values(kind="mergesort").index
     )

--- a/skgenome/merge.py
+++ b/skgenome/merge.py
@@ -23,6 +23,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
 _BF_COLS = ("chromosome", "start", "end")
+# Columns that `flatten` apportions across the pieces of a split region, being
+# quantities spread over its length rather than properties of it
+_SPLIT_COLUMNS = ("weight", "probes")
 
 
 def _fill_unnamed(table: pd.DataFrame, cmb: dict[str, Callable]) -> pd.DataFrame:
@@ -84,12 +87,39 @@ def flatten(
     Unlike :func:`merge`, which emits an overlapping group's union as one row,
     this emits one row per distinct sub-interval, so partially overlapping
     regions yield fragments narrower than either input.
+
+    Parameters
+    ----------
+    table : DataFrame
+        Genomic intervals, with at least chromosome, start and end columns.
+        Must be sorted by chromosome, start, end.
+    combine : dict, optional
+        Column-to-function mapping for aggregating the fields of the rows that
+        cover each sub-interval. See :func:`skgenome.combiners.get_combiners`.
+    split_columns : iterable of str, optional
+        Columns holding a quantity spread over the length of a region rather
+        than a property of it -- ``weight`` and ``probes`` by default. Each
+        row's value is apportioned among its sub-intervals in proportion to
+        their lengths before the covering rows are combined, so the column's
+        total is preserved instead of being duplicated into every piece. Pass
+        an empty sequence to combine these columns like any other; columns
+        without a combiner are ignored.
+
+    Returns
+    -------
+    DataFrame
+        A new table with the overlapping rows split at each breakpoint.
     """
     if table.empty:
         return table
     cmb = get_combiners(table, False, combine)
     if _nothing_to_cluster(table, 1):
         return _fill_unnamed(table, cmb)
+    split_cols = {
+        col
+        for col in (_SPLIT_COLUMNS if split_columns is None else split_columns)
+        if col in cmb
+    }
     # NB: Input rows and columns should already be sorted like this
     table = table.sort_values(["chromosome", "start", "end"])
     clustered = bioframe.cluster(
@@ -100,37 +130,49 @@ def flatten(
         group_rows = group.drop(
             columns=["cluster", "cluster_start", "cluster_end"], errors="ignore"
         )
-        all_rows.extend(_flatten_tuples(group_rows, cmb))
-    out = pd.DataFrame.from_records(all_rows, columns=table.columns)
+        all_rows.extend(_flatten_cluster(group_rows, cmb, split_cols))
+    out = pd.DataFrame(all_rows, columns=table.columns)
     out = out.reindex(
         out.chromosome.apply(sorter_chrom).sort_values(kind="mergesort").index
     )
     return _fill_unnamed(out, cmb)
 
 
-def _flatten_tuples(
-    group_df: pd.DataFrame, combine: dict[str, Callable]
-) -> list[tuple]:
-    """Divide multiple rows where they overlap.
+def _flatten_cluster(
+    group_df: pd.DataFrame, combine: dict[str, Callable], split_cols: set[str]
+) -> list[dict]:
+    """Divide one cluster of overlapping rows at each of their breakpoints.
 
-    Split at all coordinate breakpoints and combine extra fields.
+    Every sub-interval draws its values from the rows covering that
+    sub-interval alone: the columns in `combine` through their combiner, the
+    rest from the first covering row. Columns in `split_cols` are apportioned
+    by length before being combined.
     """
+    columns = list(group_df.columns)
     rows = list(group_df.itertuples(index=False))
-    if len(rows) == 1:
-        return rows
-    first_row = rows[0]
-    extra_cols = [x for x in first_row._fields[3:] if x in combine]
-    breaks = sorted(set(itertools.chain(*[(r.start, r.end) for r in rows])))
+    breaks = sorted({bound for row in rows for bound in (row.start, row.end)})
     result = []
     for bp_start, bp_end in itertools.pairwise(breaks):
-        rows_in_play = [
-            row for row in rows if row.start <= bp_start and row.end >= bp_end
-        ]
-        extra_fields = {
-            key: combine[key]([getattr(r, key) for r in rows_in_play])
-            for key in extra_cols
-        }
-        result.append(first_row._replace(start=bp_start, end=bp_end, **extra_fields))
+        # The cluster spans a contiguous range and no breakpoint falls strictly
+        # within this sub-interval, so at least one row covers all of it
+        covering = [row for row in rows if row.start <= bp_start and row.end >= bp_end]
+        piece = {}
+        for col in columns:
+            if col == "start":
+                piece[col] = bp_start
+            elif col == "end":
+                piece[col] = bp_end
+            elif col in combine:
+                values = [getattr(row, col) for row in covering]
+                if col in split_cols:
+                    values = [
+                        val * (bp_end - bp_start) / (row.end - row.start)
+                        for val, row in zip(values, covering, strict=True)
+                    ]
+                piece[col] = combine[col](values)
+            else:
+                piece[col] = getattr(covering[0], col)
+        result.append(piece)
     return result
 
 

--- a/skgenome/merge.py
+++ b/skgenome/merge.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 import bioframe
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_integer_dtype
 
 from .chromsort import sorter_chrom
 from .combiners import first_of, get_combiners, join_strings
@@ -27,6 +26,11 @@ _BF_COLS = ("chromosome", "start", "end")
 # Columns that `flatten` apportions across the pieces of a split region, being
 # quantities spread over its length rather than properties of it
 _SPLIT_COLUMNS = ("weight", "probes")
+# Those of them that count something, and so have no fractional part to give.
+# Not inferred from the column's dtype: 'weight' is a proportion that happens
+# to read as int64 whenever a file's weights are all whole, and 'probes' is a
+# count that reads as float64 whenever one row's field is blank.
+_COUNT_COLUMNS = frozenset({"probes"})
 
 
 def _fill_unnamed(table: pd.DataFrame, cmb: dict[str, Callable]) -> pd.DataFrame:
@@ -78,6 +82,66 @@ def _nothing_to_cluster(table: pd.DataFrame, bp: int) -> bool:
     return bool((changes | (gap_sizes > -bp)).all())
 
 
+def _data_columns(clustered: pd.DataFrame) -> list[str]:
+    """The columns of a `bioframe.cluster` result that came from the input.
+
+    ``cluster``, ``cluster_start`` and ``cluster_end`` are bioframe's to use,
+    so an input column of the same name is shadowed and dropped.
+    """
+    return [
+        col
+        for col in clustered.columns
+        if col not in ("cluster", "cluster_start", "cluster_end")
+    ]
+
+
+def _splice_clusters(
+    clustered: pd.DataFrame,
+    data_cols: list[str],
+    expand: Callable[[pd.DataFrame], list[dict]],
+) -> pd.DataFrame:
+    """Rebuild a clustered table, replacing each multi-row cluster with `expand`.
+
+    Rows that cluster alone are emitted verbatim; only the rows that really
+    cluster together are worth a Python-level pass. When a bait file holds a
+    handful of overlaps nearly every cluster is a singleton, and visiting them
+    all otherwise dominates the runtime.
+
+    `expand` must return at least one row for a cluster: an empty list drops
+    the cluster, and one for every cluster would leave the spliced frame with
+    no values to take its dtypes from.
+    """
+    cluster_ids = clustered["cluster"]
+    is_first = ~cluster_ids.duplicated().to_numpy()
+    in_multi_row_cluster = cluster_ids.duplicated(keep=False).to_numpy()
+    out = clustered.loc[is_first, data_cols].reset_index(drop=True)
+    if not in_multi_row_cluster.any():
+        return out
+    # `groupby(sort=False)` yields clusters in order of first appearance, which
+    # is the order `is_first` picked them out of `out`. The rows replacing a
+    # cluster take the index of the one row standing in for it there, and
+    # `mergesort` is stable, so they keep the order `expand` gave them.
+    changing = in_multi_row_cluster[is_first]
+    rows: list[dict] = []
+    index: list[int] = []
+    for position, (_cluster_id, group) in zip(
+        np.flatnonzero(changing).tolist(),
+        clustered[in_multi_row_cluster].groupby("cluster", sort=False),
+        strict=True,
+    ):
+        new_rows = expand(group)
+        rows.extend(new_rows)
+        index.extend(itertools.repeat(position, len(new_rows)))
+    # Splice via `concat` so pandas widens each column's dtype to fit the
+    # combined values, e.g. a joined name landing in an all-NaN float column.
+    replacement = pd.DataFrame(rows, columns=data_cols, index=index)
+    return (
+        pd.concat([out[~changing], replacement])
+        .sort_index(kind="mergesort")
+        .reset_index(drop=True)
+    )
+
+
 def flatten(
     table: pd.DataFrame,
     combine: dict[str, Callable] | None = None,
@@ -101,16 +165,17 @@ def flatten(
         Columns holding a quantity spread over the length of a region rather
         than a property of it -- ``weight`` and ``probes`` by default. Each
         row's value is apportioned among its sub-intervals in proportion to
-        their lengths before the covering rows are combined, so the column's
-        total is preserved instead of being duplicated into every piece. An
-        integer column stays integral, rounded piece by piece, since a count
-        such as ``probes`` is not meaningful as a fraction. Pass an empty
-        sequence to combine these columns like any other.
+        their lengths before the covering rows are combined, rather than being
+        duplicated whole into every piece. Pass an empty sequence to combine
+        these columns like any other; a column with no combiner is ignored.
 
-        Conservation holds for a column with an additive combiner, the default
-        for both of these, and for regions of positive length: a zero-width
-        row contributes a breakpoint but has no sub-interval to carry its
-        value, so it is dropped as it always has been.
+        The total is preserved exactly, given an additive combiner -- the
+        default for both of these -- and regions of positive length; a
+        zero-width row contributes a breakpoint but has no sub-interval to
+        carry its value, so it is dropped as it always has been. ``probes`` is
+        the exception: it counts bins, which have no fractional part to give,
+        so its shares are rounded piece by piece and its total can drift by up
+        to half a count per piece.
 
     Returns
     -------
@@ -143,69 +208,16 @@ def flatten(
         data_cols,
         lambda group: _flatten_cluster(group[data_cols], cmb, split_cols),
     )
-    # A count stays a count: 'probes' is documented as a number of bins, and
+    # A count stays whole: 'probes' is documented as a number of bins, and
     # `export vcf` reads a fractional probe count as a corrupt segment and drops
     # it. Rounding the shares back costs under one count per piece.
-    for col in split_cols:
-        if is_integer_dtype(table[col]):
-            out[col] = out[col].round().astype(table[col].dtype)
+    for col in split_cols & _COUNT_COLUMNS:
+        out[col] = out[col].round().astype(table[col].dtype)
     # Re-sort chromosomes cleverly instead of lexicographically
     out = out.reindex(
         out.chromosome.apply(sorter_chrom).sort_values(kind="mergesort").index
     )
     return _fill_unnamed(out, cmb)
-
-
-def _data_columns(clustered: pd.DataFrame) -> list[str]:
-    """The columns of a `bioframe.cluster` result that came from the input."""
-    return [
-        col
-        for col in clustered.columns
-        if col not in ("cluster", "cluster_start", "cluster_end")
-    ]
-
-
-def _splice_clusters(
-    clustered: pd.DataFrame,
-    data_cols: list[str],
-    expand: Callable[[pd.DataFrame], list[dict]],
-) -> pd.DataFrame:
-    """Rebuild a clustered table, replacing each multi-row cluster with `expand`.
-
-    Rows that cluster alone are emitted verbatim; only the rows that really
-    cluster together are worth a Python-level pass. When a bait file holds a
-    handful of overlaps nearly every cluster is a singleton, and visiting them
-    all otherwise dominates the runtime.
-    """
-    cluster_ids = clustered["cluster"]
-    is_first = ~cluster_ids.duplicated().to_numpy()
-    in_multi_row_cluster = cluster_ids.duplicated(keep=False).to_numpy()
-    out = clustered.loc[is_first, data_cols].reset_index(drop=True)
-    if not in_multi_row_cluster.any():
-        return out
-    # `groupby(sort=False)` yields clusters in order of first appearance, which
-    # is the order `is_first` picked them out of `out`. The rows replacing a
-    # cluster take the index of the one row standing in for it there, and
-    # `mergesort` is stable, so they keep the order `expand` gave them.
-    changing = in_multi_row_cluster[is_first]
-    rows: list[dict] = []
-    index: list[int] = []
-    for position, (_cluster_id, group) in zip(
-        np.flatnonzero(changing).tolist(),
-        clustered[in_multi_row_cluster].groupby("cluster", sort=False),
-        strict=True,
-    ):
-        new_rows = expand(group)
-        rows.extend(new_rows)
-        index.extend(itertools.repeat(position, len(new_rows)))
-    # Splice via `concat` so pandas widens each column's dtype to fit the
-    # combined values, e.g. a joined name landing in an all-NaN float column.
-    replacement = pd.DataFrame(rows, columns=data_cols, index=index)
-    return (
-        pd.concat([out[~changing], replacement])
-        .sort_index(kind="mergesort")
-        .reset_index(drop=True)
-    )
 
 
 def _flatten_cluster(
@@ -312,7 +324,12 @@ def merge(
     data_cols = _data_columns(clustered)
 
     def combine_cluster(group: pd.DataFrame) -> list[dict]:
-        """Combine one cluster's rows into the single row of their union."""
+        """Combine one cluster's rows into the single row of their union.
+
+        A closure rather than a module-level helper because it reads the
+        cluster bounds, which `_data_columns` leaves out of the group frame
+        that the combined columns come from.
+        """
         vals = {}
         for col in data_cols:
             if col == "start":

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -514,7 +514,8 @@ class IntervalTests(unittest.TestCase):
             ],
         )
         # A table with no overlaps at all passes through unchanged
-        disjoint = GA(regions.data.iloc[6:].reset_index(drop=True))
+        chr3_only = regions.data[regions.data.chromosome == "chr3"]
+        disjoint = GA(chr3_only.reset_index(drop=True))
         self.assertTrue(disjoint.flatten().data.equals(disjoint.data))
 
     def test_flatten_apportions_split_columns(self):
@@ -555,6 +556,17 @@ class IntervalTests(unittest.TestCase):
         plain = regions.flatten(split_columns=())
         self.assertEqual(list(plain["weight"]), [4.0, 7.0, 3.0])
         self.assertEqual(list(plain["probes"]), [7, 12, 5])
+
+        # Which column rounds is decided by what it means, not by the dtype it
+        # happens to arrive with. A file whose weights are all whole is written
+        # as bare integers and reads back as int64, but a weight is a
+        # proportion, so rounding it would zero every share below a half.
+        whole_weights = GA(regions.data.assign(weight=np.array([4, 3], dtype=np.int64)))
+        self.assertEqual(list(whole_weights.flatten()["weight"]), [3.0, 2.0, 2.0])
+        # A blank field in one row makes 'probes' float-typed, and it is still
+        # a count: the shares round, and stay whole for `export vcf`
+        float_probes = GA(regions.data.assign(probes=[7.0, 5.0]))
+        self.assertEqual(list(float_probes.flatten()["probes"]), [5.0, 3.0, 3.0])
 
     def test_merge(self):
         merged_coords_1 = [(1, 23, "ABCDE")]

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -453,6 +453,99 @@ class IntervalTests(unittest.TestCase):
             expect = self._from_intervals(flat_coords)
             self._compare_regions(result, expect)
 
+    def test_flatten_fields_follow_the_covering_rows(self):
+        """Each sub-interval takes its fields from the rows that cover it.
+
+        Columns with no combiner -- log2, depth, gc and the rest of a .cnr's
+        payload -- were copied from the first row of the whole overlap cluster,
+        so a piece belonging solely to a later region reported an earlier
+        region's coverage. Bookended rows were caught by this too: they
+        clustered together, and one overlap anywhere in a table sends every
+        cluster through the splitting path.
+
+        chr1 and chr2 each hold an overlapping pair plus an isolated region,
+        after and before the pair respectively, so the pieces have to be
+        interleaved back among the rows that pass through unsplit. chr3 is a
+        bookended run, which has no breakpoint to split at.
+        """
+        regions = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * 3 + ["chr2"] * 3 + ["chr3"] * 3,
+                    "start": [0, 50, 400, 0, 300, 500, 0, 100, 200],
+                    "end": [100, 200, 500, 100, 600, 700, 100, 200, 300],
+                    "gene": [*"ABC", *"PQR", *"XYZ"],
+                    "log2": [1.0, -2.0, 9.0, 3.0, 4.0, 5.0, 7.0, 7.5, 8.0],
+                }
+            )
+        )
+        flat = regions.flatten()
+        self.assertEqual(
+            list(
+                zip(
+                    flat.chromosome,
+                    flat.start,
+                    flat.end,
+                    flat["gene"],
+                    flat["log2"],
+                    strict=True,
+                )
+            ),
+            [
+                ("chr1", 0, 50, "A", 1.0),
+                ("chr1", 50, 100, "A,B", 1.0),
+                ("chr1", 100, 200, "B", -2.0),
+                ("chr1", 400, 500, "C", 9.0),
+                ("chr2", 0, 100, "P", 3.0),
+                ("chr2", 300, 500, "Q", 4.0),
+                ("chr2", 500, 600, "Q,R", 4.0),
+                ("chr2", 600, 700, "R", 5.0),
+                ("chr3", 0, 100, "X", 7.0),
+                ("chr3", 100, 200, "Y", 7.5),
+                ("chr3", 200, 300, "Z", 8.0),
+            ],
+        )
+        # A table with no overlaps at all passes through unchanged
+        disjoint = GA(regions.data.iloc[6:].reset_index(drop=True))
+        self.assertTrue(disjoint.flatten().data.equals(disjoint.data))
+
+    def test_flatten_apportions_split_columns(self):
+        """'weight' and 'probes' are divided among the pieces of a region.
+
+        They quantify a region rather than describe it, so splitting a region
+        has to divide them: replicating each row's whole value into every piece
+        inflated the totals, most starkly on the one-base slivers that .cns
+        files with off-by-one segment boundaries flatten into.
+        """
+        regions = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": "chr0",
+                    "start": [0, 300],
+                    "end": [400, 500],
+                    "gene": ["A", "B"],
+                    "weight": [4.0, 2.0],
+                    "probes": [8, 4],
+                }
+            )
+        )
+        flat = regions.flatten()
+        # A gives 3/4 of itself to chr0:0-300 and 1/4 to chr0:300-400, which B
+        # halves with chr0:400-500 -- shares of length, not equal shares
+        self.assertEqual(
+            list(
+                zip(flat.start, flat.end, flat["weight"], flat["probes"], strict=True)
+            ),
+            [(0, 300, 3.0, 6.0), (300, 400, 2.0, 4.0), (400, 500, 1.0, 2.0)],
+        )
+        self.assertAlmostEqual(flat["weight"].sum(), regions["weight"].sum())
+        self.assertAlmostEqual(flat["probes"].sum(), regions["probes"].sum())
+        # Opting out combines them like any other column, so each row's value
+        # reappears whole in every piece it was split into
+        plain = regions.flatten(split_columns=())
+        self.assertEqual(list(plain["weight"]), [4.0, 6.0, 2.0])
+        self.assertEqual(list(plain["probes"]), [8, 12, 4])
+
     def test_merge(self):
         merged_coords_1 = [(1, 23, "ABCDE")]
         merged_coords_2 = [(3, 42, "ABCDEFGHI")]

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -9,6 +9,7 @@ import unittest
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_integer_dtype
 
 from cnvlib import read_ga
 from skgenome import GenomicArray as GA
@@ -466,16 +467,21 @@ class IntervalTests(unittest.TestCase):
         chr1 and chr2 each hold an overlapping pair plus an isolated region,
         after and before the pair respectively, so the pieces have to be
         interleaved back among the rows that pass through unsplit. chr3 is a
-        bookended run, which has no breakpoint to split at.
+        bookended run, which has no breakpoint to split at, ending in a
+        zero-width region that only a clustering rule coarser than "genuinely
+        overlapping" would swallow.
         """
         regions = GA(
             pd.DataFrame(
                 {
-                    "chromosome": ["chr1"] * 3 + ["chr2"] * 3 + ["chr3"] * 3,
-                    "start": [0, 50, 400, 0, 300, 500, 0, 100, 200],
-                    "end": [100, 200, 500, 100, 600, 700, 100, 200, 300],
-                    "gene": [*"ABC", *"PQR", *"XYZ"],
-                    "log2": [1.0, -2.0, 9.0, 3.0, 4.0, 5.0, 7.0, 7.5, 8.0],
+                    "chromosome": ["chr1"] * 3 + ["chr2"] * 3 + ["chr3"] * 4,
+                    "start": [0, 50, 400, 0, 300, 500, 0, 100, 200, 300],
+                    "end": [100, 200, 500, 100, 600, 700, 100, 200, 300, 300],
+                    "gene": [*"ABC", *"PQR", *"XYZW"],
+                    "log2": [1.0, -2.0, 9.0, 3.0, 4.0, 5.0, 7.0, 7.5, 8.0, 8.5],
+                    # Not a Python identifier: a tabular input's header is the
+                    # user's own, and `itertuples` renames what it cannot use
+                    "GC content": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
                 }
             )
         )
@@ -488,21 +494,23 @@ class IntervalTests(unittest.TestCase):
                     flat.end,
                     flat["gene"],
                     flat["log2"],
+                    flat["GC content"],
                     strict=True,
                 )
             ),
             [
-                ("chr1", 0, 50, "A", 1.0),
-                ("chr1", 50, 100, "A,B", 1.0),
-                ("chr1", 100, 200, "B", -2.0),
-                ("chr1", 400, 500, "C", 9.0),
-                ("chr2", 0, 100, "P", 3.0),
-                ("chr2", 300, 500, "Q", 4.0),
-                ("chr2", 500, 600, "Q,R", 4.0),
-                ("chr2", 600, 700, "R", 5.0),
-                ("chr3", 0, 100, "X", 7.0),
-                ("chr3", 100, 200, "Y", 7.5),
-                ("chr3", 200, 300, "Z", 8.0),
+                ("chr1", 0, 50, "A", 1.0, 0.1),
+                ("chr1", 50, 100, "A,B", 1.0, 0.1),
+                ("chr1", 100, 200, "B", -2.0, 0.2),
+                ("chr1", 400, 500, "C", 9.0, 0.3),
+                ("chr2", 0, 100, "P", 3.0, 0.4),
+                ("chr2", 300, 500, "Q", 4.0, 0.5),
+                ("chr2", 500, 600, "Q,R", 4.0, 0.5),
+                ("chr2", 600, 700, "R", 5.0, 0.6),
+                ("chr3", 0, 100, "X", 7.0, 0.7),
+                ("chr3", 100, 200, "Y", 7.5, 0.8),
+                ("chr3", 200, 300, "Z", 8.0, 0.9),
+                ("chr3", 300, 300, "W", 8.5, 1.0),
             ],
         )
         # A table with no overlaps at all passes through unchanged
@@ -522,29 +530,31 @@ class IntervalTests(unittest.TestCase):
                 {
                     "chromosome": "chr0",
                     "start": [0, 300],
-                    "end": [400, 500],
+                    "end": [400, 600],
                     "gene": ["A", "B"],
-                    "weight": [4.0, 2.0],
-                    "probes": [8, 4],
+                    "weight": [4.0, 3.0],
+                    "probes": [7, 5],
                 }
             )
         )
         flat = regions.flatten()
-        # A gives 3/4 of itself to chr0:0-300 and 1/4 to chr0:300-400, which B
-        # halves with chr0:400-500 -- shares of length, not equal shares
+        # A gives 3/4 of itself to chr0:0-300 and 1/4 to chr0:300-400, where B
+        # adds a third of itself -- shares of length, not equal shares
         self.assertEqual(
-            list(
-                zip(flat.start, flat.end, flat["weight"], flat["probes"], strict=True)
-            ),
-            [(0, 300, 3.0, 6.0), (300, 400, 2.0, 4.0), (400, 500, 1.0, 2.0)],
+            list(zip(flat.start, flat.end, flat["weight"], strict=True)),
+            [(0, 300, 3.0), (300, 400, 2.0), (400, 600, 2.0)],
         )
         self.assertAlmostEqual(flat["weight"].sum(), regions["weight"].sum())
-        self.assertAlmostEqual(flat["probes"].sum(), regions["probes"].sum())
+        # A count has no fractional part to give: the shares 5.25 / 3.42 / 3.33
+        # are rounded, and the column keeps its integer type, or `export vcf`
+        # would read every piece as a segment with a corrupt probe count
+        self.assertEqual(list(flat["probes"]), [5, 3, 3])
+        self.assertTrue(is_integer_dtype(flat["probes"]))
         # Opting out combines them like any other column, so each row's value
         # reappears whole in every piece it was split into
         plain = regions.flatten(split_columns=())
-        self.assertEqual(list(plain["weight"]), [4.0, 6.0, 2.0])
-        self.assertEqual(list(plain["probes"]), [8, 12, 4])
+        self.assertEqual(list(plain["weight"]), [4.0, 7.0, 3.0])
+        self.assertEqual(list(plain["probes"]), [7, 12, 5])
 
     def test_merge(self):
         merged_coords_1 = [(1, 23, "ABCDE")]


### PR DESCRIPTION
`GenomicArray.flatten` splits overlapping regions at every breakpoint, emitting one row per distinct sub-interval. Two defects, both found while reviewing #1144.

## Each sub-interval now takes its fields from the rows covering it

Every piece was built from the first row of the whole overlap cluster, recomputing only the columns that have a combiner. Everything else — `log2`, `depth`, `gc`, `rmask`, `spread` — was inherited from that row, so a piece belonging solely to a later region reported an earlier region's coverage.

Bookended regions were caught by this as well. They clustered together, and a single overlap anywhere in a table sends every cluster through the splitting path, so a run of consecutive bins could all take the first bin's values:

```
                        before                  after
chr1  0-50    A         log2  1.0               1.0
chr1  50-100  A,B       log2  1.0               1.0
chr1  100-200 B         log2  1.0    <- A's     -2.0
chr2  0-100   G0        log2  0.0               0.0
chr2  100-200 G1        log2  0.0    <- G0's    1.0
chr2  200-300 G2        log2  0.0    <- G0's    2.0
```

A piece now draws its values from the rows covering that piece alone, the way `merge` combines a cluster: through the combiner where there is one, otherwise from the first covering row. Only rows that genuinely overlap are clustered, since bookended rows share no breakpoint to split at.

## `weight` and `probes` are divided among a region's pieces

They quantify a region rather than describe it, so splitting a region has to divide them; duplicating each row's whole value into every piece inflated the totals. On `test/formats/tr95t.cns`, whose segment boundaries overlap by one base, `probes` totalled 42085 out of an input of 27058, and one-base slivers claimed hundreds of probes each. Totals are now preserved.

This completes the intent of the `split_columns` parameter, an unused stub on `flatten` and `GenomicArray.flatten` since 2018 (395d52c). Passing an empty sequence restores the previous behaviour.

`probes` counts bins, which have no fractional part to give, so its shares are rounded and it keeps whole values; `export vcf` reads a fractional probe count as a segment written by the buggy v0.7.1 release and drops it (#53). Which column rounds is decided by what it means rather than by its dtype: a file whose weights are all whole is written as bare integers and reads back as int64, and a `.cns` with one blank probes field reads as float64.

## Singleton clusters are no longer walked in Python

`merge` stopped doing this in #1144; `flatten` now does the same. A 216k-row exome BED holding three duplicate baits goes from 49.8 s to 0.25 s, and 100k rows forming 50k two-row overlap clusters from 509 s to 20 s. Output is unchanged.

## Scope

No CNVkit pipeline output changes. `target` and `batch` reach `merge`, not `flatten`; the exposed callers are `skg_convert --flatten`, which writes bed4, and library users of `GenomicArray.flatten`. `merge` itself gives byte-identical output at `bp` of 0, 1 and -100 on every region file under `test/formats/`, and `cnvkit.py target` is byte-identical over 46 invocations across 7 bait files and 5 option sets.

Since #1144 made `merge` and `flatten` meaningfully different operators, `skg_convert`'s help and the `guess_baits.py` notes now steer bait files to `--merge`.
