### PR TITLE
Refuse interval searches whose rows are out of coordinate order

### DIFF
--- a/cnvlib/segmentation/__init__.py
+++ b/cnvlib/segmentation/__init__.py
@@ -109,10 +109,11 @@ def do_segmentation(
     if variants is not None and len(variants):
         # Process variants in genomic order. by_ranges/baf_by_ranges slice via
         # binary search and the HMM expects an ordered observation sequence, so
-        # an unsorted input VCF -- which nothing upstream sorts -- mis-assigns
-        # variants to segments (silently wrong BAF) and crashes downstream in
-        # variants_in_segment with "Improper post-processing of segment"
-        # (#893). Copy first so we don't mutate the caller's array.
+        # an unsorted input VCF -- which nothing upstream sorts -- is refused
+        # outright by skgenome.intersect, and before that check existed it
+        # mis-assigned variants to segments (silently wrong BAF) and crashed
+        # downstream in variants_in_segment with "Improper post-processing of
+        # segment" (#893). Copy first so we don't mutate the caller's array.
         variants = variants.copy()
         variants.sort()
 

--- a/skgenome/gary.py
+++ b/skgenome/gary.py
@@ -368,8 +368,10 @@ class GenomicArray:
 
         Bins in this array that fall outside the other array's bins are skipped.
 
-        `self` must be sorted by chromosome and start position, as `tabio.read`
-        and `sort` leave it; any other row order raises `ValueError`.
+        `self` must be sorted by start position within each chromosome, as
+        `tabio.read` and `sort` leave it; rows out of that order raise
+        `ValueError`. Chromosome order does not matter: this groups by
+        chromosome before searching.
 
         Parameters
         ----------
@@ -436,8 +438,11 @@ class GenomicArray:
     ) -> Self:
         """Get the GenomicArray portion within the given genomic range.
 
-        `self` must be sorted by chromosome and start position, as `tabio.read`
-        and `sort` leave it; any other row order raises `ValueError`.
+        `self` must be sorted by start position within each chromosome, as
+        `tabio.read` and `sort` leave it; rows out of that order raise
+        `ValueError`. Without a `chrom` the whole array is searched at once, so
+        it must then ascend from end to end -- which a multi-chromosome array
+        does not, since coordinates restart at every chromosome.
 
         Parameters
         ----------
@@ -478,8 +483,11 @@ class GenomicArray:
         Similar to `in_range`, but concatenating the selections of all the
         regions specified by the `starts` and `ends` arrays.
 
-        `self` must be sorted by chromosome and start position, as `tabio.read`
-        and `sort` leave it; any other row order raises `ValueError`.
+        `self` must be sorted by start position within each chromosome, as
+        `tabio.read` and `sort` leave it; rows out of that order raise
+        `ValueError`. Without a `chrom` the whole array is searched at once, so
+        it must then ascend from end to end -- which a multi-chromosome array
+        does not, since coordinates restart at every chromosome.
 
         Parameters
         ----------
@@ -529,8 +537,10 @@ class GenomicArray:
         For example, group SNVs (self) by CNV segments (other) and calculate the
         median (summary_func) of each SNV group's allele frequencies.
 
-        `self` must be sorted by chromosome and start position, as `tabio.read`
-        and `sort` leave it; any other row order raises `ValueError`.
+        `self` must be sorted by start position within each chromosome, as
+        `tabio.read` and `sort` leave it; rows out of that order raise
+        `ValueError`. Chromosome order does not matter: this groups by
+        chromosome before searching.
 
         Parameters
         ----------
@@ -582,8 +592,10 @@ class GenomicArray:
 
         Bins in this array that fall outside the other array's bins are skipped.
 
-        `self` must be sorted by chromosome and start position, as `tabio.read`
-        and `sort` leave it; any other row order raises `ValueError`.
+        `self` must be sorted by start position within each chromosome, as
+        `tabio.read` and `sort` leave it; rows out of that order raise
+        `ValueError`. Chromosome order does not matter: this groups by
+        chromosome before searching.
 
         Parameters
         ----------
@@ -759,6 +771,11 @@ class GenomicArray:
         """Select the bins in `self` that overlap the regions in `other`.
 
         The extra fields of `self`, but not `other`, are retained in the output.
+
+        The `trim` mode clips the bins it selects, which `by_ranges` does, so
+        that mode alone requires `self` to be sorted by start position within
+        each chromosome and raises `ValueError` otherwise. The other two modes
+        pair the rows through bioframe, which sorts for itself.
         """
         if not len(self) or not len(other):
             return self.as_dataframe(self.data.iloc[:0])

--- a/skgenome/gary.py
+++ b/skgenome/gary.py
@@ -368,6 +368,9 @@ class GenomicArray:
 
         Bins in this array that fall outside the other array's bins are skipped.
 
+        `self` must be sorted by chromosome and start position, as `tabio.read`
+        and `sort` leave it; any other row order raises `ValueError`.
+
         Parameters
         ----------
         other : GenomicArray
@@ -433,6 +436,9 @@ class GenomicArray:
     ) -> Self:
         """Get the GenomicArray portion within the given genomic range.
 
