### PR TITLE
Keep bioframe's bookkeeping columns out of the user's

### DIFF
--- a/skgenome/gary.py
+++ b/skgenome/gary.py
@@ -19,8 +19,6 @@ from .chromnames import (
 from .chromsort import sorter_chrom
 from .cut import cut
 from .intersect import Numeric, by_ranges, into_ranges, iter_ranges, iter_slices
-
-_BF_COLS = ("chromosome", "start", "end")
 from .merge import flatten, merge, squash
 from .rangelabel import to_label
 from .subdivide import subdivide
@@ -32,6 +30,8 @@ if TYPE_CHECKING:
     from numpy import ndarray
 
     from cnvlib.cnary import CopyNumArray
+
+_BF_COLS = ("chromosome", "start", "end")
 
 
 class GenomicArray:
@@ -749,26 +749,39 @@ class GenomicArray:
             return self.as_dataframe(pd.concat(chunks))
         if not len(self) or not len(other):
             return self.as_dataframe(self.data.iloc[:0])
+        # Take from bioframe only its pairing of the rows: with `return_input`
+        # it also returns index, index_ and the two inputs' coordinates
+        # suffixed apart, in the same frame as the user's columns, where a
+        # column of the input can share one of those names -- `read_tab`
+        # accepts arbitrary extra columns, so any name can arrive from a file,
+        # and none of them is ours to reserve. Indexing both inputs from zero
+        # makes the labels bioframe reports positions instead, so the pairing
+        # is independent of whatever labels the caller's rows carry.
+        mine = self.data.reset_index(drop=True)
+        theirs = other.data.reset_index(drop=True)
         pairs = bioframe.overlap(
-            self.data,
-            other.data,
+            mine,
+            theirs,
             how="inner",
             cols1=_BF_COLS,
             cols2=_BF_COLS,
             return_index=True,
-            return_input=True,
+            return_input=False,
         )
         if mode == "inner":
             # Keep only self bins fully contained within an other bin
+            rows = pairs["index"].to_numpy(dtype=int)
+            covering = pairs["index_"].to_numpy(dtype=int)
             pairs = pairs[
-                (pairs["start"] >= pairs["start_"]) & (pairs["end"] <= pairs["end_"])
+                (mine.start.to_numpy()[rows] >= theirs.start.to_numpy()[covering])
+                & (mine.end.to_numpy()[rows] <= theirs.end.to_numpy()[covering])
             ]
-        # Sort by `other`'s index labels then `self`'s; with `other`'s usual
-        # monotonic index this reproduces `by_ranges`' row order
+        # Sort by `other`'s rows then `self`'s, which reproduces `by_ranges`'
+        # row order
         pairs = pairs.sort_values(["index_", "index"])
-        # Return self rows (with duplicates, one per overlap pair)
-        self_indices = pairs["index"].to_numpy()
-        return self.as_dataframe(self.data.loc[self_indices])
+        # Return self rows (with duplicates, one per overlap pair), taken by
+        # position, since `mine` is `self.data` row for row
+        return self.as_dataframe(self.data.iloc[pairs["index"].to_numpy(dtype=int)])
 
     def merge(
         self,

--- a/skgenome/gary.py
+++ b/skgenome/gary.py
@@ -741,14 +741,17 @@ class GenomicArray:
 
         The extra fields of `self`, but not `other`, are retained in the output.
         """
+        if not len(self) or not len(other):
+            return self.as_dataframe(self.data.iloc[:0])
         if mode == "trim":
             chunks = [
                 chunk.data
                 for _, chunk in self.by_ranges(other, mode=mode, keep_empty=False)
             ]
+            # Nothing overlaps, so there is nothing to concatenate
+            if not chunks:
+                return self.as_dataframe(self.data.iloc[:0])
             return self.as_dataframe(pd.concat(chunks))
-        if not len(self) or not len(other):
-            return self.as_dataframe(self.data.iloc[:0])
         # Take from bioframe only its pairing of the rows: with `return_input`
         # it also returns index, index_ and the two inputs' coordinates
         # suffixed apart, in the same frame as the user's columns, where a

--- a/skgenome/merge.py
+++ b/skgenome/merge.py
@@ -82,25 +82,18 @@ def _nothing_to_cluster(table: pd.DataFrame, bp: int) -> bool:
     return bool((changes | (gap_sizes > -bp)).all())
 
 
-def _data_columns(clustered: pd.DataFrame) -> list[str]:
-    """The columns of a `bioframe.cluster` result that came from the input.
-
-    ``cluster``, ``cluster_start`` and ``cluster_end`` are bioframe's to use,
-    so an input column of the same name is shadowed and dropped.
-    """
-    return [
-        col
-        for col in clustered.columns
-        if col not in ("cluster", "cluster_start", "cluster_end")
-    ]
-
-
 def _splice_clusters(
-    clustered: pd.DataFrame,
-    data_cols: list[str],
+    table: pd.DataFrame,
+    cluster_ids: np.ndarray,
     expand: Callable[[pd.DataFrame], list[dict]],
 ) -> pd.DataFrame:
-    """Rebuild a clustered table, replacing each multi-row cluster with `expand`.
+    """Rebuild `table`, replacing each multi-row cluster with `expand`.
+
+    `cluster_ids` labels the rows of `table` with the cluster each belongs to,
+    row for row -- an array, so that it cannot align on the table's index
+    instead. Keeping it out of `table` is what lets an input column be named
+    ``cluster``: `bioframe.cluster` is asked for its own bookkeeping alone, so
+    its names and the user's never share a frame.
 
     Rows that cluster alone are emitted verbatim; only the rows that really
     cluster together are worth a Python-level pass. When a bait file holds a
@@ -111,10 +104,10 @@ def _splice_clusters(
     the cluster, and one for every cluster would leave the spliced frame with
     no values to take its dtypes from.
     """
-    cluster_ids = clustered["cluster"]
-    is_first = ~cluster_ids.duplicated().to_numpy()
-    in_multi_row_cluster = cluster_ids.duplicated(keep=False).to_numpy()
-    out = clustered.loc[is_first, data_cols].reset_index(drop=True)
+    ids = pd.Index(cluster_ids)
+    is_first = ~ids.duplicated()
+    in_multi_row_cluster = ids.duplicated(keep=False)
+    out = table[is_first].reset_index(drop=True)
     if not in_multi_row_cluster.any():
         return out
     # `groupby(sort=False)` yields clusters in order of first appearance, which
@@ -126,7 +119,9 @@ def _splice_clusters(
     index: list[int] = []
     for position, (_cluster_id, group) in zip(
         np.flatnonzero(changing).tolist(),
-        clustered[in_multi_row_cluster].groupby("cluster", sort=False),
+        table[in_multi_row_cluster].groupby(
+            cluster_ids[in_multi_row_cluster], sort=False
+        ),
         strict=True,
     ):
         new_rows = expand(group)
@@ -134,7 +129,7 @@ def _splice_clusters(
         index.extend(itertools.repeat(position, len(new_rows)))
     # Splice via `concat` so pandas widens each column's dtype to fit the
     # combined values, e.g. a joined name landing in an all-NaN float column.
-    replacement = pd.DataFrame(rows, columns=data_cols, index=index)
+    replacement = pd.DataFrame(rows, columns=table.columns, index=index)
     return (
         pd.concat([out[~changing], replacement])
         .sort_index(kind="mergesort")
@@ -195,18 +190,21 @@ def flatten(
         if col in cmb
     }
     # NB: Input rows and columns should already be sorted like this
-    table = table.sort_values(["chromosome", "start", "end"])
+    table = table.sort_values(["chromosome", "start", "end"], ignore_index=True)
     # Bookended rows share no breakpoint to split at, so cluster only the rows
     # that genuinely overlap -- the same distinction `_nothing_to_cluster`
-    # makes above when it lets a whole table through.
-    clustered = bioframe.cluster(
-        table, min_dist=None, cols=_BF_COLS, return_cluster_ids=True
-    )
-    data_cols = _data_columns(clustered)
+    # makes above when it lets a whole table through. Ask for the cluster ids
+    # alone: bioframe's other output would collide with a column of the input.
+    cluster_ids = bioframe.cluster(
+        table,
+        min_dist=None,
+        cols=_BF_COLS,
+        return_input=False,
+        return_cluster_ids=True,
+        return_cluster_intervals=False,
+    )["cluster"].to_numpy()
     out = _splice_clusters(
-        clustered,
-        data_cols,
-        lambda group: _flatten_cluster(group[data_cols], cmb, split_cols),
+        table, cluster_ids, lambda group: _flatten_cluster(group, cmb, split_cols)
     )
     # A count stays whole: 'probes' is documented as a number of bins, and
     # `export vcf` reads a fractional probe count as a corrupt segment and drops
@@ -310,44 +308,49 @@ def merge(
     if _nothing_to_cluster(table, bp):
         return _fill_unnamed(table, cmb)
     groupkey = ["chromosome", "strand"] if stranded else ["chromosome"]
-    table = table.sort_values([*groupkey, "start", "end"])
+    table = table.sort_values([*groupkey, "start", "end"], ignore_index=True)
     min_dist = None if bp == 1 else -bp
     on = ["strand"] if stranded else None
-    clustered = bioframe.cluster(
+    # The cluster ids alone: bioframe's other output, the cluster's own
+    # interval, would collide with a column of the input, and is just the
+    # extent of the rows that `_merge_cluster` combines anyway.
+    cluster_ids = bioframe.cluster(
         table,
         min_dist=min_dist,
         cols=_BF_COLS,
         on=on,
+        return_input=False,
         return_cluster_ids=True,
-        return_cluster_intervals=True,
+        return_cluster_intervals=False,
+    )["cluster"].to_numpy()
+    out = _splice_clusters(
+        table, cluster_ids, lambda group: [_merge_cluster(group, cmb)]
     )
-    data_cols = _data_columns(clustered)
-
-    def combine_cluster(group: pd.DataFrame) -> list[dict]:
-        """Combine one cluster's rows into the single row of their union.
-
-        A closure rather than a module-level helper because it reads the
-        cluster bounds, which `_data_columns` leaves out of the group frame
-        that the combined columns come from.
-        """
-        vals = {}
-        for col in data_cols:
-            if col == "start":
-                vals[col] = group["cluster_start"].iloc[0]
-            elif col == "end":
-                vals[col] = group["cluster_end"].iloc[0]
-            elif col in cmb:
-                vals[col] = cmb[col](group[col].values)
-            else:
-                vals[col] = group[col].iloc[0]
-        return [vals]
-
-    out = _splice_clusters(clustered, data_cols, combine_cluster)
     # Re-sort chromosomes cleverly instead of lexicographically
     out = out.reindex(
         out.chromosome.apply(sorter_chrom).sort_values(kind="mergesort").index
     )
     return _fill_unnamed(out, cmb)
+
+
+def _merge_cluster(group_df: pd.DataFrame, cmb: dict[str, Callable]) -> dict:
+    """Combine one group of rows into the single row spanning them.
+
+    The rows need not overlap: `merge` groups rows that reach each other
+    within a given gap, and `squash` consecutive rows that are bookended, so
+    the row emitted spans their whole extent.
+    """
+    vals = {}
+    for col in group_df.columns:
+        if col == "start":
+            vals[col] = group_df["start"].min()
+        elif col == "end":
+            vals[col] = group_df["end"].max()
+        elif col in cmb:
+            vals[col] = cmb[col](group_df[col].values)
+        else:
+            vals[col] = group_df[col].iloc[0]
+    return vals
 
 
 def squash(

--- a/skgenome/merge.py
+++ b/skgenome/merge.py
@@ -407,16 +407,8 @@ def squash(
         if len(group) == 1:
             result_rows.append(group.iloc[0])
         else:
-            vals: dict = {}
-            for col in table.columns:
-                if col == "start":
-                    vals[col] = group["start"].iloc[0]
-                elif col == "end":
-                    vals[col] = group["end"].iloc[-1]
-                elif col in cmb:
-                    vals[col] = cmb[col](group[col].values)
-                else:
-                    vals[col] = group[col].iloc[0]
-            result_rows.append(pd.Series(vals))
+            # A run of bookended rows spans from the first row's start to the
+            # last row's end, which is what `_merge_cluster` emits for a group
+            result_rows.append(pd.Series(_merge_cluster(group, cmb)))
     out = pd.DataFrame(result_rows, columns=table.columns).reset_index(drop=True)
     return _fill_unnamed(out, cmb)

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -635,6 +635,98 @@ class IntervalTests(unittest.TestCase):
             [(100, 250), (500, 600)],
         )
 
+    def test_columns_named_like_bioframe_bookkeeping(self):
+        """A column named cluster/cluster_start/cluster_end is the user's own.
+
+        ``bioframe.cluster``, which merge and flatten group rows with, used to
+        be asked for its bookkeeping alongside the input, and it names that
+        bookkeeping cluster/cluster_start/cluster_end. An input column of the
+        same name was duplicated rather than replaced. Under the name
+        ``cluster`` the duplicate label made the cluster ids a whole DataFrame,
+        so rows were grouped by bioframe's id and the user's value together and
+        genuinely overlapping rows came through unmerged and unsplit -- wrong
+        coordinates, not merely a lost column. Under ``cluster_start`` or
+        ``cluster_end``, merge read the same DataFrame where it expected one
+        coordinate and raised ``TypeError``, while flatten dropped the column
+        silently. ``tabio.read_tab`` accepts arbitrary extra columns, so a
+        header is user data, and 'cluster' is an unremarkable name for a bait
+        or sample label.
+
+        The damage was data-dependent: a table with nothing to cluster passes
+        through verbatim, so the same pipeline mangled or preserved the same
+        column according to whether that particular file held an overlap.
+        """
+        expect = {
+            # Two rows overlapping: merged into one, split into three
+            ("overlapping", "merge"): [10],
+            ("overlapping", "flatten"): [10, 10, 20],
+            # Nothing to cluster: both pass the rows through untouched
+            ("disjoint", "merge"): [10, 20],
+            ("disjoint", "flatten"): [10, 20],
+        }
+        bounds = {
+            "overlapping": ([0, 50], [100, 200]),
+            "disjoint": ([0, 500], [100, 600]),
+        }
+        for name in ("cluster", "cluster_start", "cluster_end"):
+            for layout, (starts, ends) in bounds.items():
+                regions = GA(
+                    pd.DataFrame(
+                        {
+                            "chromosome": "chr0",
+                            "start": starts,
+                            "end": ends,
+                            "gene": ["A", "B"],
+                            name: [10, 20],
+                        }
+                    )
+                )
+                for op in ("merge", "flatten"):
+                    with self.subTest(column=name, table=layout, op=op):
+                        result = getattr(regions, op)()
+                        self.assertEqual(list(result[name]), expect[layout, op])
+
+        # Every route a column can take treats these names like any other: all
+        # three at once, combined by a caller's own function...
+        overlapping = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": "chr0",
+                    "start": [0, 50],
+                    "end": [100, 200],
+                    "cluster": [10, 20],
+                    "cluster_start": [1, 2],
+                    "cluster_end": [3, 4],
+                }
+            )
+        )
+        merged = overlapping.merge()
+        self.assertEqual(
+            [merged[col].iloc[0] for col in overlapping.data.columns],
+            ["chr0", 0, 200, 10, 1, 3],
+        )
+        self.assertEqual(
+            list(overlapping.merge(combine={"cluster": sum})["cluster"]), [30]
+        )
+        # ...and apportioned by length as a quantity spread over the region,
+        # where the column's name must not decide whether the division happens
+        shares = []
+        for name in ("extra", "cluster_start"):
+            regions = GA(
+                pd.DataFrame(
+                    {
+                        "chromosome": "chr0",
+                        "start": [0, 50],
+                        "end": [100, 200],
+                        name: [1.0, 2.0],
+                    }
+                )
+            )
+            pieces = regions.flatten(combine={name: sum}, split_columns=(name,))
+            shares.append(list(pieces[name]))
+        self.assertEqual(shares[0], shares[1])
+        self.assertAlmostEqual(sum(shares[1]), 3.0)
+
     def test_nan_gene_names(self):
         """merge/flatten/subdivide tolerate NaN-float gene names (issue #850).
 

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -990,6 +990,76 @@ class IntervalTests(unittest.TestCase):
                 )
                 self._compare_regions(result, expect)
 
+    def test_intersect_columns_named_like_bioframe_bookkeeping(self):
+        """A column named index/index_/start_/end_ is the user's own.
+
+        ``intersection`` pairs rows with ``bioframe.overlap``, which returns
+        its own ``index`` and ``index_`` columns and, when asked for the inputs
+        as well, the second one's coordinates suffixed apart as ``start_`` and
+        ``end_``. An input column of one of those four names duplicated a label
+        the code then read: ``index`` and ``index_`` raised ``ValueError``
+        naming the column as not unique, and ``start_``/``end_`` raised
+        ``ValueError: Operands are not aligned`` in the 'inner' mode that is
+        the only one to compare them.
+
+        Index labels no longer influence the result at all, since the rows are
+        addressed by position: a duplicated label resolved through ``.loc`` to
+        every row that shared it, and ``other``'s labels, rather than its row
+        order, decided which of its regions was reported first.
+
+        chr0:650-750 overlaps the first selection without being contained in
+        it, so 'inner' keeps one pairing fewer than 'outer', and 'trim' clips
+        it to the selection's end. chr0:5000-5100 overlaps nothing.
+        """
+        regions = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": "chr0",
+                    "start": [0, 500, 650, 900, 5000],
+                    "end": [100, 600, 750, 1000, 5100],
+                    "gene": [*"ABECZ"],
+                }
+            )
+        )
+        selections = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": "chr0",
+                    "start": [0, 450],
+                    "end": [700, 1000],
+                    "gene": ["X", "Y"],
+                }
+            )
+        )
+        expect = {
+            "outer": [10, 20, 30, 20, 30, 40],
+            "inner": [10, 20, 20, 30, 40],
+            "trim": [10, 20, 30, 20, 30, 40],
+        }
+        for name in ("index", "index_", "start_", "end_"):
+            labelled = GA(regions.data.assign(**{name: [10, 20, 30, 40, 50]}))
+            for mode in ("outer", "inner", "trim"):
+                with self.subTest(column=name, mode=mode):
+                    result = labelled.intersection(selections, mode=mode)
+                    self.assertEqual(list(result[name]), expect[mode])
+
+        # A duplicated label -- as a table assembled from several sources
+        # carries -- once selected every row that shared it, so the pairings of
+        # A, B, E and C dragged in the region that overlaps nothing
+        duped = GA(regions.data.set_axis([0, 1, 0, 1, 0], axis=0))
+        want = regions.intersection(selections)
+        got = duped.intersection(selections)
+        self.assertEqual(
+            list(zip(got.start, got["gene"], strict=True)),
+            list(zip(want.start, want["gene"], strict=True)),
+        )
+        self.assertEqual(len(got), 6)
+        # `other`'s rows are reported in its own order, not its labels'
+        relabelled = GA(selections.data.set_axis([5, 1], axis=0))
+        self.assertEqual(
+            list(regions.intersection(relabelled)["gene"]), list(want["gene"])
+        )
+
     def test_subtract(self):
         # Test cases:
         #  | access: ====   ====   ====    ==========

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -1060,6 +1060,38 @@ class IntervalTests(unittest.TestCase):
             list(regions.intersection(relabelled)["gene"]), list(want["gene"])
         )
 
+    def test_intersect_nothing_to_select(self):
+        """Selecting nothing gives an empty array in every mode, not an error.
+
+        'trim' concatenates the pieces ``by_ranges`` yields, and ``pd.concat``
+        raises on an empty list, so a selection that nothing overlaps -- or an
+        empty array on either side -- ended in ``ValueError: No objects to
+        concatenate``, while the other two modes returned an empty array. The
+        guard for the empty inputs sat below the 'trim' branch, so it never
+        applied to it.
+        """
+        region = GA(
+            pd.DataFrame(
+                {"chromosome": ["chr1"], "start": [10], "end": [20], "gene": ["A"]}
+            )
+        )
+        empty = GA(region.data.iloc[:0])
+        selections = {
+            "empty": empty,
+            "disjoint": GA(region.data.assign(start=100, end=200)),
+            "other chromosome": GA(region.data.assign(chromosome="chrZ")),
+        }
+        for label, selection in selections.items():
+            for mode in ("outer", "inner", "trim"):
+                with self.subTest(selection=label, mode=mode):
+                    result = region.intersection(selection, mode=mode)
+                    self.assertEqual(len(result), 0)
+                    self.assertEqual(
+                        list(result.data.columns), list(region.data.columns)
+                    )
+                with self.subTest(empty_self=True, mode=mode):
+                    self.assertEqual(len(empty.intersection(region, mode=mode)), 0)
+
     def test_subtract(self):
         # Test cases:
         #  | access: ====   ====   ====    ==========


### PR DESCRIPTION
bioframe's operations add their own columns to the frame they are given, and skgenome gives them user data: `skgenome.tabio.tab.read_tab` is a bare `read_csv` documented to accept arbitrary extra columns, so a header is whatever the file says. Where the two namespaces met, an input column of the wrong name was duplicated rather than replaced, and the code then read the wrong one.

Both call sites are fixed the same way, by asking bioframe for its bookkeeping alone rather than reserving or renaming names.

## merge and flatten, against `bioframe.cluster`

`cluster` appends `cluster`, `cluster_start` and `cluster_end`. With an input column of one of those names, on master:

| input column | `merge` | `flatten` |
| --- | --- | --- |
| `cluster` | **overlapping rows left unmerged**, column dropped | **not split**, column dropped |
| `cluster_start` / `cluster_end` | `TypeError: int() argument … not 'Series'` | column dropped silently |

The `cluster` case is the serious one. The duplicated label made the cluster ids a whole DataFrame, so rows were grouped by bioframe's id and the user's value together, and genuinely overlapping regions came through unmerged: wrong coordinates, not merely a lost column. The damage was also data-dependent, since a table with nothing to cluster passes through verbatim — the same pipeline mangled or preserved the same column according to whether that particular file held an overlap.

This is reachable from the command line. Given a tab-format bait file carrying a `cluster` column, `cnvkit.py target` on master emits the baits unmerged, with no warning and no "Merged overlapping or duplicated baits" line; `skg_convert.py --merge` drops the column. `cluster` is an unremarkable name for a bait or sample label.

With `return_input=False` the cluster ids come back in a frame of their own, in input row order, and the collision cannot arise. `_splice_clusters` now pairs the table with an array of ids and `_data_columns` is gone. `merge`'s per-cluster closure becomes the module-level `_merge_cluster`, which re-derives the cluster's span as the minimum start and maximum end of its rows — exactly what bioframe reports as the cluster interval, so that interval no longer needs requesting either.

Making that loop a module-level function lets `squash` drop its own third copy of it (second commit). A squash group is a run of bookended rows, so its first start and last end are the minimum and maximum `_merge_cluster` takes.

## intersection, against `bioframe.overlap`

`overlap` returns its own `index` and `index_` and, when asked for the inputs as well, the second one's coordinates suffixed apart as `start_` and `end_`. A column of one of those four names raised: `index`/`index_` a `ValueError` naming the column as not unique, `start_`/`end_` an "Operands are not aligned" error in the `inner` mode that is the only one to compare them. Milder than the `merge` case — every path raises, none corrupts silently — but the same defect.

The same remedy applies: ask for the pairing alone. Since bioframe reports the labels of the frames it is given, indexing both from zero makes those labels positions, which incidentally fixes two more things:

- A `GenomicArray` whose rows came from several sources can carry duplicate labels, and `.loc` resolves such a label to every row that shares it. The previous code returned each of those rows once per duplicate, including regions that overlap nothing at all.
- The pairing was sorted by `other`'s labels, so a caller whose regions were indexed out of order got them reported in label order rather than in the order they appear — which is the row order this method documents itself as reproducing.

The last commit fixes a neighbouring crash found while testing the above: `mode="trim"` concatenates the pieces `by_ranges` yields, and `pd.concat` raises on an empty list, so a selection that nothing overlaps ended in `ValueError: No objects to concatenate` where the other two modes returned an empty array. The guard for an empty input sat below the `trim` branch and so never applied to it.

## Verification

Output is unchanged for every input without a colliding column or a pathological index.

- **End to end**: 29 CLI invocations covering `target` (plain, `--split`, `--annotate`, on BED/GFF/interval_list baits), `antitarget`, `access`, `skg_convert --merge/--flatten` to bed and tab, `genome_instability_index`, and a full `batch` run over `test/picard`; all 38 produced `.bed`/`.cnn`/`.cnr`/`.cns`/`.call.cns` files byte-identical between this branch and master, each side run from its own tree with the resolved module paths printed to prove the two runs used different code.
- **Differential**: every pairing of a dozen fixtures for `intersection`, and `merge`/`flatten`/`squash` over the fixture corpus plus several thousand randomised tables (multi-chromosome, unsorted, interleaved, zero-width, bookended, ragged names, seven index-label variants) — identical values, dtypes and column order except in exactly the cases this branch exists to fix.
- **Tests**: two new regression tests, each verified to fail against the code they replace. The full suite passes, including the slow frozen-pipeline regression.