+        `self` must be sorted by chromosome and start position, as `tabio.read`
+        and `sort` leave it; any other row order raises `ValueError`.
+
         Parameters
         ----------
         chrom : str or None
@@ -469,8 +475,11 @@ class GenomicArray:
     ) -> GenomicArray:
         """Get the GenomicArray portion within the specified ranges.
 
-        Similar to `in_ranges`, but concatenating the selections of all the
+        Similar to `in_range`, but concatenating the selections of all the
         regions specified by the `starts` and `ends` arrays.
+
+        `self` must be sorted by chromosome and start position, as `tabio.read`
+        and `sort` leave it; any other row order raises `ValueError`.
 
         Parameters
         ----------
@@ -515,6 +524,9 @@ class GenomicArray:
 
         For example, group SNVs (self) by CNV segments (other) and calculate the
         median (summary_func) of each SNV group's allele frequencies.
+
+        `self` must be sorted by chromosome and start position, as `tabio.read`
+        and `sort` leave it; any other row order raises `ValueError`.
 
         Parameters
         ----------
@@ -565,6 +577,9 @@ class GenomicArray:
         For example, this can be used to group SNVs by CNV segments.
 
         Bins in this array that fall outside the other array's bins are skipped.
+
+        `self` must be sorted by chromosome and start position, as `tabio.read`
+        and `sort` leave it; any other row order raises `ValueError`.
 
         Parameters
         ----------

--- a/skgenome/gary.py
+++ b/skgenome/gary.py
@@ -505,8 +505,12 @@ class GenomicArray:
             Concatenation of all the subsets of `self` enclosed by the specified
             ranges.
         """
-        table = pd.concat(iter_ranges(self.data, chrom, starts, ends, mode), sort=False)
-        return self.as_dataframe(table)
+        chunks = list(iter_ranges(self.data, chrom, starts, ends, mode))
+        # An empty `starts`/`ends` selects nothing, and `pd.concat` raises on an
+        # empty list, so hoist that case out.
+        if not chunks:
+            return self.as_dataframe(self.data.iloc[:0])
+        return self.as_dataframe(pd.concat(chunks, sort=False))
 
     def into_ranges(
         self,

--- a/skgenome/intersect.py
+++ b/skgenome/intersect.py
@@ -10,7 +10,7 @@ GenomicArray types.
 from __future__ import annotations
 
 from itertools import repeat
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, NoReturn, TypeAlias
 
 import numpy as np
 import pandas as pd
@@ -212,7 +212,13 @@ def idx_ranges(
     ends: list[int] | pd.Series,
     mode: str,
 ) -> Generator[tuple, None, None]:
-    """Iterate through sub-ranges."""
+    """Iterate through sub-ranges.
+
+    `table` must hold one chromosome's rows in ascending `start` order, as
+    every caller here arranges: `by_ranges` and `iter_slices` group by
+    chromosome, `iter_ranges` selects one, and `tabio.read` sorts what it
+    loads. Rows out of that order raise `ValueError`.
+    """
     assert mode in ("inner", "outer")
     # Edge cases: when the `table` is either empty, or both `starts` and `ends`
     # are None, we want to signal the calling function to use the entire table.
@@ -222,16 +228,47 @@ def idx_ranges(
     # chromosome.
     if not len(table) or (starts is None and ends is None):
         yield slice(None), None, None
+        return
+
+    # Both implementations below place their slice boundaries with
+    # `searchsorted`, which reads its column as ascending: handed rows in some
+    # other order it returns a position unrelated to the query, silently, and
+    # the caller gets bins that do not overlap the region it asked about. One
+    # pass to rule that out, against the pass over `end` just below and the
+    # binary searches themselves.
+    if not table.start.is_monotonic_increasing:
+        _raise_unsorted(table)
+
+    # Don't be fooled by nested bins
+    if (
+        (ends is not None and len(ends)) and (starts is not None and len(starts))
+    ) and not table.end.is_monotonic_increasing:
+        # At least one bin is fully nested -- account for it
+        irange_func = _irange_nested
     else:
-        # Don't be fooled by nested bins
-        if (
-            (ends is not None and len(ends)) and (starts is not None and len(starts))
-        ) and not table.end.is_monotonic_increasing:
-            # At least one bin is fully nested -- account for it
-            irange_func = _irange_nested
-        else:
-            irange_func = _irange_simple  # type: ignore[assignment]
-        yield from irange_func(table, starts, ends, mode)
+        irange_func = _irange_simple  # type: ignore[assignment]
+    yield from irange_func(table, starts, ends, mode)
+
+
+def _raise_unsorted(table: pd.DataFrame) -> NoReturn:
+    """Report the first row out of order, and the likely reason for it."""
+    row = int(np.flatnonzero(np.diff(table["start"].to_numpy()) < 0)[0]) + 1
+    chroms = table["chromosome"].unique()
+    if len(chroms) > 1:
+        names = ", ".join(map(str, chroms[:3]))
+        remedy = (
+            f"this selection spans {len(chroms)} chromosomes "
+            f"({names}{', ...' if len(chroms) > 3 else ''}), so name the one "
+            "to search rather than passing None"
+        )
+    else:
+        remedy = "sort the array with .sort() before selecting from it"
+    raise ValueError(
+        "Genomic intervals must be sorted by start position to be searched: "
+        f"start={table['start'].iat[row]} follows "
+        f"start={table['start'].iat[row - 1]}, at row {row} of {len(table)}. "
+        f"To fix, {remedy}."
+    )
 
 
 def _irange_simple(

--- a/skgenome/intersect.py
+++ b/skgenome/intersect.py
@@ -266,8 +266,22 @@ def idx_ranges(
 
 
 def _raise_unsorted(table: pd.DataFrame) -> NoReturn:
-    """Report the first row out of order, and the likely reason for it."""
-    row = int(np.flatnonzero(np.diff(table["start"].to_numpy()) < 0)[0]) + 1
+    """Report what is out of order about `table`, and the likely reason."""
+    starts = table["start"].to_numpy()
+    descents = np.flatnonzero(np.diff(starts) < 0)
+    if len(descents):
+        row = int(descents[0]) + 1
+        detail = (
+            f"start={starts[row]} follows start={starts[row - 1]}, at row "
+            f"{row} of {len(table)}"
+        )
+        remedy = "sort the array with .sort() before selecting from it"
+    else:
+        # No row is behind the one before it, so the column is unordered for
+        # the other reason: it holds a missing or non-finite position, which
+        # every comparison against is false.
+        detail = f"no position descends among these {len(table)} rows"
+        remedy = "drop the rows whose start is missing or non-finite"
     chroms = table["chromosome"].unique()
     if len(chroms) > 1:
         names = ", ".join(map(str, chroms[:3]))
@@ -276,13 +290,9 @@ def _raise_unsorted(table: pd.DataFrame) -> NoReturn:
             f"({names}{', ...' if len(chroms) > 3 else ''}), so name the one "
             "to search rather than passing None"
         )
-    else:
-        remedy = "sort the array with .sort() before selecting from it"
     raise ValueError(
         "Genomic intervals must be sorted by start position to be searched: "
-        f"start={table['start'].iat[row]} follows "
-        f"start={table['start'].iat[row - 1]}, at row {row} of {len(table)}. "
-        f"To fix, {remedy}."
+        f"{detail}. To fix, {remedy}."
     )
 
 

--- a/skgenome/intersect.py
+++ b/skgenome/intersect.py
@@ -17,12 +17,23 @@ import pandas as pd
 
 from .combiners import first_of, join_strings, make_const
 
+Numeric: TypeAlias = int | float | np.number
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterator, Sequence
 
     from numpy import ndarray
 
-Numeric: TypeAlias = int | float | np.number
+    # One coordinate per query region
+    Coords: TypeAlias = Sequence[Numeric] | pd.Series | ndarray
+    # ... or none at all, for a bound the caller left open
+    Bounds: TypeAlias = Coords | None
+
+# Stand-ins for the open side of a one-sided query, chosen to fall outside the
+# coordinates rather than at their edge: genomic positions are non-negative,
+# and none exceeds what an int64 column can hold.
+_BEFORE_FIRST_BASE = -1
+_PAST_LAST_BASE = np.iinfo(np.int64).max
 
 # One shared placeholder instead of a fresh array per yield: allocating one
 # costs ~200 ns against ~7 us of per-row work, and the missing-chromosome path
@@ -128,8 +139,8 @@ def into_ranges(
 def iter_ranges(
     table: pd.DataFrame,
     chrom: str | None,
-    starts: Sequence[Numeric] | None,
-    ends: Sequence[Numeric] | None,
+    starts: Bounds,
+    ends: Bounds,
     mode: str,
 ) -> Iterator[pd.DataFrame]:
     """Iterate through sub-ranges."""
@@ -208,16 +219,18 @@ def _chrom_slices(
 
 def idx_ranges(
     table: pd.DataFrame,
-    starts: list[int] | pd.Series,
-    ends: list[int] | pd.Series,
+    starts: Bounds,
+    ends: Bounds,
     mode: str,
 ) -> Generator[tuple, None, None]:
     """Iterate through sub-ranges.
 
-    `table` must hold one chromosome's rows in ascending `start` order, as
-    every caller here arranges: `by_ranges` and `iter_slices` group by
-    chromosome, `iter_ranges` selects one, and `tabio.read` sorts what it
-    loads. Rows out of that order raise `ValueError`.
+    `table`'s `start` column must ascend, since that is what lets a binary
+    search place the query. Callers that group by chromosome first --
+    `by_ranges`, `iter_slices` -- hold that per group, and `iter_ranges` does
+    when given a chromosome to select; searching a whole array at once, as
+    `in_range(None, ...)` does, needs it end to end. Rows out of order raise
+    `ValueError` rather than being answered wrongly.
     """
     assert mode in ("inner", "outer")
     # Edge cases: when the `table` is either empty, or both `starts` and `ends`
@@ -234,8 +247,8 @@ def idx_ranges(
     # `searchsorted`, which reads its column as ascending: handed rows in some
     # other order it returns a position unrelated to the query, silently, and
     # the caller gets bins that do not overlap the region it asked about. One
-    # pass to rule that out, against the pass over `end` just below and the
-    # binary searches themselves.
+    # pass to rule that out, beside the pass over `end` that chooses between
+    # those implementations, and the binary searches themselves.
     if not table.start.is_monotonic_increasing:
         _raise_unsorted(table)
 
@@ -248,79 +261,81 @@ def idx_ranges(
         # None` case above, which asks for the whole table.)
         return
 
+    # Both implementations below want a start and an end for every region, so
+    # stand in for whichever side a one-sided query left open. A real bound of
+    # 0 is not the same query as no bound at all -- it excludes a zero-width
+    # bin at the origin, whose end is not past it -- so the stand-in has to sit
+    # outside the coordinates rather than at their edge.
+    if starts is None or not len(starts):
+        starts = np.full(n_regions, _BEFORE_FIRST_BASE)
+    if ends is None or not len(ends):
+        ends = np.full(n_regions, _PAST_LAST_BASE)
+
     if table.end.is_monotonic_increasing:
         yield from _irange_simple(table, starts, ends, mode)
-        return
-
-    # At least one bin is fully nested in another, leaving `end` out of
-    # ascending order, and `_irange_simple` reads `end` with `searchsorted`
-    # too -- to place a start in 'outer' mode, an end in 'inner' mode. The
-    # masks `_irange_nested` builds compare `end` elementwise instead, so they
-    # do not care, but it wants a start and an end for every region: fill in
-    # whichever side a one-sided query left open.
-    if starts is None or not len(starts):
-        starts = np.zeros(n_regions, dtype=np.int_)
-    if ends is None or not len(ends):
-        ends = [None] * n_regions
-    yield from _irange_nested(table, starts, ends, mode)
+    else:
+        # A bin nested inside another leaves `end` out of ascending order, and
+        # `_irange_simple` reads `end` with `searchsorted` too -- to place a
+        # start in 'outer' mode, an end in 'inner' mode. The masks
+        # `_irange_nested` builds compare `end` elementwise instead.
+        yield from _irange_nested(table, starts, ends, mode)
 
 
 def _raise_unsorted(table: pd.DataFrame) -> NoReturn:
-    """Report what is out of order about `table`, and the likely reason."""
-    starts = table["start"].to_numpy()
-    descents = np.flatnonzero(np.diff(starts) < 0)
-    if len(descents):
-        row = int(descents[0]) + 1
+    """Report what is out of order about `table`, and how to fix it."""
+    starts = table["start"]
+    chroms = table["chromosome"].unique()
+    # Diagnose the cause once: each carries its own remedy, and the widest
+    # explanation is the right one to give.
+    if len(chroms) > 1:
+        # Coordinates restart at every chromosome, so an array holding more
+        # than one is out of order by construction. This is a search that
+        # named none of them.
+        shown = ", ".join(map(str, chroms[:3]))
+        opening = "Genomic intervals must be sorted by start position"
         detail = (
-            f"start={starts[row]} follows start={starts[row - 1]}, at row "
+            f"these {len(table)} rows span {len(chroms)} chromosomes "
+            f"({shown}{', ...' if len(chroms) > 3 else ''})"
+        )
+        remedy = "name the chromosome to search rather than passing None"
+    elif starts.isna().any():
+        # A missing position compares false against every other, so the column
+        # counts as unordered with no row behind the one before it.
+        opening = "Genomic intervals must have a start position"
+        detail = f"start is missing in {int(starts.isna().sum())} of {len(table)} rows"
+        remedy = "drop the rows whose start is missing"
+    else:
+        # Nothing is missing, so some row's start is simply behind the one
+        # before it. Compare the column against itself shifted rather than
+        # differencing it, so that reporting the problem cannot fail on
+        # whatever the caller put in the column.
+        values = starts.to_numpy()
+        row = int(np.flatnonzero(values[1:] < values[:-1])[0]) + 1
+        opening = "Genomic intervals must be sorted by start position"
+        detail = (
+            f"start={values[row]} follows start={values[row - 1]}, at row "
             f"{row} of {len(table)}"
         )
-        remedy = "sort the array with .sort() before selecting from it"
-    else:
-        # No row is behind the one before it, so the column is unordered for
-        # the other reason: it holds a missing or non-finite position, which
-        # every comparison against is false.
-        detail = f"no position descends among these {len(table)} rows"
-        remedy = "drop the rows whose start is missing or non-finite"
-    chroms = table["chromosome"].unique()
-    if len(chroms) > 1:
-        names = ", ".join(map(str, chroms[:3]))
-        remedy = (
-            f"this selection spans {len(chroms)} chromosomes "
-            f"({names}{', ...' if len(chroms) > 3 else ''}), so name the one "
-            "to search rather than passing None"
-        )
-    raise ValueError(
-        "Genomic intervals must be sorted by start position to be searched: "
-        f"{detail}. To fix, {remedy}."
-    )
+        remedy = "sort the rows by start -- GenomicArray.sort, or sort_values"
+    raise ValueError(f"{opening} to be searched: {detail}. To fix, {remedy}.")
 
 
 def _irange_simple(
-    table: pd.DataFrame, starts: pd.Series, ends: pd.Series, mode: str
+    table: pd.DataFrame, starts: Coords, ends: Coords, mode: str
 ) -> Iterator[tuple[slice, int, int]]:
-    """Slice subsets of table when regions are not nested."""
-    if starts is not None and len(starts):
-        if mode == "inner":
-            # Only rows entirely after the start point
-            start_idxs = table.start.searchsorted(starts)
-        else:
-            # Include all rows overlapping the start point
-            start_idxs = table.end.searchsorted(starts, "right")
-    else:
-        # `idx_ranges` has ruled out both sides being absent, so `ends` is
-        # there to take the region count from.
-        starts = np.zeros(len(ends), dtype=np.int_)
-        start_idxs = starts.copy()
+    """Select each region by slice, for a table whose bins do not nest.
 
-    if ends is not None and len(ends):
-        if mode == "inner":
-            end_idxs = table.end.searchsorted(ends, "right")
-        else:
-            end_idxs = table.start.searchsorted(ends)
+    Both coordinate columns ascend, so each region's rows are one run of the
+    table and binary search finds its two ends.
+    """
+    if mode == "inner":
+        # Only the rows the region encloses
+        start_idxs = table.start.searchsorted(starts)
+        end_idxs = table.end.searchsorted(ends, "right")
     else:
-        end_idxs = np.repeat(len(table), len(starts))
-        ends = [None] * len(starts)
+        # Also the rows straddling either boundary
+        start_idxs = table.end.searchsorted(starts, "right")
+        end_idxs = table.start.searchsorted(ends)
 
     for start_idx, start_val, end_idx, end_val in zip(
         start_idxs, starts, end_idxs, ends, strict=True
@@ -329,32 +344,24 @@ def _irange_simple(
 
 
 def _irange_nested(
-    table: pd.DataFrame,
-    starts: Sequence | ndarray,
-    ends: Sequence | ndarray,
-    mode: str,
+    table: pd.DataFrame, starts: Coords, ends: Coords, mode: str
 ) -> Iterator[tuple[ndarray, int, int]]:
-    """Slice subsets of table when regions are nested."""
+    """Select each region by mask, for a table whose bins nest.
+
+    A nested bin leaves `end` out of ascending order, so only `start` can be
+    searched; `end` is compared row by row instead.
+    """
     # ENH: Binary Interval Search (BITS) or Layer&Quinlan(2015)
     assert len(starts) == len(ends) > 0
     for start_val, end_val in zip(starts, ends, strict=True):
         # Mask of table rows to keep for this query region
-        region_mask = np.ones(len(table), dtype=np.bool_)
-        if start_val:
-            if mode == "inner":
-                # Only rows entirely after the start point
-                start_idx = table.start.searchsorted(start_val)
-                region_mask[: int(start_idx)] = 0
-            else:
-                # Include all rows overlapping the start point
-                region_mask = table.end.to_numpy() > start_val
-        if end_val is not None:
-            if mode == "inner":
-                # Only rows up to the end point
-                region_mask &= table.end.to_numpy() <= end_val
-            else:
-                # Include all rows overlapping the end point
-                end_idx = table.start.searchsorted(end_val)
-                region_mask[int(end_idx) :] = 0
+        if mode == "inner":
+            # Only the rows the region encloses
+            region_mask = table.end.to_numpy() <= end_val
+            region_mask[: int(table.start.searchsorted(start_val))] = 0
+        else:
+            # Also the rows straddling either boundary
+            region_mask = table.end.to_numpy() > start_val
+            region_mask[int(table.start.searchsorted(end_val)) :] = 0
 
         yield region_mask, start_val, end_val

--- a/skgenome/intersect.py
+++ b/skgenome/intersect.py
@@ -239,15 +239,30 @@ def idx_ranges(
     if not table.start.is_monotonic_increasing:
         _raise_unsorted(table)
 
-    # Don't be fooled by nested bins
-    if (
-        (ends is not None and len(ends)) and (starts is not None and len(starts))
-    ) and not table.end.is_monotonic_increasing:
-        # At least one bin is fully nested -- account for it
-        irange_func = _irange_nested
-    else:
-        irange_func = _irange_simple  # type: ignore[assignment]
-    yield from irange_func(table, starts, ends, mode)
+    n_regions = max(
+        0 if starts is None else len(starts), 0 if ends is None else len(ends)
+    )
+    if not n_regions:
+        # No regions to select, so nothing to yield: one region per query, and
+        # there are none. (Not the same as the `starts is None and ends is
+        # None` case above, which asks for the whole table.)
+        return
+
+    if table.end.is_monotonic_increasing:
+        yield from _irange_simple(table, starts, ends, mode)
+        return
+
+    # At least one bin is fully nested in another, leaving `end` out of
+    # ascending order, and `_irange_simple` reads `end` with `searchsorted`
+    # too -- to place a start in 'outer' mode, an end in 'inner' mode. The
+    # masks `_irange_nested` builds compare `end` elementwise instead, so they
+    # do not care, but it wants a start and an end for every region: fill in
+    # whichever side a one-sided query left open.
+    if starts is None or not len(starts):
+        starts = np.zeros(n_regions, dtype=np.int_)
+    if ends is None or not len(ends):
+        ends = [None] * n_regions
+    yield from _irange_nested(table, starts, ends, mode)
 
 
 def _raise_unsorted(table: pd.DataFrame) -> NoReturn:
@@ -283,7 +298,9 @@ def _irange_simple(
             # Include all rows overlapping the start point
             start_idxs = table.end.searchsorted(starts, "right")
     else:
-        starts = np.zeros(len(ends) if ends is not None else 1, dtype=np.int_)
+        # `idx_ranges` has ruled out both sides being absent, so `ends` is
+        # there to take the region count from.
+        starts = np.zeros(len(ends), dtype=np.int_)
         start_idxs = starts.copy()
 
     if ends is not None and len(ends):
@@ -302,7 +319,10 @@ def _irange_simple(
 
 
 def _irange_nested(
-    table: pd.DataFrame, starts: Sequence, ends: Sequence, mode: str
+    table: pd.DataFrame,
+    starts: Sequence | ndarray,
+    ends: Sequence | ndarray,
+    mode: str,
 ) -> Iterator[tuple[ndarray, int, int]]:
     """Slice subsets of table when regions are nested."""
     # ENH: Binary Interval Search (BITS) or Layer&Quinlan(2015)

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -1151,6 +1151,47 @@ class IntervalTests(unittest.TestCase):
             two_chroms.in_range(None, 0, 700)
         self.assertIn("chr1, chr2", str(caught.exception))
 
+    def test_search_one_sided_over_nested_bins(self):
+        """A half-open range selects what the closed range covering it selects.
+
+        A bin nested inside another leaves `end` out of ascending order, so the
+        slicing implementation cannot search it; the mask implementation is
+        there for exactly that. But the choice between them also asked whether
+        the query had both bounds, and a half-open range has one -- so
+        ``in_range(chrom, 20, None)`` searched a column it could not search,
+        and lost the bins covering position 20 that the equivalent closed
+        range, on the same rows, returned.
+        """
+        nested = self.regions_2
+        self.assertFalse(nested.end.is_monotonic_increasing)
+        beyond = int(nested.end.max()) + 1
+        for mode in ("outer", "inner", "trim"):
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    list(nested.in_range("chr0", 20, None, mode=mode)["gene"]),
+                    list(nested.in_range("chr0", 20, beyond, mode=mode)["gene"]),
+                )
+                self.assertEqual(
+                    list(nested.in_range("chr0", None, 20, mode=mode)["gene"]),
+                    list(nested.in_range("chr0", 0, 20, mode=mode)["gene"]),
+                )
+        # Spelled out, so the agreement above cannot be two identical mistakes:
+        # every bin reaching past 20, and every bin ending by 20.
+        self.assertEqual(
+            list(nested.in_range("chr0", 20, None)["gene"]),
+            ["A", "D", "E", "F", "G", "H", "I"],
+        )
+        self.assertEqual(
+            list(nested.in_range("chr0", None, 20, mode="inner")["gene"]), ["B", "C"]
+        )
+
+    def test_search_no_ranges_selects_nothing(self):
+        """An empty list of ranges selects nothing, rather than everything."""
+        empty = self.regions_2.in_ranges("chr0", [], [])
+        self.assertEqual(len(empty), 0)
+        self.assertEqual(list(empty.data.columns), list(self.regions_2.data.columns))
+        self.assertEqual(len(self.regions_2.in_ranges("chr0", [], None)), 0)
+
     def test_subtract(self):
         # Test cases:
         #  | access: ====   ====   ====    ==========

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -1136,13 +1136,16 @@ class IntervalTests(unittest.TestCase):
             frayed.in_range("chr0", 0, 700)
         self.assertIn("missing", str(caught.exception))
 
-    def test_search_requires_one_chromosome(self):
-        """A whole-array search names its chromosome, or is refused.
+    def test_search_across_chromosomes_is_refused(self):
+        """Searching a whole array holding several chromosomes is refused.
 
         ``in_range(None, ...)`` is documented for an array holding one
-        chromosome. Given several it searched across them all, since a second
-        chromosome's coordinates restart below the first one's: asking chr1 for
-        0-700 also returned chr2's rows.
+        chromosome. Given several it searched across them all: asking for
+        0-700 without naming a chromosome returned chr2's rows alongside
+        chr1's. What the guard sees is the coordinate restart at the boundary,
+        so it catches the multi-chromosome case as ordinary disorder -- and
+        only when the later chromosome's positions do begin below the earlier
+        one's, which for real genomic coordinates they do.
         """
         two_chroms = GA(
             pd.DataFrame(
@@ -1194,11 +1197,42 @@ class IntervalTests(unittest.TestCase):
         )
 
     def test_search_no_ranges_selects_nothing(self):
-        """An empty list of ranges selects nothing, rather than everything."""
+        """An empty list of ranges selects nothing, rather than everything.
+
+        The two spellings failed differently: an empty `starts` with no `ends`
+        was read as one region covering the whole table, while an empty
+        `starts` and `ends` yielded no regions at all and left ``pd.concat``
+        with nothing to concatenate.
+        """
         empty = self.regions_2.in_ranges("chr0", [], [])
         self.assertEqual(len(empty), 0)
         self.assertEqual(list(empty.data.columns), list(self.regions_2.data.columns))
         self.assertEqual(len(self.regions_2.in_ranges("chr0", [], None)), 0)
+
+    def test_search_start_of_zero_is_not_an_absent_bound(self):
+        """A region starting at 0 is a bound; leaving the bound out is not.
+
+        A zero-width bin at the origin ends where it starts, so no region
+        overlaps it and a query from 0 excludes it -- while a query with no
+        lower bound at all selects every row, that one included. Both
+        implementations have to agree on that: the slicing one searches `end`
+        for the query start, while the masking one read a start of 0 as no
+        bound at all, so the same question put to a nested table and to a flat
+        one came back answered differently.
+        """
+        origin = (0, 0, "Z")
+        flat = self._from_intervals([origin, (0, 50, "A"), (100, 200, "B")])
+        nested = self._from_intervals([origin, (0, 1000, "A"), (100, 200, "B")])
+        self.assertTrue(flat.end.is_monotonic_increasing)
+        self.assertFalse(nested.end.is_monotonic_increasing)
+        for label, regions in (("flat", flat), ("nested", nested)):
+            with self.subTest(bins=label):
+                self.assertEqual(
+                    list(regions.in_range("chr0", 0, 500)["gene"]), ["A", "B"]
+                )
+                self.assertEqual(
+                    list(regions.in_range("chr0", None, 500)["gene"]), ["Z", "A", "B"]
+                )
 
     def test_subtract(self):
         # Test cases:

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -1092,6 +1092,65 @@ class IntervalTests(unittest.TestCase):
                 with self.subTest(empty_self=True, mode=mode):
                     self.assertEqual(len(empty.intersection(region, mode=mode)), 0)
 
+    def test_search_requires_ascending_rows(self):
+        """Searching rows out of coordinate order raises instead of misleading.
+
+        ``searchsorted`` places the boundaries of every selection here, and it
+        reads its column as ascending: given rows in any other order it returns
+        a position unrelated to the query. The three rows below, shuffled,
+        answered "which bins overlap 0-700?" with the bin at 900-1000 as well
+        -- and in 'trim' mode clipped it to 900-700, an interval whose end
+        precedes its start. 'inner' searches a different column and happened to
+        survive, which is why every mode is checked.
+        """
+        coords = [(0, 100, "A"), (500, 600, "B"), (900, 1000, "C")]
+        ascending = self._from_intervals(coords)
+        shuffled = self._from_intervals([coords[i] for i in (2, 0, 1)])
+        selection = self._from_intervals([(0, 700, "X")])
+        for mode in ("outer", "inner", "trim"):
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    [
+                        list(rows["gene"])
+                        for _bin, rows in ascending.by_ranges(selection, mode=mode)
+                    ],
+                    [["A", "B"]],
+                )
+                with self.assertRaises(ValueError):
+                    list(shuffled.by_ranges(selection, mode=mode))
+                self.assertEqual(
+                    list(ascending.in_range("chr0", 0, 700, mode=mode)["gene"]),
+                    ["A", "B"],
+                )
+                with self.assertRaises(ValueError):
+                    shuffled.in_range("chr0", 0, 700, mode=mode)
+        self.assertEqual(list(ascending.into_ranges(selection, "gene", "-")), ["A,B"])
+        with self.assertRaises(ValueError):
+            shuffled.into_ranges(selection, "gene", "-")
+
+    def test_search_requires_one_chromosome(self):
+        """A whole-array search names its chromosome, or is refused.
+
+        ``in_range(None, ...)`` is documented for an array holding one
+        chromosome. Given several it searched across them all, since a second
+        chromosome's coordinates restart below the first one's: asking chr1 for
+        0-700 also returned chr2's rows.
+        """
+        two_chroms = GA(
+            pd.DataFrame(
+                {
+                    "chromosome": ["chr1"] * 2 + ["chr2"] * 2,
+                    "start": [0, 900] * 2,
+                    "end": [100, 1000] * 2,
+                    "gene": list("ABCD"),
+                }
+            )
+        )
+        self.assertEqual(list(two_chroms.in_range("chr1", 0, 700)["gene"]), ["A"])
+        with self.assertRaises(ValueError) as caught:
+            two_chroms.in_range(None, 0, 700)
+        self.assertIn("chr1, chr2", str(caught.exception))
+
     def test_subtract(self):
         # Test cases:
         #  | access: ====   ====   ====    ==========

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -1127,6 +1127,14 @@ class IntervalTests(unittest.TestCase):
         self.assertEqual(list(ascending.into_ranges(selection, "gene", "-")), ["A,B"])
         with self.assertRaises(ValueError):
             shuffled.into_ranges(selection, "gene", "-")
+        # A missing position leaves the column unordered without any row being
+        # behind the one before it, so the report has nothing to point at.
+        frayed = self._from_intervals(coords)
+        frayed.data = frayed.data.astype({"start": float})
+        frayed.data.loc[1, "start"] = np.nan
+        with self.assertRaises(ValueError) as caught:
+            frayed.in_range("chr0", 0, 700)
+        self.assertIn("missing", str(caught.exception))
 
     def test_search_requires_one_chromosome(self):
         """A whole-array search names its chromosome, or is refused.


### PR DESCRIPTION
Every overlap query in `skgenome/intersect.py` places its boundaries with `numpy.searchsorted`, which reads its column as ascending. Handed rows in any other order it returns a position unrelated to the query — silently. So `by_ranges`, `in_range`, `in_ranges`, `into_ranges` and `iter_ranges_of` answered "which bins overlap this region?" with bins that do not overlap it, and `trim` mode clipped those bins to intervals whose end precedes their start. The bioframe-backed siblings (`merge`, `flatten`, `subtract`, `intersection`) sort for themselves, so the same question asked two ways gave two different answers, and the bioframe one was right.

The precondition was real and already relied upon — `tabio.read` sorts what it loads, `add` and `concat` sort after concatenating — but it was neither documented on the public methods nor checked anywhere.

## What it cost

One chromosome's rows arriving in two blocks, as `cat` of two per-chromosome runs leaves them, over `test/formats/amplicon.cnr` and its segments:

| | bins in the ALK/LRP1B/NFE2L2/ERBB4 segment | segment mean log2 | copy ratio |
|---|---|---|---|
| correct | 146 | -0.8408 | 0.56x |
| before this branch | 63 | **-0.4035** | **0.76x** |

A single-copy deletion reported as near-neutral, from 57% of the segment's bins being silently dropped. Across that file 83 of 1433 bins were lost. Shuffling one chromosome's 167 rows instead: `in_range` returned 158 rows where 83 was right, and in `trim` mode 78 of them had `end < start`.

Not reachable from the command line — every CLI path reads through `tabio.read` — so the exposure is the public Python API, where a caller building a `CopyNumArray` from their own DataFrame, or concatenating without re-sorting, gets no warning at all.

## What this does

**Refuse the search** (`7d103a1`) rather than answer it wrongly, in the one function every path funnels through, naming the offending row and its likely cause. Documented on the five public methods, and on `intersection`, whose `trim` mode alone inherits the precondition.

The check is a single pass beside the pass over `end` that already chooses between the two implementations: 4.2 ms of a 2.4 s `by_ranges` call over 3M bins and 4800 segments. A reviewer built the two alternatives to be sure this was the right mechanism — sorting a copy instead reintroduces the silent cross-chromosome answer, since a whole-genome array is out of order by construction; making the operations order-independent through bioframe costs 2.8x on the same call and rewrites four functions.

**A second defect the reading exposed** (`fdc65f5`): a bin nested inside another leaves `end` out of ascending order, which is what `_irange_nested` exists for — but the choice between the implementations also asked whether the query carried *both* bounds. A half-open range carries one, so `in_range(chrom, 20, None)` searched the column it cannot search and lost the bin at 3-32 that contains position 20, which the closed range 20-43 over the same rows returned. This needs no unsorted input; it was reachable from any nested annotation file. Now the choice turns on the table's shape alone.

**Two smaller ones**: the error path itself raised `IndexError` when the column was unordered because of a missing position rather than a descent (`0d66ed8`), reachable through the public constructor since `__init__` decides whether to recast `start` from its first element alone; and a query start of 0 was indistinguishable from no start at all, so a zero-width bin at the origin was kept by one implementation and dropped by the other (`bbc3f6a`).

## Verification

- **Differentials.** 60,000 randomized cases (tables x query shapes x modes) against an elementwise overlap reference: this branch 0 mismatches, master 1493, every one of them nested with a one-sided query. 28,800 further cases confirm the final refactor moves only the two zero-width-at-the-origin cells it was meant to.
- **Blast radius.** 191 CLI invocations per tree over the repo's fixtures — `target --annotate`, `coverage`, `reference`, `fix`, `segment`, `segmetrics`, `call`, `bintest`, `genemetrics`, `export` in nine formats, `scatter`, `diagram`, `heatmap`, `batch` end to end, `skg_convert`, `cnv_annotate` — with the resolved module path printed on every run. 282 output files compared, 277 byte-identical; the 5 that differ are the unseeded `--ci`/`--pi` bootstrap columns, which differ between two runs of master as well.
- **Does anything now raise that used to work?** An instrumented master build recorded zero out-of-order calls across the full test suite, 166 CLI invocations and 87 deliberately malformed inputs (shuffled and fully reversed `.cnr`/`.cns`, `cat`-ed per-chromosome runs, descending VCFs and BEDs). The one well-formed input whose result changes is `in_range(None, ...)` on a multi-chromosome array, which the docstring already reserved for single-chromosome arrays — and which returned 168 rows spanning two chromosomes where 21 was right.
- **Tests.** Five new regression tests, each verified to fail against the code it replaces. Full suite 606 passed; `ruff` and `mypy` clean.

## For downstream Python callers

Two public-API behaviours change on well-formed input: `in_range(None, ...)` / `in_ranges(None, ...)` on an array holding several chromosomes now raises instead of searching across them, and `in_ranges(chrom, [], ...)` returns an empty array instead of every row.
